### PR TITLE
Add customizable appearance page

### DIFF
--- a/Client/App.xaml
+++ b/Client/App.xaml
@@ -10,7 +10,20 @@
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
                 <!-- Other merged dictionaries here -->
             </ResourceDictionary.MergedDictionaries>
-            <!-- Other app resources here -->
+            <!-- Default theme resources -->
+            <SolidColorBrush x:Key="TitleBarColor" Color="#FF0078D7" />
+            <SolidColorBrush x:Key="TextTitleBarColor" Color="#FF000000" />
+            <SolidColorBrush x:Key="NavigationViewColor" Color="#FFE6F1FF" />
+            <SolidColorBrush x:Key="NavigationViewItemForeground" Color="#FF000000" />
+            <SolidColorBrush x:Key="NavigationViewItemForegroundSelected" Color="#FF000000" />
+            <SolidColorBrush x:Key="NavigationViewItemIconForeground" Color="#FF000000" />
+            <SolidColorBrush x:Key="NavigationViewItemIconForegroundSelected" Color="#FF000000" />
+            <SolidColorBrush x:Key="NavigationViewItemForegroundPointerOver" Color="#FFFFFFFF" />
+            <SolidColorBrush x:Key="NavigationViewItemIconForegroundPointerOver" Color="#FFFFFFFF" />
+            <SolidColorBrush x:Key="MyMessageColor" Color="#FFCCE5FF" />
+            <SolidColorBrush x:Key="TextMyMessageColor" Color="#FF000000" />
+            <SolidColorBrush x:Key="OtherMessageColor" Color="#FFD9F2DC" />
+            <x:Double x:Key="MessageFontSize">14</x:Double>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/Client/Pages/AppearanceSettingsPage.xaml
+++ b/Client/Pages/AppearanceSettingsPage.xaml
@@ -1,0 +1,72 @@
+<Page
+    x:Class="Client.Pages.AppearanceSettingsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Client.Pages"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:vm="using:Client.ViewModel"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <ScrollViewer>
+        <StackPanel Padding="20" Spacing="20">
+            <Border Background="White" CornerRadius="8" Padding="20" >
+                <StackPanel Spacing="10">
+                    <StackPanel Orientation="Horizontal">
+                        <Button Content="← Retour" Click="Back_Click" HorizontalAlignment="Left"/>
+                        <TextBlock Text="Apparence" FontSize="18" FontWeight="Bold"/>
+                    </StackPanel>
+
+                    <ToggleSwitch x:Name="IrcModeToggle" Header="Affichage IRC (old school)"
+                                   IsOn="{x:Bind ViewModelSettings.IsOldSchoolMode, Mode=TwoWay}" />
+
+                    <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                        <TextBlock Text="Taille du texte" VerticalAlignment="Center"/>
+                        <Slider Minimum="12" Maximum="24" Width="200" Value="{x:Bind ViewModelSettings.MessageFontSize, Mode=TwoWay}"/>
+                        <TextBlock Text="{x:Bind ViewModelSettings.MessageFontSize}" Margin="5,0,0,0"/>
+                    </StackPanel>
+
+                    <StackPanel Padding="20" Spacing="10">
+                        <TextBlock Text="Aperçu : cliquez sur une zone pour choisir la couleur"/>
+                        <Canvas Height="300">
+                            <Image Source="/Assets/Appchat.png" Width="00" />
+                            <Button x:Name="TitleBarZone" Width="600" Height="20" Background="{ThemeResource TitleBarColor}" Canvas.Left="0" Canvas.Top="0">
+                                <Button.Flyout>
+                                    <Flyout>
+                                        <ColorPicker x:Name="TitleBarPicker" ColorChanged="TitleBarColor_Changed"/>
+                                    </Flyout>
+                                </Button.Flyout>
+                            </Button>
+
+                            <Button x:Name="NavZone" Width="20" Height="280" Background="{ThemeResource NavigationViewColor}" Canvas.Left="0" Canvas.Top="19">
+                                <Button.Flyout>
+                                    <Flyout>
+                                        <ColorPicker x:Name="NavPicker" ColorChanged="NavColor_Changed"/>
+                                    </Flyout>
+                                </Button.Flyout>
+                            </Button>
+
+                            <Button x:Name="MyMessageZone" Width="150" Height="40" Background="{ThemeResource MyMessageColor}" Canvas.Left="330" Canvas.Top="60">
+                                <Button.Flyout>
+                                    <Flyout>
+                                        <ColorPicker x:Name="MyBubblePicker" ColorChanged="MyMessageColor_Changed"/>
+                                    </Flyout>
+                                </Button.Flyout>
+                            </Button>
+
+                            <Button x:Name="OtherMessageZone" Width="150" Height="40" Background="{ThemeResource OtherMessageColor}" Canvas.Left="160" Canvas.Top="110">
+                                <Button.Flyout>
+                                    <Flyout>
+                                        <ColorPicker x:Name="OtherBubblePicker" ColorChanged="OtherMessageColor_Changed"/>
+                                    </Flyout>
+                                </Button.Flyout>
+                            </Button>
+                        </Canvas>
+                        <Button Content="Sauvegarder" Click="SaveSettings_Click"/>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/Client/Pages/AppearanceSettingsPage.xaml.cs
+++ b/Client/Pages/AppearanceSettingsPage.xaml.cs
@@ -1,0 +1,177 @@
+using Client.ViewModel;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using System.Diagnostics;
+using Client.Models;
+using Client.Helpers;
+using System.Linq;
+
+namespace Client.Pages
+{
+    public sealed partial class AppearanceSettingsPage : Page
+    {
+        public SettingsViewModel ViewModelSettings { get; } = new();
+
+        private AppColorSettings currentSettings = new();
+
+        public AppearanceSettingsPage()
+        {
+            this.InitializeComponent();
+            this.DataContext = ViewModelSettings;
+            ViewModelSettings.Load();
+            Debug.WriteLine($"[AppearanceSettingsPage] ViewModel instance: {ViewModelSettings.GetHashCode()}");
+
+            currentSettings = AppSettings.GetObject<AppColorSettings>("Colors");
+
+            if (FindName("TitleBarPicker") is ColorPicker tb)
+                tb.Color = ColorUtils.FromHex(currentSettings.TitleBarColor);
+            if (FindName("NavPicker") is ColorPicker np)
+                np.Color = ColorUtils.FromHex(currentSettings.NavigationViewColor);
+            if (FindName("MyBubblePicker") is ColorPicker mb)
+                mb.Color = ColorUtils.FromHex(currentSettings.MyMessageColor);
+            if (FindName("OtherBubblePicker") is ColorPicker ob)
+                ob.Color = ColorUtils.FromHex(currentSettings.OtherMessageColor);
+        }
+
+        private void TitleBarColor_Changed(ColorPicker sender, ColorChangedEventArgs args)
+        {
+            currentSettings.TitleBarColor = ColorUtils.ToHex(args.NewColor);
+            var textColorTitleBar = ColorUtils.GetContrastingTextColor(args.NewColor);
+            currentSettings.TextTitleBarColor = ColorUtils.ToHex(textColorTitleBar);
+            AppSettings.SetObject("Colors", currentSettings);
+            UpdateResourceBrush("TextTitleBarColor", textColorTitleBar);
+            if (App.MainWindow.Content is FrameworkElement root)
+            {
+                var titleBar = (Grid)root.FindName("AppTitleBar");
+                var nav = (NavigationView)root.FindName("nvSample");
+                var titleText = (TextBlock)root.FindName("TitleBarTextBlock");
+                TitleBarZone.Background = new SolidColorBrush(ColorUtils.FromHex(currentSettings.TitleBarColor));
+                ApplyColors(currentSettings, titleBar, nav, titleText);
+            }
+        }
+
+        private void NavColor_Changed(ColorPicker sender, ColorChangedEventArgs args)
+        {
+            currentSettings.NavigationViewColor = ColorUtils.ToHex(args.NewColor);
+            var textNavColor = ColorUtils.GetContrastingTextColor(args.NewColor);
+            currentSettings.TextNavigationViewColor = ColorUtils.ToHex(textNavColor);
+            AppSettings.SetObject("Colors", currentSettings);
+            if (App.MainWindow.Content is FrameworkElement root)
+            {
+                var titleBar = (Grid)root.FindName("AppTitleBar");
+                var nav = (NavigationView)root.FindName("nvSample");
+                var titleText = (TextBlock)root.FindName("TitleBarTextBlock");
+                NavZone.Background = new SolidColorBrush(ColorUtils.FromHex(currentSettings.NavigationViewColor));
+                ApplyColors(currentSettings, titleBar, nav, titleText);
+            }
+        }
+
+        private void MyMessageColor_Changed(ColorPicker sender, ColorChangedEventArgs args)
+        {
+            currentSettings.MyMessageColor = ColorUtils.ToHex(args.NewColor);
+            var textColor = ColorUtils.GetContrastingTextColor(args.NewColor);
+            currentSettings.TextMyMessageColor = ColorUtils.ToHex(textColor);
+            AppSettings.SetObject("Colors", currentSettings);
+            if (App.MainWindow.Content is FrameworkElement root)
+            {
+                var titleBar = (Grid)root.FindName("AppTitleBar");
+                var nav = (NavigationView)root.FindName("nvSample");
+                var titleText = (TextBlock)root.FindName("TitleBarTextBlock");
+                MyMessageZone.Background = new SolidColorBrush(ColorUtils.FromHex(currentSettings.MyMessageColor));
+                ApplyColors(currentSettings, titleBar, nav, titleText);
+            }
+        }
+
+        private void OtherMessageColor_Changed(ColorPicker sender, ColorChangedEventArgs args)
+        {
+            currentSettings.OtherMessageColor = ColorUtils.ToHex(args.NewColor);
+            AppSettings.SetObject("Colors", currentSettings);
+            if (App.MainWindow.Content is FrameworkElement root)
+            {
+                var titleBar = (Grid)root.FindName("AppTitleBar");
+                var nav = (NavigationView)root.FindName("nvSample");
+                var titleText = (TextBlock)root.FindName("TitleBarTextBlock");
+                OtherMessageZone.Background = new SolidColorBrush(ColorUtils.FromHex(currentSettings.OtherMessageColor));
+                ApplyColors(currentSettings, titleBar, nav, titleText);
+            }
+        }
+
+        private void SaveSettings_Click(object sender, RoutedEventArgs e)
+        {
+            AppSettings.SetObject("Colors", currentSettings);
+            if (App.MainWindow.Content is FrameworkElement root)
+            {
+                var titleBar = (Grid)root.FindName("AppTitleBar");
+                var nav = (NavigationView)root.FindName("nvSample");
+                var titleText = (TextBlock)root.FindName("TitleBarTextBlock");
+                ApplyColors(currentSettings, titleBar, nav, titleText);
+            }
+        }
+
+        public static void ApplyColors(AppColorSettings colors, Grid? titleBar = null, NavigationView? nav = null, TextBlock? titleTextBlock = null)
+        {
+            var titleColor = ColorUtils.FromHex(colors.TitleBarColor);
+            var textColorTitleBar = ColorUtils.FromHex(colors.TextTitleBarColor);
+            var navColor = ColorUtils.FromHex(colors.NavigationViewColor);
+            var textNavColor = ColorUtils.FromHex(colors.TextNavigationViewColor);
+            var pointerNavColor = ColorUtils.GetContrastingTextColor(textNavColor);
+            var myColor = ColorUtils.FromHex(colors.MyMessageColor);
+            var textMyColor = ColorUtils.FromHex(colors.TextMyMessageColor);
+            var otherColor = ColorUtils.FromHex(colors.OtherMessageColor);
+
+            UpdateResourceBrush("TitleBarColor", titleColor);
+            UpdateResourceBrush("TextTitleBarColor", textColorTitleBar);
+            UpdateResourceBrush("NavigationViewColor", navColor);
+            UpdateResourceBrush("SystemAccentColor", titleColor);
+            UpdateResourceBrush("SystemAccentColorLight3", navColor);
+            UpdateResourceBrush("MyMessageColor", myColor);
+            UpdateResourceBrush("TextMyMessageColor", textMyColor);
+            UpdateResourceBrush("NavigationViewItemForeground", textNavColor);
+            UpdateResourceBrush("NavigationViewItemForegroundSelected", textNavColor);
+            UpdateResourceBrush("NavigationViewItemIconForeground", textNavColor);
+            UpdateResourceBrush("NavigationViewItemIconForegroundSelected", textNavColor);
+            UpdateResourceBrush("NavigationViewItemForegroundPointerOver", pointerNavColor);
+            UpdateResourceBrush("NavigationViewItemIconForegroundPointerOver", pointerNavColor);
+            UpdateResourceBrush("OtherMessageColor", otherColor);
+
+            titleBar?.DispatcherQueue.TryEnqueue(() => titleBar.Background = new SolidColorBrush(titleColor));
+            nav?.DispatcherQueue.TryEnqueue(() =>
+            {
+                nav.Background = new SolidColorBrush(navColor);
+                foreach (var item in nav.MenuItems.OfType<NavigationViewItem>())
+                {
+                    item.Foreground = new SolidColorBrush(textNavColor);
+                }
+                if (nav.SettingsItem is NavigationViewItem settingsItem)
+                {
+                    settingsItem.Foreground = new SolidColorBrush(textNavColor);
+                }
+            });
+
+            titleTextBlock?.DispatcherQueue.TryEnqueue(() => titleTextBlock.Foreground = new SolidColorBrush(textColorTitleBar));
+        }
+
+        private static void UpdateResourceBrush(string key, Windows.UI.Color color)
+        {
+            if (Application.Current.Resources[key] is SolidColorBrush brush)
+            {
+                brush.Color = color;
+            }
+            else
+            {
+                Application.Current.Resources[key] = new SolidColorBrush(color);
+            }
+        }
+
+        private void Back_Click(object sender, RoutedEventArgs e)
+        {
+            if (Frame.CanGoBack)
+            {
+                Frame.GoBack();
+            }
+        }
+    }
+}
+

