### PR TITLE
Add French wiki docs

### DIFF
--- a/docs/Fonctionnement.md
+++ b/docs/Fonctionnement.md
@@ -1,0 +1,61 @@
+# Fonctionnement de l'application
+
+L'application EyeChat se compose d'un **serveur ASP.NET Core** et d'un **client WinUI**. Les deux communiquent via SignalR.
+
+## Serveur
+
+Le projet `Serveur` héberge une application ASP.NET Core qui expose un hub SignalR (`ChatHub`). Celui‑ci gère :
+
+* L'enregistrement et la déconnexion des utilisateurs
+* L'envoi des messages texte
+* La gestion de groupes protégés par mot de passe
+* Le stockage des paramètres communs (examens disponibles et salles)
+
+La base SQLite est initialisée au démarrage dans `Program.cs` :
+```csharp
+var dbFolder = Path.Combine(AppContext.BaseDirectory, "data");
+Directory.CreateDirectory(dbFolder);
+var dbPath = Path.Combine(dbFolder, "chat.db");
+
+builder.Services.AddDbContext<ChatDbContext>(options =>
+    options.UseSqlite($"Data Source={dbPath}"));
+```
+【F:Serveur/Program.cs†L6-L12】
+
+Les appels clients utilisent principalement les méthodes de `ChatHub`, par exemple `SendMessage`, `JoinProtectedGroup`, `GetExamOptions` ou `SaveRooms`.
+
+## Client
+
+Côté client, le service `SignalRService` maintient la connexion avec le serveur. Il expose des méthodes pour envoyer des messages, synchroniser les examens et les salles et charger l'historique. Une partie du code d'initialisation :
+```csharp
+Connection = new HubConnectionBuilder()
+    .WithUrl($"{ServerAddress}/chatHub")
+    .WithAutomaticReconnect()
+    .Build();
+```
+【F:Client/Services/SignalRService.cs†L60-L67】
+
+Le client stocke en local différentes informations : messages du jour, utilisateurs connus, paramètres visuels et raccourcis clavier. Ces fichiers sont créés dans le dossier `LocalApplicationData/EyeChat`.
+
+Les pages XAML offrent l'interface utilisateur :
+* `ChatPage` pour la messagerie
+* `ExamRoomPage` pour la gestion des examens et des salles
+* `AppearanceSettingsPage` et `UserSettingsPage` pour les paramètres
+
+## Persistance des données
+
+Certaines données sont partagées entre les utilisateurs via la base de données du serveur :
+
+* Table `SecureGroups` : stockage des groupes protégés et de leur mot de passe chiffré
+* Table `ServerConfig` : contient la configuration des examens et des salles sérialisée en JSON
+
+D'autres données sont uniquement locales au client (par exemple l'historique du jour ou les préférences utilisateur).
+
+## Flux typique
+
+1. Au lancement du client, `SignalRService.InitializeAsync` se charge de récupérer la liste des utilisateurs et les messages du jour auprès du serveur.
+2. L'utilisateur saisit un message sur `ChatPage`. Celui‑ci est envoyé via `SendMessage` au hub SignalR, puis distribué aux destinataires.
+3. Les examens et salles peuvent être modifiés sur `ExamRoomPage` et synchronisés manuellement avec le serveur.
+4. Les paramètres visuels ou de raccourcis sont sauvegardés immédiatement dans les fichiers locaux.
+
+Ainsi l'application fournit un système de messagerie interne avec des options personnalisables adaptées au flux de travail médical.

