### PR TITLE
Add server-side Patient storage and retrieval

### DIFF
--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -143,6 +143,15 @@
                 <TextBlock Text="{x:Bind Name}" VerticalAlignment="Center"/>
             </StackPanel>
         </DataTemplate>
+
+        <!-- Template d'affichage d'un patient dans les onglets des salles -->
+        <DataTemplate x:Key="PatientItemTemplate" x:DataType="data:Patient">
+            <StackPanel Orientation="Horizontal" Spacing="4" Padding="4">
+                <TextBlock Text="{x:Bind Title}" FontWeight="Bold"/>
+                <TextBlock Text="{x:Bind LastName}" Margin="4,0"/>
+                <TextBlock Text="{x:Bind FirstName}"/>
+            </StackPanel>
+        </DataTemplate>
         
         <Style TargetType="PivotItem">
             <Setter Property="Foreground" Value="{ThemeResource PivotHeaderForeground}" />

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -35,6 +35,7 @@ namespace Client.Pages
 
             BuildRooms();
             Rooms.CollectionChanged += Rooms_CollectionChanged;
+            Patients.CollectionChanged += Patients_CollectionChanged;
 
             UsersList.ItemsSource = ConnectedUsers;
             MessagesList.ItemsSource = Messages;
@@ -52,6 +53,7 @@ namespace Client.Pages
         {
             _service.OnMessageReceived -= OnMessageReceived;
             ViewModel.ViewModel.SettingsViewModel.DisplayStyleChanged -= ApplyChatStyle;
+            Patients.CollectionChanged -= Patients_CollectionChanged;
         }
 
         private async void ChatPage_Loaded(object sender, RoutedEventArgs e)
@@ -327,7 +329,7 @@ namespace Client.Pages
         {
             BuildRooms();
         }
-        
+
         private void BuildRooms()
         {
             RoomsWithAll.Clear();
@@ -338,9 +340,38 @@ namespace Client.Pages
             RoomsPivot.Items.Clear();
             foreach (var room in RoomsWithAll)
             {
-                var item = new PivotItem { Header = room, Content = new TextBlock { Text = room, Margin = new Thickness(10) } };
+                var list = new ListView { SelectionMode = ListViewSelectionMode.None };
+                if (Resources["PatientItemTemplate"] is DataTemplate template)
+                    list.ItemTemplate = template;
+                list.ItemsSource = GetPatientsForRoom(room).ToList();
+                var item = new PivotItem { Header = room, Content = list };
                 RoomsPivot.Items.Add(item);
             }
+
+            UpdatePatientViews();
+        }
+
+        private void Patients_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            DispatcherQueue.TryEnqueue(UpdatePatientViews);
+        }
+
+        private void UpdatePatientViews()
+        {
+            foreach (var pi in RoomsPivot.Items.OfType<PivotItem>())
+            {
+                if (pi.Content is ListView lv && pi.Header is string room)
+                {
+                    lv.ItemsSource = GetPatientsForRoom(room).ToList();
+                }
+            }
+        }
+
+        private IEnumerable<Patient> GetPatientsForRoom(string room)
+        {
+            return room == "Toutes"
+                ? Patients.OrderBy(p => p.HoldTime)
+                : Patients.Where(p => p.Position == room).OrderBy(p => p.HoldTime);
         }
     }
 

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -90,6 +90,11 @@ namespace Client.Services
                 _historyLoaded = true;
                 await SaveTodayMessagesToDiskAsync();
             }
+
+            var patients = await GetPatientsAsync();
+            Patients.Clear();
+            foreach (var p in patients)
+                Patients.Add(p);
         }
 
         public async Task ConnectAsync(string username, string avatar, string room)
@@ -215,7 +220,11 @@ namespace Client.Services
 
             Connection.On<Patient>("NewPatient", patient =>
             {
-                OnNewPatient?.Invoke(patient);
+                Dispatcher?.TryEnqueue(() =>
+                {
+                    Patients.Add(patient);
+                    OnNewPatient?.Invoke(patient);
+                });
             });
 
             Connection.On<IEnumerable<ExamOption>>("ExamOptionsUpdated", opts =>
@@ -520,6 +529,25 @@ namespace Client.Services
             {
                 Debug.WriteLine($"Erreur récupération salles : {ex.Message}");
                 return new List<string>();
+            }
+        }
+
+        public async Task<List<Patient>> GetPatientsAsync()
+        {
+            if (Connection is null || Connection.State != HubConnectionState.Connected)
+            {
+                var connected = await TryReconnectAsync();
+                if (!connected) return new List<Patient>();
+            }
+
+            try
+            {
+                return await Connection.InvokeAsync<List<Patient>>("GetPatients");
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur récupération patients : {ex.Message}");
+                return new List<Patient>();
             }
         }
         public async Task UpdateRoomNameAsync(string roomName)

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -354,5 +354,21 @@ namespace ChatServeur
                 return new List<string>();
             }
         }
+
+        public async Task DeclarePatient(Patient patient)
+        {
+            _db.Patients.Add(patient);
+            await _db.SaveChangesAsync();
+            await Clients.All.SendAsync("NewPatient", patient);
+        }
+
+        public async Task<List<Patient>> GetPatients()
+        {
+            var today = DateTime.Today;
+            return await _db.Patients
+                .Where(p => p.HoldTime.Date == today)
+                .OrderBy(p => p.HoldTime)
+                .ToListAsync();
+        }
     }
 }

--- a/Serveur/Models/ChatDbContext.cs
+++ b/Serveur/Models/ChatDbContext.cs
@@ -12,5 +12,6 @@ namespace ChatServeur
         public DbSet<GroupMembership> GroupMemberships => Set<GroupMembership>();
         public DbSet<SecureGroup> SecureGroups => Set<SecureGroup>();
         public DbSet<ServerConfig> ServerConfigs => Set<ServerConfig>();
+        public DbSet<Patient> Patients => Set<Patient>();
     }
 }

--- a/Serveur/Models/Patient.cs
+++ b/Serveur/Models/Patient.cs
@@ -1,0 +1,20 @@
+namespace ChatServeur
+{
+    public class Patient
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Colors { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string LastName { get; set; } = string.Empty;
+        public string FirstName { get; set; } = string.Empty;
+        public string Exams { get; set; } = string.Empty;
+        public string Annotation { get; set; } = string.Empty;
+        public string Position { get; set; } = string.Empty;
+        public DateTime HoldTime { get; set; }
+        public DateTime? PickUpTime { get; set; }
+        public TimeSpan TimeOrder { get; set; }
+        public string Examinator { get; set; } = string.Empty;
+        public string OperatorName { get; set; } = string.Empty;
+        public bool IsTaken { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- support patient data on server and client
- save patients in `ChatDbContext`
- expose new hub methods `DeclarePatient` and `GetPatients`
- load patients on the client and react to `NewPatient` messages
- display patients inside the rooms pivot on `ChatPage`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c1488a888324affd9980ad4630d1