--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -11,13 +11,13 @@
             <StackPanel HorizontalAlignment="Left">
                 <Border CornerRadius="10" Padding="10" Margin="5" MaxWidth="400">
                     <Border.Background>
-                        <SolidColorBrush Color="LightGray"/>
+                        <SolidColorBrush Color="{ThemeResource OtherMessageColor}"/>
                     </Border.Background>
                     <StackPanel Orientation="Horizontal" Spacing="10" MinWidth="180">
                         <Image Source="{x:Bind Avatar}" Width="40" Height="40"/>
                         <StackPanel MinWidth="200">
-                            <TextBlock Text="{x:Bind Header}" FontWeight="Bold"/>
-                            <TextBlock Text="{x:Bind Content}" TextWrapping="Wrap"/>
+                            <TextBlock Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}"/>
+                            <TextBlock Text="{x:Bind Content}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}"/>
                             <TextBlock Text="{x:Bind TimeFormatted}" FontSize="12" HorizontalAlignment="Right"/>
                         </StackPanel>
                     </StackPanel>
@@ -26,13 +26,13 @@
         </DataTemplate>
 
         <DataTemplate x:Key="MyMessageTemplate" x:DataType="data:ChatMessageModel">
-            <Border CornerRadius="10" Padding="10" Margin="5" MaxWidth="800" HorizontalAlignment="Right" Background="LightBlue">
+            <Border CornerRadius="10" Padding="10" Margin="5" MaxWidth="800" HorizontalAlignment="Right" Background="{ThemeResource MyMessageColor}">
                 <StackPanel Orientation="Horizontal" Spacing="10" MinWidth="180">
                     <Image Source="{x:Bind Avatar}" Width="40" Height="40" VerticalAlignment="Top"/>
                     <StackPanel MinWidth="200">
