### PR TITLE
Manual sync for exam/room config

### DIFF
--- a/Client/Pages/ExamRoomPage.xaml
+++ b/Client/Pages/ExamRoomPage.xaml
@@ -92,6 +92,10 @@
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>
+            <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,10,0,0">
+                <Button Content="Charger depuis serveur" Click="LoadServer_Click" />
+                <Button Content="Envoyer au serveur" Click="SendServer_Click" />
+            </StackPanel>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/Client/Pages/ExamRoomPage.xaml.cs
+++ b/Client/Pages/ExamRoomPage.xaml.cs
@@ -40,13 +40,6 @@ namespace Client.Pages
         {
             App.ChatService.ExamOptionsUpdated -= ChatService_ExamOptionsUpdated;
             App.ChatService.RoomsUpdated -= ChatService_RoomsUpdated;
-
-            if (_hasChanges)
-            {
-                await TrySendExamOptionsAsync();
-                await TrySendRoomsAsync();
-                _hasChanges = false;
-            }
         }
 
         private void DeleteExam_Click(object sender, RoutedEventArgs e)
@@ -86,6 +79,16 @@ namespace Client.Pages
             {
                 Rooms.Remove(room);
             }
+        }
+
+        private async void LoadServer_Click(object sender, RoutedEventArgs e)
+        {
+            await LoadConfigFromServerAsync();
+        }
+
+        private async void SendServer_Click(object sender, RoutedEventArgs e)
+        {
+            await SendConfigToServerAsync();
         }
         private async Task TrySendExamOptionsAsync()
         {
@@ -163,24 +166,22 @@ namespace Client.Pages
                 Frame.GoBack();
             }
         }
-        private async void ExamRoomPage_Loaded(object sender, RoutedEventArgs e)
+        private void ExamRoomPage_Loaded(object sender, RoutedEventArgs e)
         {
-            //App.ChatService.ExamOptionsUpdated += ChatService_ExamOptionsUpdated;
-            App.ChatService.RoomsUpdated += ChatService_RoomsUpdated;
-            await SyncWithServerAsync();
+            // Synchronisation manuelle uniquement
         }
 
         private void ChatService_ExamOptionsUpdated(IEnumerable<ExamOption> obj)
         {
-            _ = DispatcherQueue.TryEnqueue(async () => await SyncWithServerAsync());
+            // plus de synchronisation automatique
         }
 
         private void ChatService_RoomsUpdated(IEnumerable<string> obj)
         {
-            _ = DispatcherQueue.TryEnqueue(async () => await SyncWithServerAsync());
+            // plus de synchronisation automatique
         }
 
-        private async Task SyncWithServerAsync()
+        private async Task LoadConfigFromServerAsync()
         {
             if (App.ChatService.Connection == null ||
                 App.ChatService.Connection.State != HubConnectionState.Connected)
@@ -191,47 +192,51 @@ namespace Client.Pages
             var serverOptions = await App.ChatService.GetExamOptionsAsync();
             if (serverOptions.Any())
             {
-                if (!AreExamOptionsEqual(serverOptions, Options))
+                BackupFile(ExamOption.FilePath);
+                Options.CollectionChanged -= Options_CollectionChanged;
+                foreach (var o in Options)
+                    o.PropertyChanged -= Option_PropertyChanged;
+                Options.Clear();
+                foreach (var opt in serverOptions.OrderBy(o => o.Index))
                 {
-                    BackupFile(ExamOption.FilePath);
-                    Options.CollectionChanged -= Options_CollectionChanged;
-                    foreach (var o in Options)
-                        o.PropertyChanged -= Option_PropertyChanged;
-                    Options.Clear();
-                    foreach (var opt in serverOptions.OrderBy(o => o.Index))
-                    {
-                        Options.Add(opt);
-                        opt.PropertyChanged += Option_PropertyChanged;
-                    }
-                    Options.CollectionChanged += Options_CollectionChanged;
-                    ExamOption.Save(Options);
+                    Options.Add(opt);
+                    opt.PropertyChanged += Option_PropertyChanged;
                 }
-            }
-            else if (Options.Any())
-            {
-                await App.ChatService.SendExamOptionsAsync(Options);
+                Options.CollectionChanged += Options_CollectionChanged;
+                ExamOption.Save(Options);
             }
 
             var serverRooms = await App.ChatService.GetRoomsAsync();
             if (serverRooms.Any())
             {
-                if (!serverRooms.SequenceEqual(Rooms))
-                {
-                    BackupFile(RoomList.FilePath);
-                    Rooms.CollectionChanged -= Rooms_CollectionChanged;
-                    Rooms.Clear();
-                    foreach (var r in serverRooms)
-                        Rooms.Add(r);
-                    Rooms.CollectionChanged += Rooms_CollectionChanged;
-                    RoomList.Save(Rooms);
-                }
-            }
-            else if (Rooms.Any())
-            {
-                await App.ChatService.SendRoomsAsync(Rooms);
+                BackupFile(RoomList.FilePath);
+                Rooms.CollectionChanged -= Rooms_CollectionChanged;
+                Rooms.Clear();
+                foreach (var r in serverRooms)
+                    Rooms.Add(r);
+                Rooms.CollectionChanged += Rooms_CollectionChanged;
+                RoomList.Save(Rooms);
             }
 
             _syncing = false;
+        }
+
+        private async Task SendConfigToServerAsync()
+        {
+            try
+            {
+                if (App.ChatService.Connection != null &&
+                    App.ChatService.Connection.State == HubConnectionState.Connected)
+                {
+                    await App.ChatService.SendExamOptionsSilentAsync(Options);
+                    await App.ChatService.SendRoomsSilentAsync(Rooms);
+                    _hasChanges = false;
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur envoi configuration : {ex.Message}");
+            }
         }
 
         private static void BackupFile(string path)

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -328,6 +328,21 @@ namespace Client.Services
             }
         }
 
