### PR TITLE
Fix ChatStyle compile error

### DIFF
--- a/Client/Models/ChatMessageTemplateSelector.cs
+++ b/Client/Models/ChatMessageTemplateSelector.cs
@@ -13,12 +13,6 @@ namespace Client.Models
         public string MyUsername { get; set; } = string.Empty;
         public DataTemplate? IrcTemplate { get; set; }
 
-        public enum ChatStyle
-        {
-            Modern,
-            OldSchool
-        }
-
         public ChatStyle DisplayMode { get; set; } = ChatStyle.Modern;
 
         protected override DataTemplate? SelectTemplateCore(object item)

--- a/Client/Models/ChatStyle.cs
+++ b/Client/Models/ChatStyle.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Client.Models
+{
+    public enum ChatStyle
+    {
+        Modern,
+        OldSchool
+    }
+}


### PR DESCRIPTION
## Summary
- define `ChatStyle` enum in Models namespace
- adjust template selector to use new enum

## Testing
- `dotnet build WebApplication1.sln -v q` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559852230c8324b81d0c261f4d414c