### PR TITLE
Add exam room and user settings pages

### DIFF
--- a/Client/Helpers/AppSettings.cs
+++ b/Client/Helpers/AppSettings.cs
@@ -8,21 +8,44 @@ namespace Client.Helpers
 {
     public static class AppSettings
     {
-        private static readonly string filePath =
-            Path.Combine(AppContext.BaseDirectory, "settings.json");
-
         private static Dictionary<string, JsonElement> _settings = new();
-        public static UserInfo? CurrentSelectedUser { get; set; }
+
+        private static string FilePath =>
+            Path.Combine(AppContext.BaseDirectory,
+                $"{(CurrentSelectedUser?.Username ?? "default")}_settings.json");
+
+        private static UserInfo? _currentUser;
+        public static UserInfo? CurrentSelectedUser
+        {
+            get => _currentUser;
+            set
+            {
+                if (_currentUser?.Username != value?.Username)
+                {
+                    _currentUser = value;
+                    Load();
+                }
+            }
+        }
 
         static AppSettings()
         {
+            Load();
+        }
+
+        private static void Load()
+        {
             try
             {
-                if (File.Exists(filePath))
+                if (File.Exists(FilePath))
                 {
-                    var json = File.ReadAllText(filePath);
+                    var json = File.ReadAllText(FilePath);
                     _settings = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json)
                                 ?? new();
+                }
+                else
+                {
+                    _settings = new();
                 }
             }
             catch
@@ -72,7 +95,7 @@ namespace Client.Helpers
                 {
                     WriteIndented = true
                 });
-                File.WriteAllText(filePath, json);
+                File.WriteAllText(FilePath, json);
             }
             catch (Exception ex)
             {

--- a/Client/Pages/ExamRoomPage.xaml
+++ b/Client/Pages/ExamRoomPage.xaml
@@ -1,0 +1,98 @@
+<Page
+    x:Class="Client.Pages.ExamRoomPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:data="using:Client.Models"
+    xmlns:helpers="using:Client.Helpers"
+    x:Name="PageRoot"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Page.Resources>
+        <helpers:StringToColorConverter x:Key="StringToColorConverter" />
+    </Page.Resources>
+    <ScrollViewer>
+        <StackPanel Padding="20" Spacing="10">
+            <Button Content="← Retour" Click="Back_Click" HorizontalAlignment="Left"/>
+            <TextBlock Text="Examens" FontSize="24" FontWeight="Bold"/>
+
+            <Grid  Padding="5" ColumnSpacing="5" Margin="10,10,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="200" />
+                    <ColumnDefinition Width="100" />
+                    <ColumnDefinition Width="150" />
+                    <ColumnDefinition Width="200" />
+                    <ColumnDefinition Width="200" />
+                    <ColumnDefinition Width="80" />
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="Nom" Grid.Column="0" TextAlignment="Center"/>
+                <TextBlock Text="Couleur" Grid.Column="1" TextAlignment="Center"/>
+                <TextBlock Text="Code clavier" Grid.Column="2" TextAlignment="Center"/>
+                <TextBlock Text="Annotation" Grid.Column="3" TextAlignment="Center"/>
+                <TextBlock Text="Salle" Grid.Column="4" TextAlignment="Center"/>
+                <TextBlock Text="" Grid.Column="5" />
+            </Grid>
+
+            <ListView x:Name="OptionsList" ItemsSource="{x:Bind Options}" SelectionMode="None">
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="data:ExamOption">
+                        <Border BorderBrush="Gray" BorderThickness="0,0,0,1" Padding="0">
+                            <Grid Padding="5" ColumnSpacing="5">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="200" />
+                                    <ColumnDefinition Width="100" />
+                                    <ColumnDefinition Width="150" />
+                                    <ColumnDefinition Width="200" />
+                                    <ColumnDefinition Width="200" />
+                                    <ColumnDefinition Width="100" />
+                                </Grid.ColumnDefinitions>
+                                <TextBox Text="{x:Bind Name, Mode=TwoWay}" Grid.Column="0"/>
+                                <Grid Grid.Column="1">
+                                    <Button HorizontalAlignment="Stretch">
+                                        <Rectangle Width="32" Height="16"
+                                                   Fill="{x:Bind Color, Mode=OneWay, Converter={StaticResource StringToColorConverter}}"
+                                                   Stroke="Black"/>
+                                        <Button.Flyout>
+                                            <Flyout>
+                                                <ColorPicker
+                                                    Color="{x:Bind Color, Mode=TwoWay , Converter={StaticResource StringToColorConverter}}"
+                                                    ColorChanged="ColorPicker_ColorChanged"/>
+                                            </Flyout>
+                                        </Button.Flyout>
+                                    </Button>
+                                </Grid>
+
+                                <TextBox Text="{x:Bind CodeMSG, Mode=TwoWay}" Grid.Column="2"/>
+                                <TextBox Text="{x:Bind Annotation, Mode=TwoWay}" Grid.Column="3"/>
+                                <ComboBox Grid.Column="4" Width="200"
+                                          ItemsSource="{Binding Rooms, ElementName=PageRoot}"
+                                          SelectedItem="{x:Bind Floor, Mode=TwoWay}"/>
+                                <Button Grid.Column="5" Content="Supprimer" Click="DeleteExam_Click" />
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+            <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,10,0,0">
+                <Button Content="Ajouter" Click="Add_Click" />
+            </StackPanel>
+
+            <TextBlock Text="Salles" FontSize="24" FontWeight="Bold" Margin="0,20,0,0"/>
+            <StackPanel Orientation="Horizontal" Spacing="10">
+                <TextBox x:Name="NewRoomBox" Width="200"/>
+                <Button Content="Ajouter la salle" Click="AddRoom_Click" />
+            </StackPanel>
+            <ListView ItemsSource="{x:Bind Rooms}" SelectionMode="None">
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="x:String">
+                        <StackPanel Orientation="Horizontal" Spacing="10">
+                            <TextBlock Text="{x:Bind}" VerticalAlignment="Center" Width="200"/>
+                            <Button Content="Renommer" Click="RenameRoom_Click" />
+                            <Button Content="Supprimer" Click="RemoveRoom_Click"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+        </StackPanel>
+    </ScrollViewer>
+</Page>
+

--- a/Client/Pages/ExamRoomPage.xaml.cs
+++ b/Client/Pages/ExamRoomPage.xaml.cs
@@ -1,0 +1,268 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Client.Models;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR.Client;
+using System.Diagnostics;
+using System;
+using System.Linq;
+using System.IO;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using Client.Helpers;
+
+namespace Client.Pages
+{
+    public sealed partial class ExamRoomPage : Page
+    {
+        public ObservableCollection<ExamOption> Options { get; } = ExamOption.Load();
+        public ObservableCollection<string> Rooms { get; } = RoomList.Load();
+
+        private bool _syncing;
+
+        public ExamRoomPage()
+        {
+            this.InitializeComponent();
+            foreach (var opt in Options)
+                opt.PropertyChanged += Option_PropertyChanged;
+
+            Options.CollectionChanged += Options_CollectionChanged;
+            Rooms.CollectionChanged += Rooms_CollectionChanged;
+            this.Loaded += ExamRoomPage_Loaded;
+            this.Unloaded += ExamRoomPage_Unloaded;
+        }
+
+        private void ExamRoomPage_Unloaded(object sender, RoutedEventArgs e)
+        {
+            App.ChatService.ExamOptionsUpdated -= ChatService_ExamOptionsUpdated;
+            App.ChatService.RoomsUpdated -= ChatService_RoomsUpdated;
+        }
+
+        private void DeleteExam_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button btn && btn.DataContext is ExamOption opt)
+            {
+                Options.Remove(opt);
+            }
+        }
+        private void Add_Click(object sender, RoutedEventArgs e)
+        {
+            Options.Add(new ExamOption
+            {
+                Index = Options.Count + 1,
+                Color = "yellow"
+            });
+        }
+        private void ColorPicker_ColorChanged(ColorPicker sender, ColorChangedEventArgs args)
+        {
+            if (sender.DataContext is ExamOption option)
+            {
+                option.Color = ColorUtils.ToHex(args.NewColor);
+            }
+        }
+
+        private void AddRoom_Click(object sender, RoutedEventArgs e)
+        {
+            if (FindName("NewRoomBox") is TextBox tb && !string.IsNullOrWhiteSpace(tb.Text))
+            {
+                Rooms.Add(tb.Text);
+                tb.Text = string.Empty;
+            }
+        }
+        private void RemoveRoom_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button btn && btn.DataContext is string room)
+            {
+                Rooms.Remove(room);
+            }
+        }
+        private async Task TrySendExamOptionsAsync()
+        {
+            try
+            {
+                if (App.ChatService.Connection != null &&
+                    App.ChatService.Connection.State == HubConnectionState.Connected)
+                {
+                    await App.ChatService.SendExamOptionsAsync(Options);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur synchro examens : {ex.Message}");
+            }
+        }
+
+        private async void Option_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (_syncing) return;
+            ExamOption.Save(Options);
+            await TrySendExamOptionsAsync();
+        }
+
+        private async void Options_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (_syncing) return;
+            int index = 1;
+            foreach (var opt in Options)
+                opt.Index = index++;
+
+            if (e.NewItems != null)
+            {
+                foreach (ExamOption opt in e.NewItems)
+                    opt.PropertyChanged += Option_PropertyChanged;
+            }
+
+            if (e.OldItems != null)
+            {
+                foreach (ExamOption opt in e.OldItems)
+                    opt.PropertyChanged -= Option_PropertyChanged;
+            }
+
+            ExamOption.Save(Options);
+            await TrySendExamOptionsAsync();
+        }
+
+        private async void Rooms_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            if (_syncing) return;
+            RoomList.Save(Rooms);
+            try
+            {
+                if (App.ChatService.Connection != null &&
+                    App.ChatService.Connection.State == HubConnectionState.Connected)
+                {
+                    Debug.WriteLine($"Envoi {Rooms.Count} salles");
+                    await App.ChatService.SendRoomsAsync(Rooms);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur synchro salles : {ex.Message}");
+            }
+        }
+        private void Back_Click(object sender, RoutedEventArgs e)
+        {
+            if (Frame.CanGoBack)
+            {
+                Frame.GoBack();
+            }
+        }
+        private async void ExamRoomPage_Loaded(object sender, RoutedEventArgs e)
+        {
+            App.ChatService.ExamOptionsUpdated += ChatService_ExamOptionsUpdated;
+            App.ChatService.RoomsUpdated += ChatService_RoomsUpdated;
+            await SyncWithServerAsync();
+        }
+
+        private void ChatService_ExamOptionsUpdated(IEnumerable<ExamOption> obj)
+        {
+            _ = DispatcherQueue.TryEnqueue(async () => await SyncWithServerAsync());
+        }
+
+        private void ChatService_RoomsUpdated(IEnumerable<string> obj)
+        {
+            _ = DispatcherQueue.TryEnqueue(async () => await SyncWithServerAsync());
+        }
+
+        private async Task SyncWithServerAsync()
+        {
+            if (App.ChatService.Connection == null ||
+                App.ChatService.Connection.State != HubConnectionState.Connected)
+                return;
+
+            _syncing = true;
+
+            var serverOptions = await App.ChatService.GetExamOptionsAsync();
+            if (serverOptions.Any())
+            {
+                if (!AreExamOptionsEqual(serverOptions, Options))
+                {
+                    BackupFile(ExamOption.FilePath);
+                    Options.CollectionChanged -= Options_CollectionChanged;
+                    foreach (var o in Options)
+                        o.PropertyChanged -= Option_PropertyChanged;
+                    Options.Clear();
+                    foreach (var opt in serverOptions.OrderBy(o => o.Index))
+                    {
+                        Options.Add(opt);
+                        opt.PropertyChanged += Option_PropertyChanged;
+                    }
+                    Options.CollectionChanged += Options_CollectionChanged;
+                    ExamOption.Save(Options);
+                }
+            }
+            else if (Options.Any())
+            {
+                await App.ChatService.SendExamOptionsAsync(Options);
+            }
+
+            var serverRooms = await App.ChatService.GetRoomsAsync();
+            if (serverRooms.Any())
+            {
+                if (!serverRooms.SequenceEqual(Rooms))
+                {
+                    BackupFile(RoomList.FilePath);
+                    Rooms.CollectionChanged -= Rooms_CollectionChanged;
+                    Rooms.Clear();
+                    foreach (var r in serverRooms)
+                        Rooms.Add(r);
+                    Rooms.CollectionChanged += Rooms_CollectionChanged;
+                    RoomList.Save(Rooms);
+                }
+            }
+            else if (Rooms.Any())
+            {
+                await App.ChatService.SendRoomsAsync(Rooms);
+            }
+
+            _syncing = false;
+        }
+
+        private static void BackupFile(string path)
+        {
+            try
+            {
+                if (File.Exists(path))
+                    File.Copy(path, path + ".bak", true);
+            }
+            catch
+            {
+            }
+        }
+
+        private static bool AreExamOptionsEqual(IEnumerable<ExamOption> a, IEnumerable<ExamOption> b)
+        {
+            var ja = JsonConvert.SerializeObject(a);
+            var jb = JsonConvert.SerializeObject(b);
+            return ja == jb;
+        }
+
+        private async void RenameRoom_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button btn && btn.DataContext is string room)
+            {
+                var dialog = new ContentDialog
+                {
+                    Title = "Renommer la salle",
+                    PrimaryButtonText = "Valider",
+                    CloseButtonText = "Annuler",
+                    XamlRoot = this.XamlRoot
+                };
+
+                var box = new TextBox { Text = room };
+                dialog.Content = box;
+                var result = await dialog.ShowAsync();
+                if (result == ContentDialogResult.Primary)
+                {
+                    var index = Rooms.IndexOf(room);
+                    if (index >= 0 && !string.IsNullOrWhiteSpace(box.Text))
+                        Rooms[index] = box.Text.Trim();
+                }
+            }
+        }
+    }
+}
+

