### PR TITLE
Fix accent color resource

### DIFF
--- a/Client/App.xaml
+++ b/Client/App.xaml
@@ -28,7 +28,7 @@
             <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="#FFFFFFFF" />
             <SolidColorBrush x:Key="TextAppBackgroundColor" Color="#FF000000" />
 
-            <SolidColorBrush x:Key="SystemAccentColorDark1" Color="CadetBlue" />
+            <Color x:Key="SystemAccentColorDark1">CadetBlue</Color>
             <SolidColorBrush x:Key="AccentColor" Color="Red" />
             <x:Double x:Key="MessageFontSize">14</x:Double>
         </ResourceDictionary>

--- a/Client/Pages/AppearanceSettingsPage.xaml.cs
+++ b/Client/Pages/AppearanceSettingsPage.xaml.cs
@@ -207,13 +207,18 @@ namespace Client.Pages
 
         private static void UpdateResourceBrush(string key, Windows.UI.Color color)
         {
-            if (Application.Current.Resources[key] is SolidColorBrush brush)
+            var resources = Application.Current.Resources;
+            if (resources[key] is SolidColorBrush brush)
             {
                 brush.Color = color;
             }
+            else if (resources[key] is Windows.UI.Color)
+            {
+                resources[key] = color;
+            }
             else
             {
-                Application.Current.Resources[key] = new SolidColorBrush(color);
+                resources[key] = new SolidColorBrush(color);
             }
         }
 

--- a/docs/Personnalisation.md
+++ b/docs/Personnalisation.md
@@ -24,6 +24,8 @@ public class AppColorSettings
 
 Ces paramètres sont modifiables dans la page `AppearanceSettingsPage` où des sélecteurs de couleurs permettent de choisir la teinte voulue.
 
+Depuis cette version, la ressource `SystemAccentColorDark1` est fournie sous la forme d'un `Color` afin que l'accentuation fonctionne correctement même lorsque le fond de l'application est sombre.
+
 ## Raccourcis clavier
 
 Les touches **F5** à **F8** permettent de coller du texte prédéfini selon le contexte (Réfraction, Lentilles, Pathologies, Orthoptie). Les combinaisons **Ctrl+F9** à **Ctrl+F12** et **Shift+F9** à **Shift+F12** déclenchent l'ouverture d'une fiche patient correspondant à un examen.


### PR DESCRIPTION
## Summary
- use Color resource for `SystemAccentColorDark1`
- update resource update helper to handle both Color and SolidColorBrush
- document accent color resource

## Testing
- `dotnet build WebApplication1.sln -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a25df27048324865f8e97d9efd2b3