+        public async Task SendExamOptionsSilentAsync(IEnumerable<ExamOption> options)
+        {
+            if (Connection is null || Connection.State != HubConnectionState.Connected)
+                throw new InvalidOperationException("Connexion SignalR non établie.");
+
+            try
+            {
+                await Connection.InvokeAsync("SaveExamOptionsSilent", options);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur envoi examens silencieux : {ex.Message}");
+            }
+        }
+
         public async Task SendRoomsAsync(IEnumerable<string> rooms)
         {
             if (Connection is null || Connection.State != HubConnectionState.Connected)
@@ -340,6 +355,21 @@ namespace Client.Services
             catch (Exception ex)
             {
                 Debug.WriteLine($"Erreur envoi salles : {ex.Message}");
+            }
+        }
+
+        public async Task SendRoomsSilentAsync(IEnumerable<string> rooms)
+        {
+            if (Connection is null || Connection.State != HubConnectionState.Connected)
+                throw new InvalidOperationException("Connexion SignalR non établie.");
+
+            try
+            {
+                await Connection.InvokeAsync("SaveRoomsSilent", rooms);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur envoi salles silencieux : {ex.Message}");
             }
         }
         public async Task<List<ExamOption>> GetExamOptionsAsync()

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -248,6 +248,20 @@ namespace ChatServeur
             await Clients.All.SendAsync("ExamOptionsUpdated", options);
         }
 
+        public async Task SaveExamOptionsSilent(IEnumerable<ExamOption> options)
+        {
+            var json = JsonSerializer.Serialize(options);
+            var config = await _db.ServerConfigs.FirstOrDefaultAsync();
+            if (config == null)
+            {
+                config = new ServerConfig();
+                _db.ServerConfigs.Add(config);
+            }
+
+            config.ExamOptionsJson = json;
+            await _db.SaveChangesAsync();
+        }
+
         public async Task SaveRooms(IEnumerable<string> rooms)
         {
             var json = JsonSerializer.Serialize(rooms);
@@ -260,6 +274,19 @@ namespace ChatServeur
             config.RoomsJson = json;
             await _db.SaveChangesAsync();
             await Clients.All.SendAsync("RoomsUpdated", rooms);
+        }
+
+        public async Task SaveRoomsSilent(IEnumerable<string> rooms)
+        {
+            var json = JsonSerializer.Serialize(rooms);
+            var config = await _db.ServerConfigs.FirstOrDefaultAsync();
+            if (config == null)
+            {
+                config = new ServerConfig();
+                _db.ServerConfigs.Add(config);
+            }
+            config.RoomsJson = json;
+            await _db.SaveChangesAsync();
         }
 
         public async Task<List<ExamOption>> GetExamOptions()


### PR DESCRIPTION
## Summary
- add silent hub methods for saving exam options and rooms
- extend SignalR service with silent send helpers
- add manual sync buttons to the exam/room page
- load/send configuration on demand instead of automatically

## Testing
- `dotnet build WebApplication1.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857888adad483248473c5ae09af66a9