-                        <TextBlock Text="{x:Bind Header}" FontWeight="Bold"/>
-                        <TextBlock Text="{x:Bind Content}" TextWrapping="Wrap" MaxWidth="500" HorizontalAlignment="Left"/>
-                        <TextBlock Text="{x:Bind TimeFormatted}" FontSize="12" HorizontalAlignment="Right"/>
+                        <TextBlock Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextMyMessageColor}"/>
+                        <TextBlock Text="{x:Bind Content}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}" MaxWidth="500" HorizontalAlignment="Left" Foreground="{ThemeResource TextMyMessageColor}"/>
+                        <TextBlock Text="{x:Bind TimeFormatted}" FontSize="12" HorizontalAlignment="Right" Foreground="{ThemeResource TextMyMessageColor}"/>
                     </StackPanel>
                 </StackPanel>
             </Border>

--- a/Client/Pages/SettingsPage.xaml.cs
+++ b/Client/Pages/SettingsPage.xaml.cs
@@ -12,6 +12,7 @@ namespace Client.Pages
 
         private void Appearance_Click(object sender, RoutedEventArgs e)
         {
+            Frame.Navigate(typeof(AppearanceSettingsPage));
         }
 
         private void User_Click(object sender, RoutedEventArgs e)

--- a/Client/ViewModel/SettingsViewModel.cs
+++ b/Client/ViewModel/SettingsViewModel.cs
@@ -1,14 +1,64 @@
 using System;
