### PR TITLE
Implement persistent settings and updated models

### DIFF
--- a/Client/Helpers/AppSettings.cs
+++ b/Client/Helpers/AppSettings.cs
@@ -1,24 +1,83 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using Client.Models;
 
 namespace Client.Helpers
 {
     public static class AppSettings
     {
-        private static readonly Dictionary<string, object> _values = new();
-        public static string Get(string key, string defaultValue)
+        private static readonly string filePath =
+            Path.Combine(AppContext.BaseDirectory, "settings.json");
+
+        private static Dictionary<string, JsonElement> _settings = new();
+        public static UserInfo? CurrentSelectedUser { get; set; }
+
+        static AppSettings()
         {
-            if (_values.TryGetValue(key, out var value))
+            try
             {
-                return value?.ToString() ?? defaultValue;
+                if (File.Exists(filePath))
+                {
+                    var json = File.ReadAllText(filePath);
+                    _settings = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json)
+                                ?? new();
+                }
             }
-            return defaultValue;
+            catch
+            {
+                _settings = new();
+            }
         }
 
-        public static void Set(string key, object value)
+        public static string Get(string key, string defaultValue = "")
         {
-            _values[key] = value;
+            return _settings.TryGetValue(key, out var value) && value.ValueKind == JsonValueKind.String
+                ? value.GetString() ?? defaultValue
+                : defaultValue;
         }
 
-        public static Client.Models.UserInfo? CurrentSelectedUser { get; set; }
+        public static T GetObject<T>(string key) where T : new()
+        {
+            try
+            {
+                if (_settings.TryGetValue(key, out var value))
+                {
+                    return value.Deserialize<T>() ?? new T();
+                }
+            }
+            catch { }
+            return new T();
+        }
+
+        public static void Set(string key, string value)
+        {
+            _settings[key] = JsonDocument.Parse($"\"{value}\"").RootElement;
+            Save();
+        }
+
+        public static void SetObject<T>(string key, T value)
+        {
+            var json = JsonSerializer.Serialize(value);
+            _settings[key] = JsonDocument.Parse(json).RootElement;
+            Save();
+        }
+
+        private static void Save()
+        {
+            try
+            {
+                var json = JsonSerializer.Serialize(_settings, new JsonSerializerOptions
+                {
+                    WriteIndented = true
+                });
+                File.WriteAllText(filePath, json);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"❌ Sauvegarde échouée : {ex.Message}");
+            }
+        }
     }
 }

--- a/Client/Helpers/PatientStringHelper.cs
+++ b/Client/Helpers/PatientStringHelper.cs
@@ -1,20 +1,43 @@
+using System;
+using System.Text.RegularExpressions;
+
 namespace Client.Helpers
 {
     public static class PatientStringHelper
     {
-        public static void ExtractInfoFromInput(string input, out string title, out string lastName, out string firstName)
+        public static void ExtractInfoFromInput(string inputText, out string patientTitle, out string patientLastName, out string patientFirstName)
         {
-            title = string.Empty;
-            lastName = string.Empty;
-            firstName = string.Empty;
-            if (string.IsNullOrWhiteSpace(input))
-                return;
+            patientTitle = string.Empty;
+            patientLastName = string.Empty;
+            patientFirstName = string.Empty;
 
-            var parts = input.Split(' ', System.StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length > 0)
-                lastName = parts[0];
-            if (parts.Length > 1)
-                firstName = parts[1];
+            try
+            {
+                string patternTitleName = @"^(?i)(Mr\.?|Mlle|Mademoiselle|Mme|Monsieur|Madame|Enfant)?\s*(?<name>[\p{L}'\-\s]+?)(?:\s+n[eé]e\s+[\p{L}'\-\s]+)?\s+(?<firstName>[\p{L}'-]+)";
+
+                var matchTitleName = Regex.Match(inputText ?? string.Empty, patternTitleName);
+
+                if (matchTitleName.Success)
+                {
+                    string titre = matchTitleName.Groups[1].Value;
+                    string nom = matchTitleName.Groups["name"].Value;
+                    string prenom = matchTitleName.Groups["firstName"].Value;
+
+                    patientLastName = nom.ToUpperInvariant();
+                    patientTitle = string.IsNullOrWhiteSpace(titre) ? string.Empty : titre;
+
+                    if (!string.IsNullOrEmpty(prenom))
+                    {
+                        patientFirstName = char.ToUpper(prenom[0]) + prenom.Substring(1).ToLowerInvariant();
+                    }
+                }
+            }
+            catch
+            {
+                patientTitle = string.Empty;
+                patientLastName = string.Empty;
+                patientFirstName = string.Empty;
+            }
         }
     }
 }

--- a/Client/Helpers/RoomList.cs
+++ b/Client/Helpers/RoomList.cs
@@ -1,12 +1,41 @@
 using System.Collections.ObjectModel;
