### PR TITLE
Implement first-run user creation

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -6,6 +6,7 @@ using Microsoft.Windows.AppNotifications.Builder;
 using Client.Models;
 using Client.Helpers;
 using Microsoft.UI.Xaml.Controls;
+using System.IO;
 
 namespace Client
 {
@@ -13,6 +14,7 @@ namespace Client
     {
         public static SignalRService ChatService { get; } = new SignalRService();
         public static Window? MainWindow { get; private set; }
+        public static string UserName { get; set; } = string.Empty;
         public App()
         {
             this.InitializeComponent();
@@ -68,6 +70,43 @@ namespace Client
                     machine.RoomName = box.Text.Trim();
                     MachineConfig.Save(machine);
                 }
+            }
+
+            var appFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat");
+            Directory.CreateDirectory(appFolder);
+            var settingsFiles = Directory.GetFiles(appFolder, "*_settings.json");
+
+            if (settingsFiles.Length == 0)
+            {
+                var userDialog = new ContentDialog
+                {
+                    Title = "Nom d'utilisateur",
+                    PrimaryButtonText = "Valider",
+                    XamlRoot = root.XamlRoot
+                };
+
+                var userBox = new TextBox();
+                userDialog.Content = userBox;
+                var userResult = await userDialog.ShowAsync();
+                if (userResult == ContentDialogResult.Primary)
+                {
+                    var username = userBox.Text.Trim();
+                    App.UserName = username;
+                    AppSettings.CurrentSelectedUser = new UserInfo { Username = username };
+
+                    if (string.IsNullOrWhiteSpace(machine.DefaultUser))
+                        machine.DefaultUser = username;
+                    machine.LastUser = username;
+                    MachineConfig.Save(machine);
+                }
+            }
+            else
+            {
+                var username = !string.IsNullOrWhiteSpace(machine.LastUser)
+                    ? machine.LastUser
+                    : Path.GetFileNameWithoutExtension(settingsFiles[0]).Replace("_settings", "");
+                App.UserName = username;
+                AppSettings.CurrentSelectedUser = new UserInfo { Username = username };
             }
 
             if (!string.IsNullOrWhiteSpace(machine.RoomName))

--- a/Client/Helpers/AppSettings.cs
+++ b/Client/Helpers/AppSettings.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using Client.Models;
+using Client;
 
 namespace Client.Helpers
 {
@@ -13,7 +14,7 @@ namespace Client.Helpers
         private static string FilePath =>
               Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                 "EyeChat",
-                $"{(CurrentSelectedUser?.Username ?? "default")}_settings.json");
+                $"{(CurrentSelectedUser?.Username ?? App.UserName)}_settings.json");
 
         private static UserInfo? _currentUser;
         public static UserInfo? CurrentSelectedUser

--- a/Client/Helpers/MachineConfig.cs
+++ b/Client/Helpers/MachineConfig.cs
@@ -7,6 +7,9 @@ namespace Client.Helpers
     public class MachineConfig
     {
         public string RoomName { get; set; } = string.Empty;
+        public string DefaultUser { get; set; } = string.Empty;
+        public string LastUser { get; set; } = string.Empty;
+        public bool ConnectLastUser { get; set; }
 
         public static string FilePath =>
             Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.SignalR.Client;
 using Client.Models;
 using Client.Services;
 using Client.Helpers;
+using Client;
 
 namespace Client.Pages
 {
@@ -55,6 +56,9 @@ namespace Client.Pages
 
         private async void ChatPage_Loaded(object sender, RoutedEventArgs e)
         {
+            if (Resources["MessageTemplateSelector"] is ChatMessageTemplateSelector sel)
+                sel.MyUsername = App.UserName;
+
             var style = AppSettings.Get("ChatDisplayStyle", "Modern");
             ApplyChatStyle(style == "OldSchool" ? ChatStyle.OldSchool : ChatStyle.Modern);
 
@@ -75,7 +79,7 @@ namespace Client.Pages
                 foreach (var msg in cachedMessages)
                     Messages.Add(msg);
 
-                var result = await _service.LoadTodayMessagesAsync("Benoit");
+                var result = await _service.LoadTodayMessagesAsync(App.UserName);
                 if (result.Success)
                 {
                     foreach (var item in Messages.OfType<ChatMessageModel>().ToList())
@@ -158,7 +162,7 @@ namespace Client.Pages
             {
                 if (user != null)
                 {
-                    await _service.SendMessage("Benoit", "RDC", user.Username, text, @"E:\benoit.png", DateTime.Now);
+                    await _service.SendMessage(App.UserName, "RDC", user.Username, text, @"E:\benoit.png", DateTime.Now);
                     Debug.WriteLine($"📤 Message envoyé à {user.Username}: {text}");
                     InputBox.Text = string.Empty;
                 }
@@ -176,7 +180,7 @@ namespace Client.Pages
 
         private async Task LoadHistoryAsync(string withUser)
         {
-            var username = "Benoit";
+            var username = App.UserName;
 
             try
             {
@@ -254,7 +258,7 @@ namespace Client.Pages
                 _currentDate = _currentDate.AddDays(-1);
                 tryCount++;
 
-                var result = await _service.LoadMessagesForDateAsync("Moi", _currentDate);
+                var result = await _service.LoadMessagesForDateAsync(App.UserName, _currentDate);
 
                 if (result.Success && result.Value.Any())
                 {

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -1,5 +1,6 @@
 using Client.Models;
 using Client.Helpers;
+using Client;
 using Microsoft.AspNetCore.SignalR.Client;
 using System;
 using System.Collections.Generic;
@@ -69,7 +70,7 @@ namespace Client.Services
                 ConnectedUsers.Add(user);
             }
 
-            await ConnectAsync("Benoit", @"E:\benoit.png", RoomName);
+            await ConnectAsync(App.UserName, @"E:\benoit.png", RoomName);
 
             Messages.Clear();
             Messages.Add(new LoadMorePlaceholder());
@@ -78,7 +79,7 @@ namespace Client.Services
             foreach (var msg in cached)
                 Messages.Add(msg);
 
-            var result = await LoadTodayMessagesAsync("Benoit");
+            var result = await LoadTodayMessagesAsync(App.UserName);
             if (result.Success)
             {
                 foreach (var item in Messages.OfType<ChatMessageModel>().ToList())


### PR DESCRIPTION
## Summary
- store default and last user in `machine.json`
- keep track of the current user name in `App.UserName`
- use the last user name to build settings path in `AppSettings`
- prompt for user name on first start and save it
- connect and load messages with the selected user

## Testing
- `dotnet build WebApplication1.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861468e33348324bdc36c1ab75b6dbd