--- a/Client/Pages/SettingsPage.xaml.cs
+++ b/Client/Pages/SettingsPage.xaml.cs
@@ -17,6 +17,7 @@ namespace Client.Pages
 
         private void User_Click(object sender, RoutedEventArgs e)
         {
+            Frame.Navigate(typeof(UserSettingsPage));
         }
 
         private void System_Click(object sender, RoutedEventArgs e)
@@ -25,6 +26,7 @@ namespace Client.Pages
 
         private void Exam_Click(object sender, RoutedEventArgs e)
         {
+            Frame.Navigate(typeof(ExamRoomPage));
         }
     }
 }

--- a/Client/Pages/UserSettingsPage.xaml
+++ b/Client/Pages/UserSettingsPage.xaml
@@ -1,0 +1,201 @@
+<Page
+    x:Class="Client.Pages.UserSettingsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:vm="using:Client.ViewModel"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <ScrollViewer>
+        <StackPanel Padding="20" Spacing="20">
+            <Button Content="← Retour" Click="Back_Click" HorizontalAlignment="Left"/>
+            <TextBlock Text="Utilisateur" FontSize="24" FontWeight="Bold"/>
+            <Border Background="White" CornerRadius="8" Padding="20">
+                <StackPanel Spacing="10">
+                    <TextBlock Text="Raccourcis en tête" FontSize="18" FontWeight="Bold"/>
+
+                    <StackPanel Orientation="Horizontal" Spacing="10">
+
+                    <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="400">
+                        <StackPanel Spacing="10">
+                                <TextBlock Text="F5" FontWeight="Bold" HorizontalAlignment="Center"/>
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <TextBlock Text="Réfraction :" Width="100" VerticalAlignment="Center"/>
+                                    <TextBox Text="{x:Bind ViewModelSettings.ShortcutF5Refraction, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="200"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <TextBlock Text="Lentilles :" Width="100" VerticalAlignment="Center"/>
+                                    <TextBox Text="{x:Bind ViewModelSettings.ShortcutF5Lentilles, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="200"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <TextBlock Text="Pathologies :" Width="100" VerticalAlignment="Center"/>
+                                    <TextBox Text="{x:Bind ViewModelSettings.ShortcutF5Pathologies, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="200"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <TextBlock Text="Orthoptie :" Width="100" VerticalAlignment="Center"/>
+                                    <TextBox Text="{x:Bind ViewModelSettings.ShortcutF5Orthoptie, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="200"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
+
+                    <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="400">
+                        <StackPanel Spacing="10">
+                            <TextBlock Text="F6" FontWeight="Bold" HorizontalAlignment="Center"/>
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <TextBlock Text="Réfraction :" Width="100" VerticalAlignment="Center"/>
+                                    <TextBox Text="{x:Bind ViewModelSettings.ShortcutF6Refraction, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="200"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <TextBlock Text="Lentilles :" Width="100" VerticalAlignment="Center"/>
+                                    <TextBox Text="{x:Bind ViewModelSettings.ShortcutF6Lentilles, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="200"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <TextBlock Text="Pathologies :" Width="100" VerticalAlignment="Center"/>
+                                    <TextBox Text="{x:Bind ViewModelSettings.ShortcutF6Pathologies, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="200"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <TextBlock Text="Orthoptie :" Width="100" VerticalAlignment="Center"/>
+                                    <TextBox Text="{x:Bind ViewModelSettings.ShortcutF6Orthoptie, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="200"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
+
+                    <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="400">
+                        <StackPanel Spacing="10">
+                                <TextBlock Text="F7" FontWeight="Bold" HorizontalAlignment="Center"/>
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <TextBlock Text="Réfraction :" Width="100" VerticalAlignment="Center"/>
+                                    <TextBox Text="{x:Bind ViewModelSettings.ShortcutF7Refraction, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="200"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <TextBlock Text="Lentilles :" Width="100" VerticalAlignment="Center"/>
+                                    <TextBox Text="{x:Bind ViewModelSettings.ShortcutF7Lentilles, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="200"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <TextBlock Text="Pathologies :" Width="100" VerticalAlignment="Center"/>
+                                    <TextBox Text="{x:Bind ViewModelSettings.ShortcutF7Pathologies, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="200"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <TextBlock Text="Orthoptie :" Width="100" VerticalAlignment="Center"/>
+                                    <TextBox Text="{x:Bind ViewModelSettings.ShortcutF7Orthoptie, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="200"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
+                    <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="400">
+                        <StackPanel Spacing="10">
+                                <TextBlock Text="F8" FontWeight="Bold" HorizontalAlignment="Center"/>
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <TextBlock Text="Réfraction :" Width="100" VerticalAlignment="Center"/>
+                                    <TextBox Text="{x:Bind ViewModelSettings.ShortcutF8Refraction, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="200"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <TextBlock Text="Lentilles :" Width="100" VerticalAlignment="Center"/>
+                                    <TextBox Text="{x:Bind ViewModelSettings.ShortcutF8Lentilles, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="200"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <TextBlock Text="Pathologies :" Width="100" VerticalAlignment="Center"/>
+                                    <TextBox Text="{x:Bind ViewModelSettings.ShortcutF8Pathologies, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="200"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <TextBlock Text="Orthoptie :" Width="100" VerticalAlignment="Center"/>
+                                    <TextBox Text="{x:Bind ViewModelSettings.ShortcutF8Orthoptie, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="200"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+            <Border Background="White" CornerRadius="8" Padding="20">
+                <StackPanel Spacing="10">
+                    <TextBlock Text="Raccourcis patient" FontSize="18" FontWeight="Bold"/>
+                    <StackPanel Orientation="Horizontal" Spacing="10">
+                        <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
+                            <StackPanel Spacing="10">
+                                <TextBlock Text="Ctrl F9" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                <ComboBox Width="150"
+                                          ItemsSource="{x:Bind ExamOptions}"
+                                          DisplayMemberPath="Name"
+                                          SelectedValuePath="Name"
+                                          SelectedValue="{x:Bind ViewModelSettings.CtrlF9Exam, Mode=TwoWay}"/>
+                            </StackPanel>
+                        </Border>
+                        <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
+                            <StackPanel Spacing="10">
+                                <TextBlock Text="Maj F9" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                <ComboBox Width="150"
+                                          ItemsSource="{x:Bind ExamOptions}"
+                                          DisplayMemberPath="Name"
+                                          SelectedValuePath="Name"
+                                          SelectedValue="{x:Bind ViewModelSettings.ShiftF9Exam, Mode=TwoWay}"/>
+                            </StackPanel>
+                        </Border>
+                        <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
+                            <StackPanel Spacing="10">
+                                <TextBlock Text="Ctrl F10" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                <ComboBox Width="150"
+                                          ItemsSource="{x:Bind ExamOptions}"
+                                          DisplayMemberPath="Name"
+                                          SelectedValuePath="Name"
+                                          SelectedValue="{x:Bind ViewModelSettings.CtrlF10Exam, Mode=TwoWay}"/>
+                            </StackPanel>
+                        </Border>
+                        <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
+                            <StackPanel Spacing="10">
+                                <TextBlock Text="Maj F10" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                <ComboBox Width="150"
+                                          ItemsSource="{x:Bind ExamOptions}"
+                                          DisplayMemberPath="Name"
+                                          SelectedValuePath="Name"
+                                          SelectedValue="{x:Bind ViewModelSettings.ShiftF10Exam, Mode=TwoWay}"/>
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="10">
+                        <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
+                            <StackPanel Spacing="10">
+                                <TextBlock Text="Ctrl F11" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                <ComboBox Width="150"
+                                          ItemsSource="{x:Bind ExamOptions}"
+                                          DisplayMemberPath="Name"
+                                          SelectedValuePath="Name"
+                                          SelectedValue="{x:Bind ViewModelSettings.CtrlF11Exam, Mode=TwoWay}"/>
+                            </StackPanel>
+                        </Border>
+                        <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
+                            <StackPanel Spacing="10">
+                                <TextBlock Text="Maj F11" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                <ComboBox Width="150"
+                                          ItemsSource="{x:Bind ExamOptions}"
+                                          DisplayMemberPath="Name"
+                                          SelectedValuePath="Name"
+                                          SelectedValue="{x:Bind ViewModelSettings.ShiftF11Exam, Mode=TwoWay}"/>
+                            </StackPanel>
+                        </Border>
+                        <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
+                            <StackPanel Spacing="10">
+                                <TextBlock Text="Ctrl F12" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                <ComboBox Width="150"
+                                          ItemsSource="{x:Bind ExamOptions}"
+                                          DisplayMemberPath="Name"
+                                          SelectedValuePath="Name"
+                                          SelectedValue="{x:Bind ViewModelSettings.CtrlF12Exam, Mode=TwoWay}"/>
+                            </StackPanel>
+                        </Border>
+                        <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
+                            <StackPanel Spacing="10">
+                                <TextBlock Text="Maj F12" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                <ComboBox Width="150"
+                                          ItemsSource="{x:Bind ExamOptions}"
+                                          DisplayMemberPath="Name"
+                                          SelectedValuePath="Name"
+                                          SelectedValue="{x:Bind ViewModelSettings.ShiftF12Exam, Mode=TwoWay}"/>
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+        </StackPanel>
+    </ScrollViewer>
+</Page>
+

