### PR TITLE
Add patient context menu and server updates

### DIFF
--- a/Client/Models/Patient.cs
+++ b/Client/Models/Patient.cs
@@ -21,5 +21,9 @@ namespace Client.Models
         public bool IsTaken { get; set; }
 
         public string HoldTimeFormatted => HoldTime.ToString("HH:mm");
+
+        public string ToggleExamLabel => IsTaken
+            ? $"Annuler {Exams} de {FirstName} {LastName}"
+            : $"Faire passer {Exams} de {FirstName} {LastName}";
     }
 }

--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -148,7 +148,13 @@
 
         <!-- Template d'affichage d'un patient dans les onglets des salles -->
         <DataTemplate x:Key="PatientItemTemplate" x:DataType="data:Patient">
-            <Border Background="{x:Bind Colors}" Margin="0,4" >
+            <Border Background="{x:Bind Colors}" Margin="0,4">
+                <Border.ContextFlyout>
+                    <MenuFlyout>
+                        <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
+                        <MenuFlyoutItem Text="{x:Bind ToggleExamLabel}" Tag="{x:Bind}" Click="TogglePatientTaken_Click" />
+                    </MenuFlyout>
+                </Border.ContextFlyout>
                 <Grid Padding="4">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -45,6 +45,8 @@ namespace Client.Pages
             _service.ConnectedUsers.CollectionChanged += (_, _) => DispatcherQueue.TryEnqueue(TryRestoreUserSelection);
 
             _service.OnMessageReceived += OnMessageReceived;
+            _service.OnPatientRemoved += Service_OnPatientRemoved;
+            _service.OnPatientUpdated += Service_OnPatientUpdated;
             Loaded += ChatPage_Loaded;
             Unloaded += ChatPage_Unloaded;
         }
@@ -52,6 +54,8 @@ namespace Client.Pages
         private void ChatPage_Unloaded(object sender, RoutedEventArgs e)
         {
             _service.OnMessageReceived -= OnMessageReceived;
+            _service.OnPatientRemoved -= Service_OnPatientRemoved;
+            _service.OnPatientUpdated -= Service_OnPatientUpdated;
             ViewModel.ViewModel.SettingsViewModel.DisplayStyleChanged -= ApplyChatStyle;
             Patients.CollectionChanged -= Patients_CollectionChanged;
         }
@@ -365,6 +369,38 @@ namespace Client.Pages
                     lv.ItemsSource = GetPatientsForRoom(room).ToList();
                 }
             }
+        }
+
+        private async void DeletePatient_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as MenuFlyoutItem)?.Tag is Patient patient)
+            {
+                Patients.Remove(patient);
+                await _service.RemovePatientAsync(patient.Id);
+            }
+        }
+
+        private async void TogglePatientTaken_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as MenuFlyoutItem)?.Tag is Patient patient)
+            {
+                var newValue = !patient.IsTaken;
+                await _service.SetPatientTakenAsync(patient.Id, newValue);
+            }
+        }
+
+        private void Service_OnPatientRemoved(string id)
+        {
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                var p = Patients.FirstOrDefault(x => x.Id == id);
+                if (p != null) Patients.Remove(p);
+            });
+        }
+
+        private void Service_OnPatientUpdated(Patient patient)
+        {
+            DispatcherQueue.TryEnqueue(UpdatePatientViews);
         }
 
         private IEnumerable<Patient> GetPatientsForRoom(string room)

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -47,6 +47,8 @@ namespace Client.Services
 
         public event Action<ChatMessageModel>? OnMessageReceived;
         public event Action<Patient>? OnNewPatient;
+        public event Action<string>? OnPatientRemoved;
+        public event Action<Patient>? OnPatientUpdated;
         public event Action<IEnumerable<ExamOption>>? ExamOptionsUpdated;
         public event Action<IEnumerable<string>>? RoomsUpdated;
 
@@ -226,6 +228,35 @@ namespace Client.Services
                 });
             });
 
+            Connection.On<string>("PatientRemoved", id =>
+            {
+                Dispatcher?.TryEnqueue(() =>
+                {
+                    var existing = Patients.FirstOrDefault(p => p.Id == id);
+                    if (existing != null)
+                        Patients.Remove(existing);
+                    OnPatientRemoved?.Invoke(id);
+                });
+            });
+
+            Connection.On<Patient>("PatientUpdated", patient =>
+            {
+                Dispatcher?.TryEnqueue(() =>
+                {
+                    var existing = Patients.FirstOrDefault(p => p.Id == patient.Id);
+                    if (existing != null)
+                    {
+                        var index = Patients.IndexOf(existing);
+                        Patients[index] = patient;
+                    }
+                    else
+                    {
+                        Patients.Add(patient);
+                    }
+                    OnPatientUpdated?.Invoke(patient);
+                });
+            });
+
             Connection.On<IEnumerable<ExamOption>>("ExamOptionsUpdated", opts =>
             {
                 ExamOptionsUpdated?.Invoke(opts);
@@ -369,6 +400,18 @@ namespace Client.Services
         public async Task DeclarePatient(Patient p)
         {
             await Connection.InvokeAsync("DeclarePatient", p);
+        }
+
+        public async Task RemovePatientAsync(string id)
+        {
+            if (Connection != null && Connection.State == HubConnectionState.Connected)
+                await Connection.InvokeAsync("RemovePatient", id);
+        }
+
+        public async Task SetPatientTakenAsync(string id, bool isTaken)
+        {
+            if (Connection != null && Connection.State == HubConnectionState.Connected)
+                await Connection.InvokeAsync("UpdatePatientIsTaken", id, isTaken);
         }
         public async Task<List<ChatMessageModel>> LoadTodayMessagesFromDiskAsync()
         {

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -362,6 +362,29 @@ namespace ChatServeur
             await Clients.All.SendAsync("NewPatient", patient);
         }
 
+        public async Task RemovePatient(string id)
+        {
+            var patient = await _db.Patients.FindAsync(id);
+            if (patient != null)
+            {
+                _db.Patients.Remove(patient);
+                await _db.SaveChangesAsync();
+                await Clients.All.SendAsync("PatientRemoved", id);
+            }
+        }
+
+        public async Task UpdatePatientIsTaken(string id, bool isTaken)
+        {
+            var patient = await _db.Patients.FindAsync(id);
+            if (patient != null)
+            {
+                patient.IsTaken = isTaken;
+                _db.Patients.Update(patient);
+                await _db.SaveChangesAsync();
+                await Clients.All.SendAsync("PatientUpdated", patient);
+            }
+        }
+
         public async Task<List<Patient>> GetPatients()
         {
             var today = DateTime.Today;

--- a/Serveur/Models/Patient.cs
+++ b/Serveur/Models/Patient.cs
@@ -17,5 +17,9 @@
         public string Examinator { get; set; } = string.Empty;
         public string OperatorName { get; set; } = string.Empty;
         public bool IsTaken { get; set; }
+
+        public string ToggleExamLabel => IsTaken
+            ? $"Annuler {Exams} de {FirstName} {LastName}"
+            : $"Faire passer {Exams} de {FirstName} {LastName}";
     }
 }


### PR DESCRIPTION
## Summary
- implement context menu for patient items with actions to delete or toggle exam state
- update ChatPage to handle patient menu actions
- extend SignalR service with events and methods for patient removal and update
- add server-side APIs for removing and updating patients
- add helper property `ToggleExamLabel` in patient models

## Testing
- `dotnet build WebApplication1.sln -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863bc71f6988324b295e85bb736eca3