### PR TITLE
Manage chat window behavior on message arrival

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -1,6 +1,10 @@
 using Microsoft.UI.Xaml;
 using System;
 using Client.Services;
+using Microsoft.Windows.AppNotifications;
+using Microsoft.Windows.AppNotifications.Builder;
+using Client.Models;
+using Client.Helpers;
 
 namespace Client
 {
@@ -19,9 +23,69 @@ namespace Client
             MainWindow = m_window;
 
             ChatService.Dispatcher = m_window.DispatcherQueue;
+            ChatService.OnMessageReceived += ChatService_OnMessageReceived;
             _ = ChatService.InitializeAsync();
 
             m_window.Activate();
+        }
+
+        private void ChatService_OnMessageReceived(ChatMessageModel chat)
+        {
+            if (MainWindow is not MainWindow mw)
+                return;
+
+            bool isForeground = WindowHelper.IsForeground(mw);
+            bool isChat = mw.IsChatPageActive;
+
+            if (!isForeground)
+            {
+                mw.DispatcherQueue.TryEnqueue(() =>
+                {
+                    mw.ShowChatPage();
+                    mw.SetTopMost(true, false);
+                    mw.ScrollMessagesToEnd();
+                });
+            }
+            else if (mw.IsTopMost)
+            {
+                if (isChat)
+                {
+                    mw.DispatcherQueue.TryEnqueue(mw.ScrollMessagesToEnd);
+                }
+                else
+                {
+                    mw.DispatcherQueue.TryEnqueue(() => ShowNotification(chat));
+                }
+            }
+            else
+            {
+                if (isChat)
+                {
+                    mw.DispatcherQueue.TryEnqueue(mw.ScrollMessagesToEnd);
+                }
+                else
+                {
+                    mw.DispatcherQueue.TryEnqueue(() => ShowNotification(chat));
+                }
+            }
+        }
+
+        private static void ShowNotification(ChatMessageModel chat)
+        {
+            try
+            {
+                var notification = new AppNotificationBuilder()
+                    .AddText("EyeChat")
+                    .AddText($"{chat.Sender}: {chat.Content}")
+                    .BuildNotification();
+
+                AppNotificationManager.Default.Register();
+                AppNotificationManager.Default.Show(notification);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"❌ Toast error: {ex.Message}");
+            }
         }
 
         private Window? m_window;

--- a/Client/Helpers/WindowHelper.cs
+++ b/Client/Helpers/WindowHelper.cs
@@ -1,0 +1,37 @@
+using Microsoft.UI.Xaml;
+using System;
+using System.Runtime.InteropServices;
+using WinRT.Interop;
+
+namespace Client.Helpers
+{
+    public static class WindowHelper
+    {
+        private const uint SWP_NOSIZE = 0x0001;
+        private const uint SWP_NOMOVE = 0x0002;
+        private const uint SWP_NOACTIVATE = 0x0010;
+        private static readonly IntPtr HWND_TOPMOST = new(-1);
+        private static readonly IntPtr HWND_NOTOPMOST = new(-2);
+
+        [DllImport("user32.dll")]
+        private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter,
+            int X, int Y, int cx, int cy, uint uFlags);
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr GetForegroundWindow();
+
+        public static void SetTopMost(Window window, bool topMost, bool activate)
+        {
+            var hwnd = WindowNative.GetWindowHandle(window);
+            uint flags = SWP_NOMOVE | SWP_NOSIZE | (activate ? 0u : SWP_NOACTIVATE);
+            SetWindowPos(hwnd, topMost ? HWND_TOPMOST : HWND_NOTOPMOST,
+                0, 0, 0, 0, flags);
+        }
+
+        public static bool IsForeground(Window window)
+        {
+            var hwnd = WindowNative.GetWindowHandle(window);
+            return GetForegroundWindow() == hwnd;
+        }
+    }
+}

--- a/Client/MainWindow.xaml.cs
+++ b/Client/MainWindow.xaml.cs
@@ -6,11 +6,16 @@ using Microsoft.UI.Windowing;
 using WinRT.Interop;
 using Windows.UI;
 using Microsoft.UI;
+using Client.Helpers;
 
 namespace Client
 {
     public sealed partial class MainWindow : Window
     {
+        public bool IsTopMost { get; private set; }
+
+        public bool IsChatPageActive => contentFrame.CurrentSourcePageType == typeof(Pages.ChatPage);
+
         public MainWindow()
         {
             this.InitializeComponent();
@@ -64,6 +69,20 @@ namespace Client
             }
 
             return contentFrame.Content as Pages.ChatPage;
+        }
+
+        public void SetTopMost(bool topMost, bool activate = false)
+        {
+            WindowHelper.SetTopMost(this, topMost, activate);
+            IsTopMost = topMost;
+        }
+
+        public void ScrollMessagesToEnd()
+        {
+            if (contentFrame.Content is Pages.ChatPage chat)
+            {
+                chat.ScrollToLastMessage();
+            }
         }
     }
 }

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -298,7 +298,7 @@ namespace Client.Pages
             MessagesList.UpdateLayout();
         }
 
-        private async void ScrollToLastMessage()
+        public async void ScrollToLastMessage()
         {
             await Task.Delay(100);
 


### PR DESCRIPTION
## Summary
- expose `ScrollToLastMessage` for external calls
- track and control topmost state in `MainWindow`
- add `WindowHelper` for foreground and topmost handling
- bring chat window to front or notify when messages arrive

## Testing
- `dotnet build Client/Client.csproj -nologo` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6858d30f86488324b00b8d7544de23f6