--- a/Client/Pages/UserSettingsPage.xaml.cs
+++ b/Client/Pages/UserSettingsPage.xaml.cs
@@ -1,0 +1,31 @@
+using Client.ViewModel;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using System.Diagnostics;
+using Client.Models;
+using System.Collections.ObjectModel;
+
+namespace Client.Pages
+{
+    public sealed partial class UserSettingsPage : Page
+    {
+        public SettingsViewModel ViewModelSettings { get; } = new();
+        public ObservableCollection<ExamOption> ExamOptions { get; } = ExamOption.Load();
+
+        public UserSettingsPage()
+        {
+            this.InitializeComponent();
+            this.DataContext = ViewModelSettings;
+            ViewModelSettings.Load();
+            Debug.WriteLine($"[UserSettingsPage] ViewModel instance: {ViewModelSettings.GetHashCode()}");
+        }
+        private void Back_Click(object sender, RoutedEventArgs e)
+        {
+            if (Frame.CanGoBack)
+            {
+                Frame.GoBack();
+            }
+        }
+    }
+}
+

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -29,6 +29,8 @@ namespace Client.Services
 
         public event Action<ChatMessageModel>? OnMessageReceived;
         public event Action<Patient>? OnNewPatient;
+        public event Action<IEnumerable<ExamOption>>? ExamOptionsUpdated;
+        public event Action<IEnumerable<string>>? RoomsUpdated;
 
         private static readonly JsonSerializerSettings CamelCaseSettings = new()
         {
@@ -133,6 +135,16 @@ namespace Client.Services
             Connection.On<Patient>("NewPatient", patient =>
             {
                 OnNewPatient?.Invoke(patient);
+            });
+
+            Connection.On<IEnumerable<ExamOption>>("ExamOptionsUpdated", opts =>
+            {
+                ExamOptionsUpdated?.Invoke(opts);
+            });
+
+            Connection.On<IEnumerable<string>>("RoomsUpdated", rooms =>
+            {
+                RoomsUpdated?.Invoke(rooms);
             });
 
             try

--- a/Client/ViewModel/SettingsViewModel.cs
+++ b/Client/ViewModel/SettingsViewModel.cs
@@ -10,6 +10,34 @@ namespace Client.ViewModel
     {
         private bool _isOldSchoolMode;
         private double _messageFontSize = 14;
+        private string _shortcutF5Refraction = string.Empty;
+        private string _shortcutF5Lentilles = string.Empty;
+        private string _shortcutF5Pathologies = string.Empty;
+        private string _shortcutF5Orthoptie = string.Empty;
+
+        private string _shortcutF6Refraction = string.Empty;
+        private string _shortcutF6Lentilles = string.Empty;
+        private string _shortcutF6Pathologies = string.Empty;
+        private string _shortcutF6Orthoptie = string.Empty;
+
+        private string _shortcutF7Refraction = string.Empty;
+        private string _shortcutF7Lentilles = string.Empty;
+        private string _shortcutF7Pathologies = string.Empty;
+        private string _shortcutF7Orthoptie = string.Empty;
+
+        private string _shortcutF8Refraction = string.Empty;
+        private string _shortcutF8Lentilles = string.Empty;
+        private string _shortcutF8Pathologies = string.Empty;
+        private string _shortcutF8Orthoptie = string.Empty;
+
+        private string _ctrlF9Exam = string.Empty;
+        private string _shiftF9Exam = string.Empty;
+        private string _ctrlF10Exam = string.Empty;
+        private string _shiftF10Exam = string.Empty;
+        private string _ctrlF11Exam = string.Empty;
+        private string _shiftF11Exam = string.Empty;
+        private string _ctrlF12Exam = string.Empty;
+        private string _shiftF12Exam = string.Empty;
 
         public event Action<ChatStyle>? DisplayStyleChanged;
         public event PropertyChangedEventHandler? PropertyChanged;
@@ -44,6 +72,153 @@ namespace Client.ViewModel
             }
         }
 