+using System.ComponentModel;
+using Microsoft.UI.Xaml;
+using Client.Helpers;
+using Client.Models;
 
 namespace Client.ViewModel
 {
-    public class SettingsViewModel
+    public class SettingsViewModel : INotifyPropertyChanged
     {
-        public event Action<Models.ChatStyle>? DisplayStyleChanged;
+        private bool _isOldSchoolMode;
+        private double _messageFontSize = 14;
 
-        public void RaiseDisplayStyleChanged(Models.ChatStyle style)
+        public event Action<ChatStyle>? DisplayStyleChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public bool IsOldSchoolMode
         {
-            DisplayStyleChanged?.Invoke(style);
+            get => _isOldSchoolMode;
+            set
+            {
+                if (_isOldSchoolMode != value)
+                {
+                    _isOldSchoolMode = value;
+                    OnPropertyChanged(nameof(IsOldSchoolMode));
+                    AppSettings.Set("ChatDisplayStyle", value ? "OldSchool" : "Modern");
+                    DisplayStyleChanged?.Invoke(value ? ChatStyle.OldSchool : ChatStyle.Modern);
+                }
+            }
+        }
+
+        public double MessageFontSize
+        {
+            get => _messageFontSize;
+            set
+            {
+                if (_messageFontSize != value)
+                {
+                    _messageFontSize = value;
+                    OnPropertyChanged(nameof(MessageFontSize));
+                    AppSettings.Set("MessageFontSize", value.ToString());
+                    Application.Current.Resources["MessageFontSize"] = value;
+                }
+            }
+        }
+
+        public void Load()
+        {
+            var style = AppSettings.Get("ChatDisplayStyle", "Modern");
+            _isOldSchoolMode = style == "OldSchool";
+            if (double.TryParse(AppSettings.Get("MessageFontSize", "14"), out var size))
+            {
+                _messageFontSize = size;
+            }
+            // update resources with loaded values
+            Application.Current.Resources["MessageFontSize"] = _messageFontSize;
+        }
+
+        private void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }


### PR DESCRIPTION
## Summary
- define theme resources for colours and font size
- update chat message templates to use these theme resources
- implement SettingsViewModel with appearance settings support
- navigate to new appearance settings page from the settings page
- add the new `AppearanceSettingsPage` for colour customisation

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ab30b60c832485bf550bf9c6a91e