### PR TITLE
Switch to theme-based background

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -22,6 +22,12 @@ namespace Client
             m_window = new MainWindow();
             MainWindow = m_window;
 
+            var theme = AppSettings.Get("AppTheme", "Dark");
+            if (Enum.TryParse<ApplicationTheme>(theme, out var appTheme))
+            {
+                RequestedTheme = appTheme;
+            }
+
             ChatService.Dispatcher = m_window.DispatcherQueue;
             ChatService.OnMessageReceived += ChatService_OnMessageReceived;
             _ = ChatService.InitializeAsync();

--- a/Client/Pages/AppearanceSettingsPage.xaml
+++ b/Client/Pages/AppearanceSettingsPage.xaml
@@ -31,11 +31,10 @@
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
-                        <TextBlock Text="Fond de l'application" VerticalAlignment="Center"/>
-                        <ComboBox x:Name="BackgroundCombo" Width="120" SelectionChanged="BackgroundCombo_Changed">
-                            <ComboBoxItem Content="Blanc" Tag="#FFFFFFFF" />
-                            <ComboBoxItem Content="Noir" Tag="#FF000000" />
-                            <ComboBoxItem Content="Gris" Tag="#FF808080" />
+                        <TextBlock Text="Thème" VerticalAlignment="Center"/>
+                        <ComboBox x:Name="ThemeCombo" Width="120" SelectionChanged="ThemeCombo_Changed">
+                            <ComboBoxItem Content="Clair" Tag="Light" />
+                            <ComboBoxItem Content="Sombre" Tag="Dark" />
                         </ComboBox>
                     </StackPanel>
 

--- a/Client/Pages/AppearanceSettingsPage.xaml.cs
+++ b/Client/Pages/AppearanceSettingsPage.xaml.cs
@@ -35,13 +35,13 @@ namespace Client.Pages
                 ob.Color = ColorUtils.FromHex(currentSettings.OtherMessageColor);
             if (FindName("AccentDark1Picker") is ColorPicker ad)
                 ad.Color = ColorUtils.FromHex(currentSettings.SystemAccentColorDark1);
-            if (FindName("BackgroundCombo") is ComboBox bg)
+            if (FindName("ThemeCombo") is ComboBox theme)
             {
-                bg.SelectedIndex = currentSettings.AppBackgroundColor.ToUpper() switch
+                theme.SelectedIndex = ViewModelSettings.AppTheme switch
                 {
-                    "#FF000000" => 1,
-                    "#FF808080" => 2,
-                    _ => 0
+                    "Light" => 0,
+                    "Dark" => 1,
+                    _ => 1
                 };
             }
         }
@@ -111,21 +111,11 @@ namespace Client.Pages
             }
         }
 
-        private void BackgroundCombo_Changed(object sender, SelectionChangedEventArgs e)
+        private void ThemeCombo_Changed(object sender, SelectionChangedEventArgs e)
         {
-            if (BackgroundCombo.SelectedItem is ComboBoxItem item && item.Tag is string hex)
+            if (ThemeCombo.SelectedItem is ComboBoxItem item && item.Tag is string theme)
             {
-                currentSettings.AppBackgroundColor = hex;
-                var textColor = ColorUtils.GetContrastingTextColor(ColorUtils.FromHex(hex));
-                currentSettings.TextAppBackgroundColor = ColorUtils.ToHex(textColor);
-                AppSettings.SetObject("Colors", currentSettings);
-                if (App.MainWindow.Content is FrameworkElement root)
-                {
-                    var titleBar = (Grid)root.FindName("AppTitleBar");
-                    var nav = (NavigationView)root.FindName("nvSample");
-                    var titleText = (TextBlock)root.FindName("TitleBarTextBlock");
-                    ApplyColors(currentSettings, titleBar, nav, titleText);
-                }
+                ViewModelSettings.AppTheme = theme;
             }
         }
 
@@ -166,8 +156,6 @@ namespace Client.Pages
             var textMyColor = ColorUtils.FromHex(colors.TextMyMessageColor);
             var otherColor = ColorUtils.FromHex(colors.OtherMessageColor);
             var textOtherColor = ColorUtils.FromHex(colors.TextOtherMessageColor);