+        private string Get(string key) => AppSettings.Get(key, string.Empty);
+        private void Set(string key, string value) => AppSettings.Set(key, value);
+
+        public string ShortcutF5Refraction
+        {
+            get => _shortcutF5Refraction;
+            set { if (_shortcutF5Refraction != value) { _shortcutF5Refraction = value; OnPropertyChanged(nameof(ShortcutF5Refraction)); Set("ShortcutF5Refraction", value); } }
+        }
+
+        public string ShortcutF5Lentilles
+        {
+            get => _shortcutF5Lentilles;
+            set { if (_shortcutF5Lentilles != value) { _shortcutF5Lentilles = value; OnPropertyChanged(nameof(ShortcutF5Lentilles)); Set("ShortcutF5Lentilles", value); } }
+        }
+
+        public string ShortcutF5Pathologies
+        {
+            get => _shortcutF5Pathologies;
+            set { if (_shortcutF5Pathologies != value) { _shortcutF5Pathologies = value; OnPropertyChanged(nameof(ShortcutF5Pathologies)); Set("ShortcutF5Pathologies", value); } }
+        }
+
+        public string ShortcutF5Orthoptie
+        {
+            get => _shortcutF5Orthoptie;
+            set { if (_shortcutF5Orthoptie != value) { _shortcutF5Orthoptie = value; OnPropertyChanged(nameof(ShortcutF5Orthoptie)); Set("ShortcutF5Orthoptie", value); } }
+        }
+
+        public string ShortcutF6Refraction
+        {
+            get => _shortcutF6Refraction;
+            set { if (_shortcutF6Refraction != value) { _shortcutF6Refraction = value; OnPropertyChanged(nameof(ShortcutF6Refraction)); Set("ShortcutF6Refraction", value); } }
+        }
+
+        public string ShortcutF6Lentilles
+        {
+            get => _shortcutF6Lentilles;
+            set { if (_shortcutF6Lentilles != value) { _shortcutF6Lentilles = value; OnPropertyChanged(nameof(ShortcutF6Lentilles)); Set("ShortcutF6Lentilles", value); } }
+        }
+
+        public string ShortcutF6Pathologies
+        {
+            get => _shortcutF6Pathologies;
+            set { if (_shortcutF6Pathologies != value) { _shortcutF6Pathologies = value; OnPropertyChanged(nameof(ShortcutF6Pathologies)); Set("ShortcutF6Pathologies", value); } }
+        }
+
+        public string ShortcutF6Orthoptie
+        {
+            get => _shortcutF6Orthoptie;
+            set { if (_shortcutF6Orthoptie != value) { _shortcutF6Orthoptie = value; OnPropertyChanged(nameof(ShortcutF6Orthoptie)); Set("ShortcutF6Orthoptie", value); } }
+        }
+
+        public string ShortcutF7Refraction
+        {
+            get => _shortcutF7Refraction;
+            set { if (_shortcutF7Refraction != value) { _shortcutF7Refraction = value; OnPropertyChanged(nameof(ShortcutF7Refraction)); Set("ShortcutF7Refraction", value); } }
+        }
+
+        public string ShortcutF7Lentilles
+        {
+            get => _shortcutF7Lentilles;
+            set { if (_shortcutF7Lentilles != value) { _shortcutF7Lentilles = value; OnPropertyChanged(nameof(ShortcutF7Lentilles)); Set("ShortcutF7Lentilles", value); } }
+        }
+
+        public string ShortcutF7Pathologies
+        {
+            get => _shortcutF7Pathologies;
+            set { if (_shortcutF7Pathologies != value) { _shortcutF7Pathologies = value; OnPropertyChanged(nameof(ShortcutF7Pathologies)); Set("ShortcutF7Pathologies", value); } }
+        }
+
+        public string ShortcutF7Orthoptie
+        {
+            get => _shortcutF7Orthoptie;
+            set { if (_shortcutF7Orthoptie != value) { _shortcutF7Orthoptie = value; OnPropertyChanged(nameof(ShortcutF7Orthoptie)); Set("ShortcutF7Orthoptie", value); } }
+        }
+
+        public string ShortcutF8Refraction
+        {
+            get => _shortcutF8Refraction;
+            set { if (_shortcutF8Refraction != value) { _shortcutF8Refraction = value; OnPropertyChanged(nameof(ShortcutF8Refraction)); Set("ShortcutF8Refraction", value); } }
+        }
+
+        public string ShortcutF8Lentilles
+        {
+            get => _shortcutF8Lentilles;
+            set { if (_shortcutF8Lentilles != value) { _shortcutF8Lentilles = value; OnPropertyChanged(nameof(ShortcutF8Lentilles)); Set("ShortcutF8Lentilles", value); } }
+        }
+
+        public string ShortcutF8Pathologies
+        {
+            get => _shortcutF8Pathologies;
+            set { if (_shortcutF8Pathologies != value) { _shortcutF8Pathologies = value; OnPropertyChanged(nameof(ShortcutF8Pathologies)); Set("ShortcutF8Pathologies", value); } }
+        }
+
+        public string ShortcutF8Orthoptie
+        {
+            get => _shortcutF8Orthoptie;
+            set { if (_shortcutF8Orthoptie != value) { _shortcutF8Orthoptie = value; OnPropertyChanged(nameof(ShortcutF8Orthoptie)); Set("ShortcutF8Orthoptie", value); } }
+        }
+
+        public string CtrlF9Exam
+        {
+            get => _ctrlF9Exam;
+            set { if (_ctrlF9Exam != value) { _ctrlF9Exam = value; OnPropertyChanged(nameof(CtrlF9Exam)); Set("CtrlF9Exam", value); } }
+        }
+
+        public string ShiftF9Exam
+        {
+            get => _shiftF9Exam;
+            set { if (_shiftF9Exam != value) { _shiftF9Exam = value; OnPropertyChanged(nameof(ShiftF9Exam)); Set("ShiftF9Exam", value); } }
+        }
+
+        public string CtrlF10Exam
+        {
+            get => _ctrlF10Exam;
+            set { if (_ctrlF10Exam != value) { _ctrlF10Exam = value; OnPropertyChanged(nameof(CtrlF10Exam)); Set("CtrlF10Exam", value); } }
+        }
+
+        public string ShiftF10Exam
+        {
+            get => _shiftF10Exam;
+            set { if (_shiftF10Exam != value) { _shiftF10Exam = value; OnPropertyChanged(nameof(ShiftF10Exam)); Set("ShiftF10Exam", value); } }
+        }
+
+        public string CtrlF11Exam
+        {
+            get => _ctrlF11Exam;
+            set { if (_ctrlF11Exam != value) { _ctrlF11Exam = value; OnPropertyChanged(nameof(CtrlF11Exam)); Set("CtrlF11Exam", value); } }
+        }
+
+        public string ShiftF11Exam
+        {
+            get => _shiftF11Exam;
+            set { if (_shiftF11Exam != value) { _shiftF11Exam = value; OnPropertyChanged(nameof(ShiftF11Exam)); Set("ShiftF11Exam", value); } }
+        }
+
+        public string CtrlF12Exam
+        {
+            get => _ctrlF12Exam;
+            set { if (_ctrlF12Exam != value) { _ctrlF12Exam = value; OnPropertyChanged(nameof(CtrlF12Exam)); Set("CtrlF12Exam", value); } }
+        }
+
+        public string ShiftF12Exam
+        {
+            get => _shiftF12Exam;
+            set { if (_shiftF12Exam != value) { _shiftF12Exam = value; OnPropertyChanged(nameof(ShiftF12Exam)); Set("ShiftF12Exam", value); } }
+        }
+
         public void Load()
         {
             var style = AppSettings.Get("ChatDisplayStyle", "Modern");
@@ -52,8 +227,39 @@ namespace Client.ViewModel
             {
                 _messageFontSize = size;
             }
+
+            _shortcutF5Refraction = Get("ShortcutF5Refraction");
+            _shortcutF5Lentilles = Get("ShortcutF5Lentilles");
+            _shortcutF5Pathologies = Get("ShortcutF5Pathologies");
+            _shortcutF5Orthoptie = Get("ShortcutF5Orthoptie");
+
+            _shortcutF6Refraction = Get("ShortcutF6Refraction");
+            _shortcutF6Lentilles = Get("ShortcutF6Lentilles");
+            _shortcutF6Pathologies = Get("ShortcutF6Pathologies");
+            _shortcutF6Orthoptie = Get("ShortcutF6Orthoptie");
+
+            _shortcutF7Refraction = Get("ShortcutF7Refraction");
+            _shortcutF7Lentilles = Get("ShortcutF7Lentilles");
+            _shortcutF7Pathologies = Get("ShortcutF7Pathologies");
+            _shortcutF7Orthoptie = Get("ShortcutF7Orthoptie");
+
+            _shortcutF8Refraction = Get("ShortcutF8Refraction");
+            _shortcutF8Lentilles = Get("ShortcutF8Lentilles");
+            _shortcutF8Pathologies = Get("ShortcutF8Pathologies");
+            _shortcutF8Orthoptie = Get("ShortcutF8Orthoptie");
+
+            _ctrlF9Exam = Get("CtrlF9Exam");
+            _shiftF9Exam = Get("ShiftF9Exam");
+            _ctrlF10Exam = Get("CtrlF10Exam");
+            _shiftF10Exam = Get("ShiftF10Exam");
+            _ctrlF11Exam = Get("CtrlF11Exam");
+            _shiftF11Exam = Get("ShiftF11Exam");
+            _ctrlF12Exam = Get("CtrlF12Exam");
+            _shiftF12Exam = Get("ShiftF12Exam");
+
             // update resources with loaded values
             Application.Current.Resources["MessageFontSize"] = _messageFontSize;
+            OnPropertyChanged(string.Empty);
         }
 
         private void OnPropertyChanged(string propertyName)

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -245,6 +245,7 @@ namespace ChatServeur
 
             config.ExamOptionsJson = json;
             await _db.SaveChangesAsync();
