### PR TITLE
Add background and accent color customization

### DIFF
--- a/Client/App.xaml
+++ b/Client/App.xaml
@@ -23,6 +23,12 @@
             <SolidColorBrush x:Key="MyMessageColor" Color="#FFCCE5FF" />
             <SolidColorBrush x:Key="TextMyMessageColor" Color="#FF000000" />
             <SolidColorBrush x:Key="OtherMessageColor" Color="#FFD9F2DC" />
+            <SolidColorBrush x:Key="TextOtherMessageColor" Color="#FF000000" />
+
+            <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="#FFFFFFFF" />
+            <SolidColorBrush x:Key="TextAppBackgroundColor" Color="#FF000000" />
+
+            <SolidColorBrush x:Key="SystemAccentColorDark1" Color="CadetBlue" />
             <SolidColorBrush x:Key="AccentColor" Color="Red" />
             <x:Double x:Key="MessageFontSize">14</x:Double>
         </ResourceDictionary>

--- a/Client/MainWindow.xaml
+++ b/Client/MainWindow.xaml
@@ -12,7 +12,7 @@
         <MicaBackdrop />
     </Window.SystemBackdrop>
     
-    <Grid Background="White">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="48"/>
             <RowDefinition Height="*"/>

--- a/Client/Models/AppColorSettings.cs
+++ b/Client/Models/AppColorSettings.cs
@@ -9,5 +9,11 @@ namespace Client.Models
         public string MyMessageColor { get; set; } = "#FFCCE5FF";
         public string TextMyMessageColor { get; set; } = "#FF000000";
         public string OtherMessageColor { get; set; } = "#FFD9F2DC";
+        public string TextOtherMessageColor { get; set; } = "#FF000000";
+
+        public string AppBackgroundColor { get; set; } = "#FFFFFFFF";
+        public string TextAppBackgroundColor { get; set; } = "#FF000000";
+
+        public string SystemAccentColorDark1 { get; set; } = "#FF5F9EA0"; // CadetBlue
     }
 }

--- a/Client/Pages/AppearanceSettingsPage.xaml
+++ b/Client/Pages/AppearanceSettingsPage.xaml
@@ -27,6 +27,15 @@
                         <TextBlock Text="{x:Bind ViewModelSettings.MessageFontSize}" Margin="5,0,0,0"/>
                     </StackPanel>
 
+                    <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                        <TextBlock Text="Fond de l'application" VerticalAlignment="Center"/>
+                        <ComboBox x:Name="BackgroundCombo" Width="120" SelectionChanged="BackgroundCombo_Changed">
+                            <ComboBoxItem Content="Blanc" Tag="#FFFFFFFF" />
+                            <ComboBoxItem Content="Noir" Tag="#FF000000" />
+                            <ComboBoxItem Content="Gris" Tag="#FF808080" />
+                        </ComboBox>
+                    </StackPanel>
+
                     <StackPanel Padding="20" Spacing="10">
                         <TextBlock Text="Aperçu : cliquez sur une zone pour choisir la couleur"/>
                         <Canvas Height="300">
@@ -63,6 +72,7 @@
                                 </Button.Flyout>
                             </Button>
                         </Canvas>
+                        <ColorPicker x:Name="AccentDark1Picker" Header="Accent sombre" ColorChanged="AccentDark1Color_Changed"/>
                         <Button Content="Sauvegarder" Click="SaveSettings_Click"/>
                     </StackPanel>
                 </StackPanel>

--- a/Client/Pages/AppearanceSettingsPage.xaml.cs
+++ b/Client/Pages/AppearanceSettingsPage.xaml.cs
@@ -33,6 +33,17 @@ namespace Client.Pages
                 mb.Color = ColorUtils.FromHex(currentSettings.MyMessageColor);
             if (FindName("OtherBubblePicker") is ColorPicker ob)
                 ob.Color = ColorUtils.FromHex(currentSettings.OtherMessageColor);
+            if (FindName("AccentDark1Picker") is ColorPicker ad)
+                ad.Color = ColorUtils.FromHex(currentSettings.SystemAccentColorDark1);
+            if (FindName("BackgroundCombo") is ComboBox bg)
+            {
+                bg.SelectedIndex = currentSettings.AppBackgroundColor.ToUpper() switch
+                {
+                    "#FF000000" => 1,
+                    "#FF808080" => 2,
+                    _ => 0
+                };
+            }
         }
 
         private void TitleBarColor_Changed(ColorPicker sender, ColorChangedEventArgs args)
