### PR TITLE
Add SignalR chat server code

### DIFF
--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -1,0 +1,263 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using static ChatServeur.PasswordHelper;
+
+namespace ChatServeur
+{
+    public class ChatHub : Hub
+    {
+        private static readonly Dictionary<string, UserInfo> ConnectedUsers = new();
+        private static readonly Dictionary<string, string> _userToConnectionId = new();
+        private static readonly Dictionary<string, HashSet<string>> GroupMembers = new();
+
+        private readonly ChatDbContext _db;
+
+        public ChatHub(ChatDbContext db)
+        {
+            _db = db;
+        }
+
+        public override Task OnConnectedAsync()
+        {
+            return base.OnConnectedAsync();
+        }
+
+        public override async Task OnDisconnectedAsync(Exception? ex)
+        {
+            if (ConnectedUsers.Remove(Context.ConnectionId, out var user))
+            {
+                await Clients.All.SendAsync("UserDisconnected", user.Username);
+                await Clients.All.SendAsync("UserListUpdated", ConnectedUsers.Values);
+                _userToConnectionId.Remove(user.Username);
+
+                foreach (var group in GroupMembers.Keys)
+                {
+                    GroupMembers[group].Remove(user.Username);
+                }
+            }
+
+            await base.OnDisconnectedAsync(ex);
+        }
+
+        public async Task RegisterUser(string username, string avatar, string room)
+        {
+            try
+            {
+                Console.WriteLine($"[SERVER] RegisterUser : {username}");
+
+                var user = new UserInfo
+                {
+                    ConnectionId = Context.ConnectionId,
+                    Username = username,
+                    Avatar = avatar,
+                    Room = room,
+                    DisplayName = username,
+                    IsOnline = true,
+                    Note = string.Empty
+                };
+
+                ConnectedUsers[Context.ConnectionId] = user;
+                _userToConnectionId[username] = Context.ConnectionId;
+
+                await Groups.AddToGroupAsync(Context.ConnectionId, "A Tous");
+
+                var groups = await _db.GroupMemberships
+                    .Where(g => g.Username == username)
+                    .Select(g => g.GroupName)
+                    .ToListAsync();
+
+                foreach (var group in groups)
+                {
+                    await Groups.AddToGroupAsync(Context.ConnectionId, group);
+                }
+
+                await Clients.All.SendAsync("UserConnected", user);
+                var baseUsers = new List<UserInfo>
+                {
+                    new UserInfo
+                    {
+                        ConnectionId = string.Empty,
+                        Username = "A Tous",
+                        Avatar = "ms-appx:///Assets/earth.png",
+                        Room = string.Empty,
+                        DisplayName = "A Tous",
+                        IsOnline = true,
+                        Note = string.Empty
+                    },
+                    new UserInfo
+                    {
+                        ConnectionId = string.Empty,
+                        Username = "Secrétariat",
+                        Avatar = "ms-appx:///Assets/secretaria.png",
+                        Room = string.Empty,
+                        DisplayName = "Secrétariat",
+                        IsOnline = true,
+                        Note = string.Empty
+                    }
+                };
+
+                var userList = baseUsers.Concat(ConnectedUsers.Values).ToList();
+
+                await Clients.All.SendAsync("UserListUpdated", userList);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[SERVER ERROR] RegisterUser : {ex.Message}");
+                throw;
+            }
+        }
+
+        public async Task SendMessage(string sender, string room, string destinataire, string content, string avatar, DateTime timestamp)
+        {
+            var message = new ChatMessage
+            {
+                Sender = sender,
+                Destinataire = destinataire,
+                Room = room,
+                Content = content,
+                Avatar = avatar,
+                Timestamp = timestamp
+            };
+
+            _db.Messages.Add(message);
+            await _db.SaveChangesAsync();
+
+            if (destinataire == "A Tous")
+            {
+                await Clients.All.SendAsync("ReceiveMessage", sender, room, destinataire, content, avatar, timestamp);
+            }
+            else if (destinataire == "Secrétariat")
+            {
+                await Clients.Group("Secrétariat").SendAsync("ReceiveMessage", sender, room, destinataire, content, avatar, timestamp);
+                await Clients.Caller.SendAsync("ReceiveMessage", sender, room, "Secrétariat", content, avatar, timestamp);
+
+                var membres = GetGroupMembers("Secrétariat");
+                foreach (var user in membres)
+                {
+                    await Clients.Caller.SendAsync("ReceiveMessage", sender, room, user, content, avatar, timestamp);
+                }
+            }
+            else if (_userToConnectionId.TryGetValue(destinataire, out var targetConnectionId))
+            {
+                await Clients.Client(targetConnectionId).SendAsync("ReceiveMessage", sender, room, content, avatar, timestamp);
+            }
+            else
+            {
+                await Clients.Group(destinataire).SendAsync("ReceiveMessage", sender, room, content, avatar, timestamp);
+            }
+        }
+
+        public async Task JoinRoom(string roomName)
+        {
+            var username = ConnectedUsers[Context.ConnectionId].Username;
+
+            if (!GroupMembers.ContainsKey(roomName))
+                GroupMembers[roomName] = new HashSet<string>();
+
+            GroupMembers[roomName].Add(username);
+
+            await Groups.AddToGroupAsync(Context.ConnectionId, roomName);
+        }
+
+        public async Task<string> JoinProtectedGroup(string groupName, string password)
+        {
+            var username = ConnectedUsers[Context.ConnectionId].Username;
+
+            var group = await _db.SecureGroups.FirstOrDefaultAsync(g => g.Name == groupName);
+
+            if (group == null)
+            {
+                var newGroup = new SecureGroup
+                {
+                    Name = groupName,
+                    PasswordHash = HashPassword(password)
+                };
+                _db.SecureGroups.Add(newGroup);
+                _db.GroupMemberships.Add(new GroupMembership { Username = username, GroupName = groupName });
+                await _db.SaveChangesAsync();
+
+                await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+                return "created";
+            }
+            else
+            {
+                if (VerifyPassword(password, group.PasswordHash))
+                {
+                    var alreadyIn = await _db.GroupMemberships.AnyAsync(g => g.Username == username && g.GroupName == groupName);
+                    if (!alreadyIn)
+                        _db.GroupMemberships.Add(new GroupMembership { Username = username, GroupName = groupName });
+
+                    await _db.SaveChangesAsync();
+                    await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+                    return "joined";
+                }
+                else
+                {
+                    return "wrong_password";
+                }
+            }
+        }
+
+        public async Task SendToRoom(string roomName, string username, string message)
+        {
+            await Clients.Group(roomName).SendAsync("ReceiveMessage", username, message);
+        }
+
+        private List<string> GetGroupMembers(string groupName)
+        {
+            if (GroupMembers.TryGetValue(groupName, out var members))
+            {
+                return members.ToList();
+            }
+            return new List<string>();
+        }
+
+        public async Task<List<ChatMessage>> GetTodayMessages(string username)
+        {
+            var today = DateTime.Today;
+
+            return await _db.Messages
+                .Where(m => (m.Sender == username || m.Destinataire == username || m.Destinataire == "A Tous") && m.Timestamp.Date == today)
+                .OrderBy(m => m.Timestamp)
+                .ToListAsync();
+        }
+
+        public async Task<List<ChatMessage>> GetMessagesForDate(string username, DateTime date)
+        {
+            var day = date.Date;
+
+            return await _db.Messages
+                .Where(m => (m.Sender == username || m.Destinataire == username || m.Destinataire == "A Tous") && m.Timestamp.Date == day)
+                .OrderBy(m => m.Timestamp)
+                .ToListAsync();
+        }
+
+        public async Task SaveExamOptions(object options)
+        {
+            var json = JsonSerializer.Serialize(options);
+            var config = await _db.ServerConfigs.FirstOrDefaultAsync();
+            if (config == null)
+            {
+                config = new ServerConfig();
+                _db.ServerConfigs.Add(config);
+            }
+
+            config.ExamOptionsJson = json;
+            await _db.SaveChangesAsync();
+        }
+
+        public async Task SaveRooms(IEnumerable<string> rooms)
+        {
+            var json = JsonSerializer.Serialize(rooms);
+            var config = await _db.ServerConfigs.FirstOrDefaultAsync();
+            if (config == null)
+            {
+                config = new ServerConfig();
+                _db.ServerConfigs.Add(config);
+            }
+            config.RoomsJson = json;
+            await _db.SaveChangesAsync();
+        }
+    }
+}

