### PR TITLE
Apply saved theme colors at startup

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -5,6 +5,7 @@ using Microsoft.Windows.AppNotifications;
 using Microsoft.Windows.AppNotifications.Builder;
 using Client.Models;
 using Client.Helpers;
+using Client.Pages;
 
 namespace Client
 {
@@ -21,6 +22,8 @@ namespace Client
         {
             m_window = new MainWindow();
             MainWindow = m_window;
+
+            ApplySavedColors();
 
             ChatService.Dispatcher = m_window.DispatcherQueue;
             ChatService.OnMessageReceived += ChatService_OnMessageReceived;
@@ -85,6 +88,18 @@ namespace Client
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"❌ Toast error: {ex.Message}");
+            }
+        }
+
+        private void ApplySavedColors()
+        {
+            var colors = AppSettings.GetObject<AppColorSettings>("Colors");
+            if (m_window?.Content is FrameworkElement root)
+            {
+                var titleBar = (Grid)root.FindName("AppTitleBar");
+                var nav = (NavigationView)root.FindName("nvSample");
+                var titleText = (TextBlock)root.FindName("TitleBarTextBlock");
+                AppearanceSettingsPage.ApplyColors(colors, titleBar, nav, titleText);
             }
         }
 

--- a/Client/Pages/AppearanceSettingsPage.xaml
+++ b/Client/Pages/AppearanceSettingsPage.xaml
@@ -39,7 +39,7 @@
                     <StackPanel Padding="20" Spacing="10">
                         <TextBlock Text="Aperçu : cliquez sur une zone pour choisir la couleur"/>
                         <Canvas Height="300">
-                            <Image Source="/Assets/Appchat.png" Width="00" />
+                            <Image Source="/Assets/Appchat.png" Width="600" />
                             <Button x:Name="TitleBarZone" Width="600" Height="20" Background="{ThemeResource TitleBarColor}" Canvas.Left="0" Canvas.Top="0">
                                 <Button.Flyout>
                                     <Flyout>


### PR DESCRIPTION
## Summary
- fix preview image width in appearance settings page
- load saved color settings on app launch

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a7e4edb5483248a433bbf602d2e86