+using System.IO;
+using Newtonsoft.Json;
 
 namespace Client.Helpers
 {
     public static class RoomList
     {
+        public static readonly string FilePath =
+            Path.Combine(AppContext.BaseDirectory, "Assets", "rooms.json");
+
         public static ObservableCollection<string> Load()
         {
-            return new ObservableCollection<string> { "Salle 1", "Salle 2" };
+            try
+            {
+                if (File.Exists(FilePath))
+                {
+                    var json = File.ReadAllText(FilePath);
+                    return JsonConvert.DeserializeObject<ObservableCollection<string>>(json)
+                           ?? new ObservableCollection<string>();
+                }
+            }
+            catch
+            {
+            }
+            return new ObservableCollection<string>();
+        }
+
+        public static void Save(ObservableCollection<string> rooms)
+        {
+            try
+            {
+                var json = JsonConvert.SerializeObject(rooms, Formatting.Indented);
+                File.WriteAllText(FilePath, json);
+            }
+            catch
+            {
+            }
         }
     }
 }

--- a/Client/Helpers/StringToColorConverter.cs
+++ b/Client/Helpers/StringToColorConverter.cs
@@ -1,0 +1,33 @@
+using Microsoft.UI;
+using Microsoft.UI.Xaml.Data;
+using Client.Models;
+using System;
+using Windows.UI;
+
+namespace Client.Helpers
+{
+    public class StringToColorConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            if (value is string s)
+            {
+                try
+                {
+                    return ColorUtils.FromHex(s);
+                }
+                catch { }
+            }
+            return Colors.Black;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            if (value is Color color)
+            {
+                return ColorUtils.ToHex(color);
+            }
+            return "#000000";
+        }
+    }
+}

--- a/Client/Models/AppColorSettings.cs
+++ b/Client/Models/AppColorSettings.cs
@@ -1,0 +1,13 @@
+namespace Client.Models
+{
+    public class AppColorSettings
+    {
+        public string TitleBarColor { get; set; } = "#FF0078D7";
+        public string TextTitleBarColor { get; set; } = "#FF000000";
+        public string NavigationViewColor { get; set; } = "#FFE6F1FF";
+        public string TextNavigationViewColor { get; set; } = "#FF000000";
+        public string MyMessageColor { get; set; } = "#FFCCE5FF";
+        public string TextMyMessageColor { get; set; } = "#FF000000";
+        public string OtherMessageColor { get; set; } = "#FFD9F2DC";
+    }
+}

--- a/Client/Models/ChatMessageModel.cs
+++ b/Client/Models/ChatMessageModel.cs
@@ -4,11 +4,15 @@ namespace Client.Models
 {
     public class ChatMessageModel
     {
-        public string Avatar { get; set; } = string.Empty;
-        public string Header { get; set; } = string.Empty;
+        public string Sender { get; set; } = string.Empty;
+        public string Destinataire { get; set; } = string.Empty;
+        public string Room { get; set; } = string.Empty;
         public string Content { get; set; } = string.Empty;
-        public string IrcHeader { get; set; } = string.Empty;
+        public string Avatar { get; set; } = string.Empty;
         public DateTime Timestamp { get; set; }
-        public string TimeFormatted => Timestamp.ToString("HH:mm");
+
+        public string TimeFormatted => Timestamp.ToString("dd/MM/yy HH:mm");
+        public string Header => $"{Sender} ({Room}) :";
+        public string IrcHeader => $"[{Timestamp:dd/MM/yy HH:mm}] <{Sender} ({Room})> <{Destinataire}> : {Content}";
     }
 }