--- a/Serveur/Models/ChatDbContext.cs
+++ b/Serveur/Models/ChatDbContext.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace ChatServeur
+{
+    public class ChatDbContext : DbContext
+    {
+        public ChatDbContext(DbContextOptions<ChatDbContext> options) : base(options)
+        {
+        }
+
+        public DbSet<ChatMessage> Messages => Set<ChatMessage>();
+        public DbSet<GroupMembership> GroupMemberships => Set<GroupMembership>();
+        public DbSet<SecureGroup> SecureGroups => Set<SecureGroup>();
+        public DbSet<ServerConfig> ServerConfigs => Set<ServerConfig>();
+    }
+}

--- a/Serveur/Models/ChatMessage.cs
+++ b/Serveur/Models/ChatMessage.cs
@@ -1,0 +1,13 @@
+namespace ChatServeur
+{
+    public class ChatMessage
+    {
+        public int Id { get; set; }
+        public string Sender { get; set; } = string.Empty;
+        public string Destinataire { get; set; } = string.Empty;
+        public string Room { get; set; } = string.Empty;
+        public string Content { get; set; } = string.Empty;
+        public string Avatar { get; set; } = string.Empty;
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/Serveur/Models/GroupMembership.cs
+++ b/Serveur/Models/GroupMembership.cs
@@ -1,0 +1,9 @@
+namespace ChatServeur
+{
+    public class GroupMembership
+    {
+        public int Id { get; set; }
+        public string Username { get; set; } = string.Empty;
+        public string GroupName { get; set; } = string.Empty;
+    }
+}

--- a/Serveur/Models/PasswordHelper.cs
+++ b/Serveur/Models/PasswordHelper.cs
@@ -1,0 +1,25 @@
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Cryptography.KeyDerivation;
+
+namespace ChatServeur
+{
+    public static class PasswordHelper
+    {
+        public static string HashPassword(string password)
+        {
+            byte[] salt = RandomNumberGenerator.GetBytes(128 / 8);
+            byte[] hash = KeyDerivation.Pbkdf2(password, salt, KeyDerivationPrf.HMACSHA256, 10000, 256 / 8);
+            return $"{Convert.ToBase64String(salt)}:{Convert.ToBase64String(hash)}";
+        }
+
+        public static bool VerifyPassword(string password, string hashed)
+        {
+            var parts = hashed.Split(':');
+            if (parts.Length != 2)
+                return false;
+            byte[] salt = Convert.FromBase64String(parts[0]);
+            byte[] hash = KeyDerivation.Pbkdf2(password, salt, KeyDerivationPrf.HMACSHA256, 10000, 256 / 8);
+            return Convert.ToBase64String(hash) == parts[1];
+        }
+    }
+}

--- a/Serveur/Models/SecureGroup.cs
+++ b/Serveur/Models/SecureGroup.cs
@@ -1,0 +1,9 @@
+namespace ChatServeur
+{
+    public class SecureGroup
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string PasswordHash { get; set; } = string.Empty;
+    }
+}

--- a/Serveur/Models/ServerConfig.cs
+++ b/Serveur/Models/ServerConfig.cs
@@ -1,0 +1,9 @@
+namespace ChatServeur
+{
+    public class ServerConfig
+    {
+        public int Id { get; set; }
+        public string ExamOptionsJson { get; set; } = string.Empty;
+        public string RoomsJson { get; set; } = string.Empty;
+    }
+}

--- a/Serveur/Models/UserInfo.cs
+++ b/Serveur/Models/UserInfo.cs
@@ -1,0 +1,13 @@
+namespace ChatServeur
+{
+    public class UserInfo
+    {
+        public string ConnectionId { get; set; } = string.Empty;
+        public string Username { get; set; } = string.Empty;
+        public string Avatar { get; set; } = string.Empty;
+        public string Room { get; set; } = string.Empty;
+        public string DisplayName { get; set; } = string.Empty;
+        public bool IsOnline { get; set; }
+        public string Note { get; set; } = string.Empty;
+    }
+}

--- a/Serveur/Program.cs
+++ b/Serveur/Program.cs
@@ -1,15 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using ChatServeur;
+
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
+var dbFolder = Path.Combine(AppContext.BaseDirectory, "data");
+Directory.CreateDirectory(dbFolder);
+var dbPath = Path.Combine(dbFolder, "chat.db");
+
+builder.Services.AddDbContext<ChatDbContext>(options =>
+    options.UseSqlite($"Data Source={dbPath}"));
+
 builder.Services.AddRazorPages();
+builder.Services.AddSignalR();
+builder.WebHost.UseUrls("http://0.0.0.0:5000");
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Error");
-    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
 }
 
@@ -17,9 +26,20 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 
 app.UseRouting();
-
 app.UseAuthorization();
 
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<ChatDbContext>();
+    db.Database.EnsureCreated();
+    if (!db.ServerConfigs.Any())
+    {
+        db.ServerConfigs.Add(new ServerConfig());
+        db.SaveChanges();
+    }
+}
+
 app.MapRazorPages();
+app.MapHub<ChatHub>("/chatHub");
 
 app.Run();

--- a/Serveur/Serveur.csproj
+++ b/Serveur/Serveur.csproj
@@ -4,6 +4,10 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
+</PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add ChatHub implementation with group management, messaging and persistence
- add EF Core models and context for chat data
- update server program to configure SQLite database and SignalR
- reference EF Core SQLite provider

## Testing
- `dotnet build WebApplication1.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685431bf995c8324a6077b0ccd19fc98