--- a/docs/Personnalisation.md
+++ b/docs/Personnalisation.md
@@ -1,0 +1,91 @@
+# Personnalisation de l'application
+
+Cette page décrit les principaux éléments personnalisables de l'application **EyeChat** côté client et côté serveur.
+
+## Couleurs de l'interface
+
+Le client permet de personnaliser les couleurs de la barre de titre, du menu de navigation, ainsi que les couleurs des bulles de messages. Ces valeurs sont sauvegardées localement dans un fichier *settings.json* lié à l'utilisateur courant et sont appliquées via `AppSettings.SetObject("Colors", ...)`.
+
+Les propriétés concernées se trouvent dans `AppColorSettings` :
+
+```csharp
+public class AppColorSettings
+{
+    public string TitleBarColor { get; set; } = "#FF0078D7";
+    public string TextTitleBarColor { get; set; } = "#FF000000";
+    public string NavigationViewColor { get; set; } = "#FFE6F1FF";
+    public string TextNavigationViewColor { get; set; } = "#FF000000";
+    public string MyMessageColor { get; set; } = "#FFCCE5FF";
+    public string TextMyMessageColor { get; set; } = "#FF000000";
+    public string OtherMessageColor { get; set; } = "#FFD9F2DC";
+}
+```
+【F:Client/Models/AppColorSettings.cs†L1-L14】
+
+Ces paramètres sont modifiables dans la page `AppearanceSettingsPage` où des sélecteurs de couleurs permettent de choisir la teinte voulue.
+
+## Raccourcis clavier
+
+Les touches **F5** à **F8** permettent de coller du texte prédéfini selon le contexte (Réfraction, Lentilles, Pathologies, Orthoptie). Les combinaisons **Ctrl+F9** à **Ctrl+F12** et **Shift+F9** à **Shift+F12** déclenchent l'ouverture d'une fiche patient correspondant à un examen.
+
+Les valeurs sont stockées et chargées par `SettingsViewModel` via `AppSettings`. Exemple :
+
+```csharp
+public string ShortcutF5Refraction
+{
+    get => _shortcutF5Refraction;
+    set { if (_shortcutF5Refraction != value) { _shortcutF5Refraction = value; OnPropertyChanged(nameof(ShortcutF5Refraction)); Set("ShortcutF5Refraction", value); } }
+}
+```
+【F:Client/ViewModel/SettingsViewModel.cs†L12-L74】
+
+## Liste des examens et salles
+
+La page `ExamRoomPage` permet de gérer la liste des examens médicaux disponibles et les salles associées. Chaque examen possède un nom, une couleur, un code clavier et une annotation. Les données sont sauvegardées dans `exam_options.json` via `ExamOption.Save` et dans `rooms.json` via `RoomList.Save` :
+
+```csharp
+public static readonly string FilePath = Path.Combine(
+    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+    "EyeChat",
+    "exam_options.json");
+```
+【F:Client/Models/ExamOption.cs†L63-L68】
+
+```csharp
+public static readonly string FilePath =
+    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "EyeChat", "rooms.json");
+```
+【F:Client/Helpers/RoomList.cs†L9-L13】
+
+La configuration peut être envoyée au serveur ou chargée depuis celui‑ci via `SendExamOptionsAsync`, `SendRoomsAsync`, `GetExamOptionsAsync` et `GetRoomsAsync` du service SignalR.
+
+## Style d'affichage du chat
+
+L'utilisateur peut choisir entre un affichage "old school" (type IRC) ou "moderne". Ce choix est enregistré dans les paramètres (`ChatDisplayStyle`) et déclenche `DisplayStyleChanged` qui applique le style sur la page de chat :
+
+```csharp
+public bool IsOldSchoolMode
+{
+    get => _isOldSchoolMode;
+    set
+    {
+        if (_isOldSchoolMode != value)
+        {
+            _isOldSchoolMode = value;
+            OnPropertyChanged(nameof(IsOldSchoolMode));
+            AppSettings.Set("ChatDisplayStyle", value ? "OldSchool" : "Modern");
+            DisplayStyleChanged?.Invoke(value ? ChatStyle.OldSchool : ChatStyle.Modern);
+        }
+    }
+}
+```
+【F:Client/ViewModel/SettingsViewModel.cs†L10-L36】
+
+## Autres réglages
+
+* Taille de la police des messages (`MessageFontSize`).
+* Adresse du serveur SignalR (chargée au démarrage dans `SignalRService`).
+* Mémorisation de l'utilisateur sélectionné pour l'envoi des messages (`AppSettings.CurrentSelectedUser`).
+
+Ces paramètres sont tous stockés localement afin d'être conservés entre les sessions de l'application.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# Documentation
+
+Ce dossier contient des pages d'aide pour l'application **EyeChat**.
+
+- [Fonctionnement](Fonctionnement.md) : architecture générale et échanges entre le client et le serveur.
+- [Personnalisation](Personnalisation.md) : réglages disponibles côté client et côté serveur.


### PR DESCRIPTION
## Summary
- document customization options (colors, raccourcis, examens, style de chat)
- document overall client/server architecture
- add docs/README with links

## Testing
- `dotnet build WebApplication1.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858d5b375b88324b8290449cb3cb774