### PR TITLE
Improve connection persistence and scanning

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -17,6 +17,10 @@ namespace Client
         {
             m_window = new MainWindow();
             MainWindow = m_window;
+
+            ChatService.Dispatcher = m_window.DispatcherQueue;
+            _ = ChatService.InitializeAsync();
+
             m_window.Activate();
         }
 

--- a/Client/Helpers/NetworkScanner.cs
+++ b/Client/Helpers/NetworkScanner.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Client.Helpers
@@ -31,27 +32,40 @@ namespace Client.Helpers
             }
 
             using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(1) };
-            using var ping = new Ping();
+
             foreach (var baseIp in networks.Distinct())
             {
                 var bytes = baseIp.GetAddressBytes();
-                for (int i = 1; i < 255; i++)
+                var ips = Enumerable.Range(1, 254)
+                                    .Select(i => $"{bytes[0]}.{bytes[1]}.{bytes[2]}.{i}")
+                                    .ToList();
+
+                string? found = null;
+
+                await Parallel.ForEachAsync(ips, new ParallelOptions { MaxDegreeOfParallelism = 32 }, async (ip, ct) =>
                 {
-                    var ip = $"{bytes[0]}.{bytes[1]}.{bytes[2]}.{i}";
+                    if (found != null)
+                        return;
+
                     try
                     {
-                        var reply = await ping.SendPingAsync(ip, 500);
+                        using var ping = new Ping();
+                        var reply = await ping.SendPingAsync(ip, 200);
                         if (reply.Status != IPStatus.Success)
-                            continue;
+                            return;
+
                         var url = $"http://{ip}:{port}/";
-                        using var response = await http.GetAsync(url);
+                        using var response = await http.GetAsync(url, ct);
                         if (response.IsSuccessStatusCode)
-                            return $"http://{ip}:{port}";
+                            Interlocked.CompareExchange(ref found, $"http://{ip}:{port}", null);
                     }
                     catch
                     {
                     }
-                }
+                });
+
+                if (found != null)
+                    return found;
             }
             return null;
         }

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -66,25 +66,26 @@ namespace Client.Pages
             TryRestoreUserSelection();
             await WaitForConnectionReady();
 
-            Messages.Clear();
-            Messages.Add(new LoadMorePlaceholder());
-
-            var cachedMessages = await _service.LoadTodayMessagesFromDiskAsync();
-            if (cachedMessages.Any())
+            if (!_service.IsHistoryLoaded && !Messages.OfType<ChatMessageModel>().Any())
             {
+                Messages.Clear();
+                Messages.Add(new LoadMorePlaceholder());
+
+                var cachedMessages = await _service.LoadTodayMessagesFromDiskAsync();
                 foreach (var msg in cachedMessages)
                     Messages.Add(msg);
-                ScrollToLastMessage();
-            }
 
-            var result = await _service.LoadTodayMessagesAsync("Moi");
-            if (result.Success)
-            {
-                Messages.RemoveWhere<ChatMessageModel>();
-                foreach (var msg in result.Value)
-                    Messages.Add(msg);
+                var result = await _service.LoadTodayMessagesAsync("Moi");
+                if (result.Success)
+                {
+                    foreach (var item in Messages.OfType<ChatMessageModel>().ToList())
+                        Messages.Remove(item);
+                    foreach (var msg in result.Value)
+                        Messages.Add(msg);
 
-                await _service.SaveTodayMessagesToDiskAsync();
+                    await _service.SaveTodayMessagesToDiskAsync();
+                }
+
                 ScrollToLastMessage();
             }
 

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -28,6 +28,11 @@ namespace Client.Services
         public ObservableCollection<Patient> Patients { get; } = new();
         public ObservableCollection<object> Messages { get; } = new();
 
+        private bool _initialized;
+        private bool _historyLoaded;
+
+        public bool IsHistoryLoaded => _historyLoaded;
+
         public string ServerAddress { get; set; } = "http://localhost:5000";
 
         public SignalRService()
@@ -46,9 +51,33 @@ namespace Client.Services
             ContractResolver = new Newtonsoft.Json.Serialization.CamelCasePropertyNamesContractResolver()
         };
 
-        public Task InitializeAsync()
+        public async Task InitializeAsync()
         {
-            return ConnectAsync("Moi", @"E:\benoit.png", "RDC");
+            if (_initialized)
+                return;
+
+            _initialized = true;
+
+            await ConnectAsync("Moi", @"E:\benoit.png", "RDC");
+
+            Messages.Clear();
+            Messages.Add(new LoadMorePlaceholder());
+
+            var cached = await LoadTodayMessagesFromDiskAsync();
+            foreach (var msg in cached)
+                Messages.Add(msg);
+
+            var result = await LoadTodayMessagesAsync("Moi");
+            if (result.Success)
+            {
+                foreach (var item in Messages.OfType<ChatMessageModel>().ToList())
+                    Messages.Remove(item);
+                foreach (var msg in result.Value)
+                    Messages.Add(msg);
+
+                _historyLoaded = true;
+                await SaveTodayMessagesToDiskAsync();
+            }
         }
 
         public async Task ConnectAsync(string username, string avatar, string room)
@@ -134,23 +163,25 @@ namespace Client.Services
                 });
             });
 
-            Connection.On<string, string,string, string, string, DateTime>("ReceiveMessage", (user, room, destinataire, msg, avatar, time) =>
+            Connection.On<string, string, string, string, string, DateTime>("ReceiveMessage", (user, room, destinataire, msg, avatar, time) =>
             {
-                Dispatcher?.TryEnqueue(() =>
+                var chat = new ChatMessageModel
                 {
-                    var chat = new ChatMessageModel
-                    {
-                        Sender = user,
-                        Destinataire = destinataire,
-                        Room = room,
-                        Content = msg,
-                        Timestamp = time,
-                        Avatar  = avatar
-                    };
-                    Debug.WriteLine($"✅ Message reçu de {user} dans la salle {room} : {msg} ({time})");
+                    Sender = user,
+                    Destinataire = destinataire,
+                    Room = room,
+                    Content = msg,
+                    Timestamp = time,
+                    Avatar = avatar
+                };
+
+                Debug.WriteLine($"✅ Message reçu de {user} dans la salle {room} : {msg} ({time})");
+
+                Dispatcher?.TryEnqueue(async () =>
+                {
+                    Messages.Add(chat);
                     OnMessageReceived?.Invoke(chat);
-
-
+                    await SaveTodayMessagesToDiskAsync();
                 });
             });
 


### PR DESCRIPTION
## Summary
- connect SignalR service when the application launches
- update network scanner to probe IPs in parallel
- avoid reloading chat history on every navigation
- persist incoming messages even when ChatPage isn't active

## Testing
- `dotnet build WebApplication1.sln -v q` *(fails: `dotnet` not found)*
- `dotnet test WebApplication1.sln -v q` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685808266d788324a98ed94eee4564e2