### PR TITLE
Keep offline users and store user list locally

### DIFF
--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -58,6 +58,14 @@ namespace Client.Services
 
             _initialized = true;
 
+            var cachedUsers = await LoadUsersFromDiskAsync();
+            foreach (var user in cachedUsers)
+            {
+                user.IsOnline = false;
+                user.Room = "Hors ligne";
+                ConnectedUsers.Add(user);
+            }
+
             await ConnectAsync("Benoit", @"E:\benoit.png", "RDC");
 
             Messages.Clear();
@@ -116,25 +124,38 @@ namespace Client.Services
                     Debug.WriteLine($"❌ Toast error: {ex.Message}");
                 }
 
+                foreach (var u in ConnectedUsers)
+                {
+                    u.IsOnline = false;
+                    u.Room = "Hors ligne";
+                }
+                await SaveUsersToDiskAsync();
                 await Task.Delay(3000);
             };
 
             Connection.On<UserInfo>("UserConnected", user =>
             {
-                Dispatcher?.TryEnqueue(() =>
+                Dispatcher?.TryEnqueue(async () =>
                 {
-                    if (!ConnectedUsers.Any(u => u.Username == user.Username))
+                    var existing = ConnectedUsers.FirstOrDefault(u => u.Username == user.Username);
+                    if (existing != null)
+                    {
+                        var index = ConnectedUsers.IndexOf(existing);
+                        ConnectedUsers[index] = user;
+                    }
+                    else
                     {
                         ConnectedUsers.Add(user);
-                        Debug.WriteLine($"✅ User connecté : {user.Username}");
                     }
+                    Debug.WriteLine($"✅ User connecté : {user.Username}");
+                    await SaveUsersToDiskAsync();
                 });
             });
 
 
             Connection.On<List<UserInfo>>("UserListUpdated", users =>
             {
-                Dispatcher?.TryEnqueue(() =>
+                Dispatcher?.TryEnqueue(async () =>
                 {
                     ConnectedUsers.Clear();
 
@@ -143,6 +164,8 @@ namespace Client.Services
                         ConnectedUsers.Add(user);
                         Debug.WriteLine($"✅ User list ajoutée : {user.Username} ({user.Room})");
                     }
+
+                    await SaveUsersToDiskAsync();
                 });
             });
 
@@ -365,6 +388,38 @@ namespace Client.Services
             catch (Exception ex)
             {
                 Debug.WriteLine($"Erreur sauvegarde cache local : {ex.Message}");
+            }
+        }
+
+        public async Task<List<UserInfo>> LoadUsersFromDiskAsync()
+        {
+            try
+            {
+                var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat", "users.json");
+                if (File.Exists(path))
+                {
+                    var json = await File.ReadAllTextAsync(path);
+                    return JsonConvert.DeserializeObject<List<UserInfo>>(json) ?? new();
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur lecture users cache : {ex.Message}");
+            }
+            return new();
+        }
+
+        public async Task SaveUsersToDiskAsync()
+        {
+            try
+            {
+                var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat", "users.json");
+                var json = JsonConvert.SerializeObject(ConnectedUsers.ToList(), Formatting.Indented);
+                await File.WriteAllTextAsync(path, json);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur sauvegarde users cache : {ex.Message}");
             }
         }
         public async Task SendExamOptionsAsync(IEnumerable<ExamOption> options)

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -9,7 +9,32 @@ namespace ChatServeur
     {
         private static readonly Dictionary<string, UserInfo> ConnectedUsers = new();
         private static readonly Dictionary<string, string> _userToConnectionId = new();
+        private static readonly Dictionary<string, UserInfo> AllUsers = new();
         private static readonly Dictionary<string, HashSet<string>> GroupMembers = new();
+
+        private static readonly List<UserInfo> BaseUsers = new()
+        {
+            new UserInfo
+            {
+                ConnectionId = string.Empty,
+                Username = "A Tous",
+                Avatar = "ms-appx:///Assets/earth.png",
+                Room = string.Empty,
+                DisplayName = "A Tous",
+                IsOnline = true,
+                Note = string.Empty
+            },
+            new UserInfo
+            {
+                ConnectionId = string.Empty,
+                Username = "Secrétariat",
+                Avatar = "ms-appx:///Assets/secretaria.png",
+                Room = string.Empty,
+                DisplayName = "Secrétariat",
+                IsOnline = true,
+                Note = string.Empty
+            }
+        };
 
         private readonly ChatDbContext _db;
 
@@ -27,8 +52,15 @@ namespace ChatServeur
         {
             if (ConnectedUsers.Remove(Context.ConnectionId, out var user))
             {
+                user.IsOnline = false;
+                user.Room = "Hors ligne";
+                AllUsers[user.Username] = user;
+
                 await Clients.All.SendAsync("UserDisconnected", user.Username);
-                await Clients.All.SendAsync("UserListUpdated", ConnectedUsers.Values);
+
+                var userList = BaseUsers.Concat(AllUsers.Values).ToList();
+                await Clients.All.SendAsync("UserListUpdated", userList);
+
                 _userToConnectionId.Remove(user.Username);
 
                 foreach (var group in GroupMembers.Keys)
@@ -59,6 +91,7 @@ namespace ChatServeur
 
                 ConnectedUsers[Context.ConnectionId] = user;
                 _userToConnectionId[username] = Context.ConnectionId;
+                AllUsers[username] = user;
 
                 await Groups.AddToGroupAsync(Context.ConnectionId, "A Tous");
                 if (!GroupMembers.ContainsKey("A Tous"))
@@ -79,31 +112,8 @@ namespace ChatServeur
                 }
 
                 await Clients.All.SendAsync("UserConnected", user);
-                var baseUsers = new List<UserInfo>
-                {
-                    new UserInfo
-                    {
-                        ConnectionId = string.Empty,
-                        Username = "A Tous",
-                        Avatar = "ms-appx:///Assets/earth.png",
-                        Room = string.Empty,
-                        DisplayName = "A Tous",
-                        IsOnline = true,
-                        Note = string.Empty
-                    },
-                    new UserInfo
-                    {
-                        ConnectionId = string.Empty,
-                        Username = "Secrétariat",
-                        Avatar = "ms-appx:///Assets/secretaria.png",
-                        Room = string.Empty,
-                        DisplayName = "Secrétariat",
-                        IsOnline = true,
-                        Note = string.Empty
-                    }
-                };
 
-                var userList = baseUsers.Concat(ConnectedUsers.Values).ToList();
+                var userList = BaseUsers.Concat(AllUsers.Values).ToList();
 
                 await Clients.All.SendAsync("UserListUpdated", userList);
             }


### PR DESCRIPTION
## Summary
- track all users server-side and mark them offline on disconnect
- always include default "A Tous" and "Secrétariat" users
- persist user list locally on client and load it at startup
- update SignalR client to save user list whenever it changes

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68581a4a7474832496027ff09415d1d2