### PR TITLE
Support taken patient view

### DIFF
--- a/Client/Models/Patient.cs
+++ b/Client/Models/Patient.cs
@@ -21,6 +21,7 @@ namespace Client.Models
         public bool IsTaken { get; set; }
 
         public string HoldTimeFormatted => HoldTime.ToString("HH:mm");
+        public string? PickUpTimeFormatted => PickUpTime?.ToString("HH:mm");
 
         public string ToggleExamLabel => IsTaken
             ? $"Annuler {Exams} de {FirstName} {LastName}"

--- a/Client/Models/PatientTemplateSelector.cs
+++ b/Client/Models/PatientTemplateSelector.cs
@@ -1,0 +1,18 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Client.Models
+{
+    public class PatientTemplateSelector : DataTemplateSelector
+    {
+        public DataTemplate? DefaultTemplate { get; set; }
+        public DataTemplate? TakenTemplate { get; set; }
+
+        protected override DataTemplate? SelectTemplateCore(object item)
+        {
+            if (item is Patient patient)
+                return patient.IsTaken ? TakenTemplate : DefaultTemplate;
+            return base.SelectTemplateCore(item);
+        }
+    }
+}

--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -146,8 +146,8 @@
 
         <!-- Template d'affichage d'un patient dans les onglets des salles -->
 
-        <!-- Template d'affichage d'un patient dans les onglets des salles -->
-        <DataTemplate x:Key="PatientItemTemplate" x:DataType="data:Patient">
+        <!-- Template d'affichage d'un patient non pris en charge -->
+        <DataTemplate x:Key="PatientDefaultTemplate" x:DataType="data:Patient">
             <Border Background="{x:Bind Colors}" Margin="0,4">
                 <Border.ContextFlyout>
                     <MenuFlyout>
@@ -186,6 +186,41 @@
                 </Grid>
             </Border>
         </DataTemplate>
+
+        <!-- Template d'affichage d'un patient déjà pris en charge -->
+        <DataTemplate x:Key="PatientTakenTemplate" x:DataType="data:Patient">
+            <Border Background="Gray" Margin="0,4">
+                <Border.ContextFlyout>
+                    <MenuFlyout>
+                        <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
+                        <MenuFlyoutItem Text="{x:Bind ToggleExamLabel}" Tag="{x:Bind}" Click="TogglePatientTaken_Click" />
+                    </MenuFlyout>
+                </Border.ContextFlyout>
+                <Grid Padding="4">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal" Spacing="4">
+                        <TextBlock Text="{x:Bind Title}" FontWeight="Bold"/>
+                        <TextBlock Text="{x:Bind LastName}" Margin="4,0"/>
+                        <TextBlock Text="{x:Bind FirstName}" />
+                    </StackPanel>
+
+                    <TextBlock Grid.Row="0" Grid.Column="1"
+                               Text="{x:Bind PickUpTimeFormatted}"
+                               HorizontalAlignment="Right"/>
+                </Grid>
+            </Border>
+        </DataTemplate>
+
+        <data:PatientTemplateSelector x:Key="PatientTemplateSelector"
+                                      DefaultTemplate="{StaticResource PatientDefaultTemplate}"
+                                      TakenTemplate="{StaticResource PatientTakenTemplate}" />
 
         <Style TargetType="PivotItem">
             <Setter Property="Foreground" Value="{ThemeResource PivotHeaderForeground}" />

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -345,8 +345,8 @@ namespace Client.Pages
             foreach (var room in RoomsWithAll)
             {
                 var list = new ListView { SelectionMode = ListViewSelectionMode.None };
-                if (Resources["PatientItemTemplate"] is DataTemplate template)
-                    list.ItemTemplate = template;
+                if (Resources["PatientTemplateSelector"] is DataTemplateSelector selector)
+                    list.ItemTemplateSelector = selector;
                 list.ItemsSource = GetPatientsForRoom(room).ToList();
                 var item = new PivotItem { Header = room, Content = list };
                 RoomsPivot.Items.Add(item);
@@ -385,6 +385,9 @@ namespace Client.Pages
             if ((sender as MenuFlyoutItem)?.Tag is Patient patient)
             {
                 var newValue = !patient.IsTaken;
+                patient.IsTaken = newValue;
+                patient.PickUpTime = newValue ? DateTime.Now : null;
+                UpdatePatientViews();
                 await _service.SetPatientTakenAsync(patient.Id, newValue);
             }
         }

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -379,6 +379,7 @@ namespace ChatServeur
             if (patient != null)
             {
                 patient.IsTaken = isTaken;
+                patient.PickUpTime = isTaken ? DateTime.Now : null;
                 _db.Patients.Update(patient);
                 await _db.SaveChangesAsync();
                 await Clients.All.SendAsync("PatientUpdated", patient);

--- a/Serveur/Models/Patient.cs
+++ b/Serveur/Models/Patient.cs
@@ -18,6 +18,8 @@
         public string OperatorName { get; set; } = string.Empty;
         public bool IsTaken { get; set; }
 
+        public string? PickUpTimeFormatted => PickUpTime?.ToString("HH:mm");
+
         public string ToggleExamLabel => IsTaken
             ? $"Annuler {Exams} de {FirstName} {LastName}"
             : $"Faire passer {Exams} de {FirstName} {LastName}";


### PR DESCRIPTION
## Summary
- add `PickUpTimeFormatted` property to patient model
- create `PatientTemplateSelector` to swap templates
- add taken patient template and selector usage in `ChatPage`
- update toggle logic to fill `PickUpTime`
- persist pickup time on the server

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68642dc5eb7c8324b470f0013e03c90f