@@ -87,7 +98,8 @@ namespace Client.Pages
         private void OtherMessageColor_Changed(ColorPicker sender, ColorChangedEventArgs args)
         {
             currentSettings.OtherMessageColor = ColorUtils.ToHex(args.NewColor);
-            var otherColor = ColorUtils.FromHex(currentSettings.OtherMessageColor);
+            var textColor = ColorUtils.GetContrastingTextColor(args.NewColor);
+            currentSettings.TextOtherMessageColor = ColorUtils.ToHex(textColor);
             AppSettings.SetObject("Colors", currentSettings);
             if (App.MainWindow.Content is FrameworkElement root)
             {
@@ -95,6 +107,37 @@ namespace Client.Pages
                 var nav = (NavigationView)root.FindName("nvSample");
                 var titleText = (TextBlock)root.FindName("TitleBarTextBlock");
                 OtherMessageZone.Background = new SolidColorBrush(ColorUtils.FromHex(currentSettings.OtherMessageColor));
+                ApplyColors(currentSettings, titleBar, nav, titleText);
+            }
+        }
+
+        private void BackgroundCombo_Changed(object sender, SelectionChangedEventArgs e)
+        {
+            if (BackgroundCombo.SelectedItem is ComboBoxItem item && item.Tag is string hex)
+            {
+                currentSettings.AppBackgroundColor = hex;
+                var textColor = ColorUtils.GetContrastingTextColor(ColorUtils.FromHex(hex));
+                currentSettings.TextAppBackgroundColor = ColorUtils.ToHex(textColor);
+                AppSettings.SetObject("Colors", currentSettings);
+                if (App.MainWindow.Content is FrameworkElement root)
+                {
+                    var titleBar = (Grid)root.FindName("AppTitleBar");
+                    var nav = (NavigationView)root.FindName("nvSample");
+                    var titleText = (TextBlock)root.FindName("TitleBarTextBlock");
+                    ApplyColors(currentSettings, titleBar, nav, titleText);
+                }
+            }
+        }
+
+        private void AccentDark1Color_Changed(ColorPicker sender, ColorChangedEventArgs args)
+        {
+            currentSettings.SystemAccentColorDark1 = ColorUtils.ToHex(args.NewColor);
+            AppSettings.SetObject("Colors", currentSettings);
+            if (App.MainWindow.Content is FrameworkElement root)
+            {
+                var titleBar = (Grid)root.FindName("AppTitleBar");
+                var nav = (NavigationView)root.FindName("nvSample");
+                var titleText = (TextBlock)root.FindName("TitleBarTextBlock");
                 ApplyColors(currentSettings, titleBar, nav, titleText);
             }
         }
@@ -121,6 +164,10 @@ namespace Client.Pages
             var myColor = ColorUtils.FromHex(colors.MyMessageColor);
             var textMyColor = ColorUtils.FromHex(colors.TextMyMessageColor);
             var otherColor = ColorUtils.FromHex(colors.OtherMessageColor);
+            var textOtherColor = ColorUtils.FromHex(colors.TextOtherMessageColor);
+            var backgroundColor = ColorUtils.FromHex(colors.AppBackgroundColor);
+            var textBackgroundColor = ColorUtils.FromHex(colors.TextAppBackgroundColor);
+            var accentDark1 = ColorUtils.FromHex(colors.SystemAccentColorDark1);
 
             UpdateResourceBrush("TitleBarColor", titleColor);
             UpdateResourceBrush("TextTitleBarColor", textColorTitleBar);
@@ -136,6 +183,10 @@ namespace Client.Pages
             UpdateResourceBrush("NavigationViewItemForegroundPointerOver", pointerNavColor);
             UpdateResourceBrush("NavigationViewItemIconForegroundPointerOver", pointerNavColor);
             UpdateResourceBrush("OtherMessageColor", otherColor);
+            UpdateResourceBrush("TextOtherMessageColor", textOtherColor);
+            UpdateResourceBrush("ApplicationPageBackgroundThemeBrush", backgroundColor);
+            UpdateResourceBrush("TextAppBackgroundColor", textBackgroundColor);
+            UpdateResourceBrush("SystemAccentColorDark1", accentDark1);
 
             titleBar?.DispatcherQueue.TryEnqueue(() => titleBar.Background = new SolidColorBrush(titleColor));
             nav?.DispatcherQueue.TryEnqueue(() =>

--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -16,9 +16,9 @@
                     <StackPanel Orientation="Horizontal" Spacing="10" MinWidth="180">
                         <Image Source="{x:Bind Avatar}" Width="40" Height="40"/>
                         <StackPanel MinWidth="200">
-                            <TextBlock Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}"/>
-                            <TextBlock Text="{x:Bind Content}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}"/>
-                            <TextBlock Text="{x:Bind TimeFormatted}" FontSize="12" HorizontalAlignment="Right"/>
+                            <TextBlock Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextOtherMessageColor}"/>
+                            <TextBlock Text="{x:Bind Content}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextOtherMessageColor}"/>
+                            <TextBlock Text="{x:Bind TimeFormatted}" FontSize="12" HorizontalAlignment="Right" Foreground="{ThemeResource TextOtherMessageColor}"/>
                         </StackPanel>
                     </StackPanel>
                 </Border>
@@ -136,7 +136,7 @@
         </DataTemplate>
     </Page.Resources>
 
-    <Grid Padding="10" Background="White">
+    <Grid Padding="10" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="400"/>
             <ColumnDefinition Width="*"/>

--- a/Client/Pages/HistoryPage.xaml
+++ b/Client/Pages/HistoryPage.xaml
@@ -2,7 +2,7 @@
     x:Class="Client.Pages.HistoryPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Grid Background="White">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <TextBlock Text="History" HorizontalAlignment="Center" VerticalAlignment="Center"/>
     </Grid>
 </Page>


### PR DESCRIPTION
## Summary
- allow setting application background color
- compute text color automatically for chosen background and other message bubbles
- add accent color customization picker
- update color resources and apply them throughout the app

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68592d5d50488324b1115c1f468045f8