--- a/Client/Models/ChatMessageTemplateSelector.cs
+++ b/Client/Models/ChatMessageTemplateSelector.cs
@@ -1,37 +1,43 @@
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml;
+using System.Diagnostics;
 
 namespace Client.Models
 {
-    public enum ChatStyle
-    {
-        Modern,
-        OldSchool
-    }
-
     public class ChatMessageTemplateSelector : DataTemplateSelector
     {
-        public string MyUsername { get; set; } = string.Empty;
         public DataTemplate? MyMessageTemplate { get; set; }
         public DataTemplate? OtherMessageTemplate { get; set; }
-        public DataTemplate? IrcTemplate { get; set; }
         public DataTemplate? LoadMoreTemplate { get; set; }
         public DataTemplate? EmptyTemplate { get; set; }
+        public string MyUsername { get; set; } = string.Empty;
+        public DataTemplate? IrcTemplate { get; set; }
+
+        public enum ChatStyle
+        {
+            Modern,
+            OldSchool
+        }
 
         public ChatStyle DisplayMode { get; set; } = ChatStyle.Modern;
 
         protected override DataTemplate? SelectTemplateCore(object item)
         {
-            if (item is LoadMorePlaceholder) return LoadMoreTemplate;
-            if (item is EmptyPlaceholder) return EmptyTemplate;
+            if (item is LoadMorePlaceholder)
+                return LoadMoreTemplate;
+
+            if (item is EmptyPlaceholder)
+                return EmptyTemplate;
+
             if (item is ChatMessageModel message)
             {
-                if (!string.IsNullOrEmpty(message.IrcHeader))
+                Debug.WriteLine($"[Selector] Style={DisplayMode}, Sender={message.Sender}, MyUsername={MyUsername}");
+                if (DisplayMode == ChatStyle.OldSchool)
                     return IrcTemplate;
-                if (message.Header == MyUsername)
-                    return MyMessageTemplate;
-                return OtherMessageTemplate;
+                else
+                    return message.Sender == MyUsername ? MyMessageTemplate : OtherMessageTemplate;
             }
+
             return base.SelectTemplateCore(item);
         }
     }

--- a/Client/Models/ColorHelper.cs
+++ b/Client/Models/ColorHelper.cs
@@ -1,0 +1,17 @@
+using System;
+using Microsoft.UI;
+
+namespace Client.Models
+{
+    public static class ColorHelper
+    {
+        public static Windows.UI.Color FromArgb(string hex)
+        {
+            return Microsoft.UI.ColorHelper.FromArgb(
+                Convert.ToByte(hex.Substring(1, 2), 16),
+                Convert.ToByte(hex.Substring(3, 2), 16),
+                Convert.ToByte(hex.Substring(5, 2), 16),
+                Convert.ToByte(hex.Substring(7, 2), 16));
+        }
+    }
+}

--- a/Client/Models/ColorUtils.cs
+++ b/Client/Models/ColorUtils.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.UI;
+using Microsoft.UI.Xaml.Media;
+using Windows.UI;
+
+namespace Client.Models
+{
+    public static class ColorUtils
+    {
+        private static readonly IReadOnlyDictionary<string, Color> NamedColors =
+           typeof(Colors)
+               .GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+               .Where(p => p.PropertyType == typeof(Color))
+               .ToDictionary(p => p.Name.ToLowerInvariant(), p => (Color)p.GetValue(null)!);
+
+        public static Color FromHex(string hex)
+        {
+            if (string.IsNullOrWhiteSpace(hex))
+                return Colors.Black;
+
+            hex = hex.Trim();
+
+            if (NamedColors.TryGetValue(hex.ToLowerInvariant(), out var named))
+            {
+                return named;
+            }
+
+            hex = hex.Replace("#", "");
+            if (hex.Length == 6)
+                hex = "FF" + hex;
+
+            byte a = Convert.ToByte(hex.Substring(0, 2), 16);
+            byte r = Convert.ToByte(hex.Substring(2, 2), 16);
+            byte g = Convert.ToByte(hex.Substring(4, 2), 16);
+            byte b = Convert.ToByte(hex.Substring(6, 2), 16);
+
+            return Color.FromArgb(a, r, g, b);
+        }
+
+        public static string ToHex(Color color)
+        {
+            return $"#{color.A:X2}{color.R:X2}{color.G:X2}{color.B:X2}";
+        }
+
+        public static Color GetContrastingTextColor(Color background)
+        {
+            double luminance = (0.299 * background.R + 0.587 * background.G + 0.114 * background.B) / 255;
+            return luminance > 0.5 ? Colors.Black : Colors.White;
+        }
+    }
+}

--- a/Client/Models/EmptyPlaceholder.cs
+++ b/Client/Models/EmptyPlaceholder.cs
@@ -2,6 +2,6 @@ namespace Client.Models
 {
     public class EmptyPlaceholder
     {
-        public string Message { get; set; } = "";
+        public string Message { get; set; } = "— Aucun message trouvé —";
     }
 }

--- a/Client/Models/ExamOption.cs
+++ b/Client/Models/ExamOption.cs
@@ -1,15 +1,130 @@
 using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.IO;
+using Newtonsoft.Json;
 
 namespace Client.Models
 {
-    public class ExamOption
+    public class ExamOption : INotifyPropertyChanged
     {
-        public string Name { get; set; } = string.Empty;
-        public string Floor { get; set; } = string.Empty;
+        private int _index;
+        private string _name = string.Empty;
+        private string _color = string.Empty;
+        private string _codeMSG = string.Empty;
+        private string _annotation = string.Empty;
+        private string _floor = string.Empty;
+
+        public int Index
+        {
+            get => _index;
+            set
+            {
+                if (_index != value)
+                {
+                    _index = value;
+                    OnPropertyChanged(nameof(Index));
+                }
+            }
+        }
+
+        public string Name
+        {
+            get => _name;
+            set
+            {
+                if (_name != value)
+                {
+                    _name = value;
+                    OnPropertyChanged(nameof(Name));
+                }
+            }
+        }
+
+        public string Color
+        {
+            get => _color;
+            set
+            {
+                if (_color != value)
+                {
+                    _color = value;
+                    OnPropertyChanged(nameof(Color));
+                }
+            }
+        }
+
+        public string CodeMSG
+        {
+            get => _codeMSG;
+            set
+            {
+                if (_codeMSG != value)
+                {
+                    _codeMSG = value;
+                    OnPropertyChanged(nameof(CodeMSG));
+                }
+            }
+        }
+
+        public string Annotation
+        {
+            get => _annotation;
+            set
+            {
+                if (_annotation != value)
+                {
+                    _annotation = value;
+                    OnPropertyChanged(nameof(Annotation));
+                }
+            }
+        }
+
+        public string Floor
+        {
+            get => _floor;
+            set
+            {
+                if (_floor != value)
+                {
+                    _floor = value;
+                    OnPropertyChanged(nameof(Floor));
+                }
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyChanged(string propertyName) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+        public static readonly string FilePath = Path.Combine(AppContext.BaseDirectory, "Assets", "exam_options.json");
 
         public static ObservableCollection<ExamOption> Load()
         {
+            try
+            {
+                if (File.Exists(FilePath))
+                {
+                    var json = File.ReadAllText(FilePath);
+                    return JsonConvert.DeserializeObject<ObservableCollection<ExamOption>>(json)
+                           ?? new ObservableCollection<ExamOption>();
+                }
+            }
+            catch
+            {
+            }
             return new ObservableCollection<ExamOption>();
+        }
+
+        public static void Save(ObservableCollection<ExamOption> options)
+        {
+            try
+            {
+                var json = JsonConvert.SerializeObject(options, Formatting.Indented);
+                File.WriteAllText(FilePath, json);
+            }
+            catch
+            {
+            }
         }
     }
 }

--- a/Client/Models/Patient.cs
+++ b/Client/Models/Patient.cs
@@ -1,7 +1,22 @@
+using System;
+
 namespace Client.Models
 {
     public class Patient
     {
-        public string Name { get; set; } = string.Empty;
+        public string Id { get; set; } = string.Empty;
+        public string Colors { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string LastName { get; set; } = string.Empty;
+        public string FirstName { get; set; } = string.Empty;
+        public string Exams { get; set; } = string.Empty;
+        public string Annotation { get; set; } = string.Empty;
+        public string Position { get; set; } = string.Empty;
+        public DateTime HoldTime { get; set; }
+        public DateTime? PickUpTime { get; set; }
+        public TimeSpan TimeOrder { get; set; }
+        public string Examinator { get; set; } = string.Empty;
+        public string OperatorName { get; set; } = string.Empty;
+        public bool IsTaken { get; set; }
     }
 }

--- a/Client/Models/Result.cs
+++ b/Client/Models/Result.cs
@@ -2,18 +2,11 @@ namespace Client.Models
 {
     public class Result<T>
     {
-        public bool Success { get; }
-        public T? Value { get; }
-        public string Error { get; }
+        public bool Success { get; init; }
+        public T? Value { get; init; }
+        public string? Error { get; init; }
 
-        private Result(bool success, T? value, string error)
-        {
-            Success = success;
-            Value = value;
-            Error = error;
-        }
-
-        public static Result<T> Ok(T value) => new Result<T>(true, value, string.Empty);
-        public static Result<T> Fail(string error) => new Result<T>(false, default, error);
+        public static Result<T> Ok(T value) => new() { Success = true, Value = value };
+        public static Result<T> Fail(string message) => new() { Success = false, Error = message };
     }
 }

--- a/Client/Models/SpeedMessageModel.cs
+++ b/Client/Models/SpeedMessageModel.cs
@@ -1,0 +1,11 @@
+namespace Client.Models
+{
+    public class SpeedMessageModel
+    {
+        public int Index { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string Destinataire { get; set; } = string.Empty;
+        public string Message { get; set; } = string.Empty;
+        public string Options { get; set; } = string.Empty;
+    }
+}

--- a/Client/Models/TrimmerHints.cs
+++ b/Client/Models/TrimmerHints.cs
@@ -1,0 +1,14 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Client.Models
+{
+    public static class TrimmerHints
+    {
+        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(UserInfo))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(ChatMessageModel))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Patient))]
+        public static void PreserveForSignalR()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- persist app settings to `settings.json`
- improve patient name extraction with regex
- add color utilities and converter helpers
- expand data models for chat and exams
- include trimmer hints for SignalR

## Testing
- `dotnet build WebApplication1.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685594edaefc8324bf6a37e12e40f5b8