-            var backgroundColor = ColorUtils.FromHex(colors.AppBackgroundColor);
-            var textBackgroundColor = ColorUtils.FromHex(colors.TextAppBackgroundColor);
             var accentDark1 = ColorUtils.FromHex(colors.SystemAccentColorDark1);
 
             UpdateResourceBrush("TitleBarColor", titleColor);
@@ -185,8 +173,6 @@ namespace Client.Pages
             UpdateResourceBrush("NavigationViewItemIconForegroundPointerOver", pointerNavColor);
             UpdateResourceBrush("OtherMessageColor", otherColor);
             UpdateResourceBrush("TextOtherMessageColor", textOtherColor);
-            UpdateResourceBrush("ApplicationPageBackgroundThemeBrush", backgroundColor);
-            UpdateResourceBrush("TextAppBackgroundColor", textBackgroundColor);
             UpdateResourceBrush("SystemAccentColorDark1", accentDark1);
             UpdateResourceBrush("PivotHeaderForeground", textNavColor);
 

--- a/Client/ViewModel/SettingsViewModel.cs
+++ b/Client/ViewModel/SettingsViewModel.cs
@@ -10,6 +10,7 @@ namespace Client.ViewModel
     {
         private bool _isOldSchoolMode;
         private double _messageFontSize = 14;
+        private string _appTheme = "Dark";
         private string _shortcutF5Refraction = string.Empty;
         private string _shortcutF5Lentilles = string.Empty;
         private string _shortcutF5Pathologies = string.Empty;
@@ -68,6 +69,21 @@ namespace Client.ViewModel
                     OnPropertyChanged(nameof(MessageFontSize));
                     AppSettings.Set("MessageFontSize", value.ToString());
                     Application.Current.Resources["MessageFontSize"] = value;
+                }
+            }
+        }
+
+        public string AppTheme
+        {
+            get => _appTheme;
+            set
+            {
+                if (_appTheme != value)
+                {
+                    _appTheme = value;
+                    OnPropertyChanged(nameof(AppTheme));
+                    AppSettings.Set("AppTheme", value);
+                    ApplyTheme(value);
                 }
             }
         }
@@ -227,6 +243,8 @@ namespace Client.ViewModel
             {
                 _messageFontSize = size;
             }
+            _appTheme = AppSettings.Get("AppTheme", "Dark");
+            ApplyTheme(_appTheme);
 
             _shortcutF5Refraction = Get("ShortcutF5Refraction");
             _shortcutF5Lentilles = Get("ShortcutF5Lentilles");
@@ -260,6 +278,14 @@ namespace Client.ViewModel
             // update resources with loaded values
             Application.Current.Resources["MessageFontSize"] = _messageFontSize;
             OnPropertyChanged(string.Empty);
+        }
+
+        private static void ApplyTheme(string theme)
+        {
+            if (Enum.TryParse<ApplicationTheme>(theme, out var appTheme))
+            {
+                Application.Current.RequestedTheme = appTheme;
+            }
         }
 
         private void OnPropertyChanged(string propertyName)

--- a/docs/Personnalisation.md
+++ b/docs/Personnalisation.md
@@ -22,6 +22,28 @@ public class AppColorSettings
 ```
 【F:Client/Models/AppColorSettings.cs†L1-L14】
 
+Le thème clair ou sombre est mémorisé séparément via `SettingsViewModel.AppTheme`. Ce
+propriété met à jour `Application.Current.RequestedTheme` pour appliquer le thème
+à toute l'application :
+
+```csharp
+public string AppTheme
+{
+    get => _appTheme;
+    set
+    {
+        if (_appTheme != value)
+        {
+            _appTheme = value;
+            OnPropertyChanged(nameof(AppTheme));
+            AppSettings.Set("AppTheme", value);
+            // met à jour Application.Current.RequestedTheme
+        }
+    }
+}
+```
+【F:Client/ViewModel/SettingsViewModel.cs†L76-L89】
+
 Ces paramètres sont modifiables dans la page `AppearanceSettingsPage` où des sélecteurs de couleurs permettent de choisir la teinte voulue.
 
 Depuis cette version, la ressource `SystemAccentColorDark1` est fournie sous la forme d'un `Color` afin que l'accentuation fonctionne correctement même lorsque le fond de l'application est sombre.


### PR DESCRIPTION
## Summary
- replace the background color selector with a light/dark theme selector
- persist theme selection in `SettingsViewModel` and apply it at startup
- update docs accordingly

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe28af02c83249b4b12839ed995ac