+            await Clients.All.SendAsync("ExamOptionsUpdated", options);
         }
 
         public async Task SaveRooms(IEnumerable<string> rooms)
@@ -258,6 +259,37 @@ namespace ChatServeur
             }
             config.RoomsJson = json;
             await _db.SaveChangesAsync();
+            await Clients.All.SendAsync("RoomsUpdated", rooms);
+        }
+
+        public async Task<List<ExamOption>> GetExamOptions()
+        {
+            var config = await _db.ServerConfigs.FirstOrDefaultAsync();
+            if (config == null || string.IsNullOrEmpty(config.ExamOptionsJson))
+                return new List<ExamOption>();
+            try
+            {
+                return JsonSerializer.Deserialize<List<ExamOption>>(config.ExamOptionsJson) ?? new List<ExamOption>();
+            }
+            catch
+            {
+                return new List<ExamOption>();
+            }
+        }
+
+        public async Task<List<string>> GetRooms()
+        {
+            var config = await _db.ServerConfigs.FirstOrDefaultAsync();
+            if (config == null || string.IsNullOrEmpty(config.RoomsJson))
+                return new List<string>();
+            try
+            {
+                return JsonSerializer.Deserialize<List<string>>(config.RoomsJson) ?? new List<string>();
+            }
+            catch
+            {
+                return new List<string>();
+            }
         }
     }
 }

--- a/Serveur/Models/ExamOption.cs
+++ b/Serveur/Models/ExamOption.cs
@@ -1,0 +1,13 @@
+namespace ChatServeur
+{
+    public class ExamOption
+    {
+        public int Index { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Color { get; set; } = string.Empty;
+        public string CodeMSG { get; set; } = string.Empty;
+        public string Annotation { get; set; } = string.Empty;
+        public string Floor { get; set; } = string.Empty;
+    }
+}
+


### PR DESCRIPTION
## Summary
- store settings in per-user json files
- add ExamRoomPage for configuring exam options and rooms
- add UserSettingsPage for configuring shortcuts
- broadcast exam/room updates via SignalR and expose retrieval methods
- wire navigation from settings

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6856d321e47c83249e572eccf5c0db6f