### PR TITLE
Ajout modification du temps des patients

### DIFF
--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -151,9 +151,14 @@
             <Border Background="{x:Bind Colors}" Margin="0,4">
                 <Border.ContextFlyout>
                     <MenuFlyout>
-                        <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
-                        <MenuFlyoutItem Text="{x:Bind ToggleExamLabel}" Tag="{x:Bind}" Click="TogglePatientTaken_Click" />
-                    </MenuFlyout>
+                    <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
+                    <MenuFlyoutItem Text="{x:Bind ToggleExamLabel}" Tag="{x:Bind}" Click="TogglePatientTaken_Click" />
+                    <MenuFlyoutSubItem Text="Modification temps">
+                        <MenuFlyoutItem Text="Mettre en premier" Tag="{x:Bind}" Click="MovePatientFirst_Click" />
+                        <MenuFlyoutItem Text="Monter d'un cran" Tag="{x:Bind}" Click="MovePatientUp_Click" />
+                        <MenuFlyoutItem Text="Descendre d'un cran" Tag="{x:Bind}" Click="MovePatientDown_Click" />
+                    </MenuFlyoutSubItem>
+                </MenuFlyout>
                 </Border.ContextFlyout>
                 <Grid Padding="4">
                     <Grid.RowDefinitions>
@@ -192,9 +197,14 @@
             <Border Background="Gray" Margin="0,4">
                 <Border.ContextFlyout>
                     <MenuFlyout>
-                        <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
-                        <MenuFlyoutItem Text="{x:Bind ToggleExamLabel}" Tag="{x:Bind}" Click="TogglePatientTaken_Click" />
-                    </MenuFlyout>
+                    <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
+                    <MenuFlyoutItem Text="{x:Bind ToggleExamLabel}" Tag="{x:Bind}" Click="TogglePatientTaken_Click" />
+                    <MenuFlyoutSubItem Text="Modification temps">
+                        <MenuFlyoutItem Text="Mettre en premier" Tag="{x:Bind}" Click="MovePatientFirst_Click" />
+                        <MenuFlyoutItem Text="Monter d'un cran" Tag="{x:Bind}" Click="MovePatientUp_Click" />
+                        <MenuFlyoutItem Text="Descendre d'un cran" Tag="{x:Bind}" Click="MovePatientDown_Click" />
+                    </MenuFlyoutSubItem>
+                </MenuFlyout>
                 </Border.ContextFlyout>
                 <Grid Padding="4">
                     <Grid.RowDefinitions>

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -375,8 +375,21 @@ namespace Client.Pages
         {
             if ((sender as MenuFlyoutItem)?.Tag is Patient patient)
             {
-                Patients.Remove(patient);
-                await _service.RemovePatientAsync(patient.Id);
+                var dialog = new ContentDialog
+                {
+                    Title = "Confirmation",
+                    Content = "Supprimer ce patient ?",
+                    PrimaryButtonText = "Oui",
+                    CloseButtonText = "Non",
+                    XamlRoot = (this.Content as FrameworkElement)?.XamlRoot
+                };
+
+                var result = await dialog.ShowAsync();
+                if (result == ContentDialogResult.Primary)
+                {
+                    Patients.Remove(patient);
+                    await _service.RemovePatientAsync(patient.Id);
+                }
             }
         }
 
@@ -389,6 +402,61 @@ namespace Client.Pages
                 patient.PickUpTime = newValue ? DateTime.Now : null;
                 UpdatePatientViews();
                 await _service.SetPatientTakenAsync(patient.Id, newValue);
+            }
+        }
+
+        private async void MovePatientFirst_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as MenuFlyoutItem)?.Tag is Patient patient)
+            {
+                var lastTaken = Patients.Where(p => p.IsTaken).OrderBy(p => p.HoldTime).LastOrDefault();
+                var firstWaiting = Patients.Where(p => !p.IsTaken).OrderBy(p => p.HoldTime).FirstOrDefault();
+                if (lastTaken != null && firstWaiting != null)
+                {
+                    var avgTicks = (lastTaken.HoldTime.Ticks + firstWaiting.HoldTime.Ticks) / 2;
+                    var newTime = new DateTime(avgTicks);
+                    patient.HoldTime = newTime;
+                    UpdatePatientViews();
+                    await _service.UpdatePatientHoldTimeAsync(patient.Id, newTime);
+                }
+            }
+        }
+
+        private async void MovePatientUp_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as MenuFlyoutItem)?.Tag is Patient patient)
+            {
+                var list = Patients.Where(p => !p.IsTaken).OrderBy(p => p.HoldTime).ToList();
+                var index = list.IndexOf(patient);
+                if (index > 0)
+                {
+                    var h1 = list[Math.Max(index - 1, 0)].HoldTime;
+                    var h2 = list[Math.Max(index - 2, 0)].HoldTime;
+                    var avgTicks = (h1.Ticks + h2.Ticks) / 2;
+                    var newTime = new DateTime(avgTicks);
+                    patient.HoldTime = newTime;
+                    UpdatePatientViews();
+                    await _service.UpdatePatientHoldTimeAsync(patient.Id, newTime);
+                }
+            }
+        }
+
+        private async void MovePatientDown_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as MenuFlyoutItem)?.Tag is Patient patient)
+            {
+                var list = Patients.Where(p => !p.IsTaken).OrderBy(p => p.HoldTime).ToList();
+                var index = list.IndexOf(patient);
+                if (index >= 0 && index < list.Count - 1)
+                {
+                    var h1 = list[Math.Min(index + 1, list.Count - 1)].HoldTime;
+                    var h2 = list[Math.Min(index + 2, list.Count - 1)].HoldTime;
+                    var avgTicks = (h1.Ticks + h2.Ticks) / 2;
+                    var newTime = new DateTime(avgTicks);
+                    patient.HoldTime = newTime;
+                    UpdatePatientViews();
+                    await _service.UpdatePatientHoldTimeAsync(patient.Id, newTime);
+                }
             }
         }
 

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -413,6 +413,12 @@ namespace Client.Services
             if (Connection != null && Connection.State == HubConnectionState.Connected)
                 await Connection.InvokeAsync("UpdatePatientIsTaken", id, isTaken);
         }
+
+        public async Task UpdatePatientHoldTimeAsync(string id, DateTime newTime)
+        {
+            if (Connection != null && Connection.State == HubConnectionState.Connected)
+                await Connection.InvokeAsync("UpdatePatientHoldTime", id, newTime);
+        }
         public async Task<List<ChatMessageModel>> LoadTodayMessagesFromDiskAsync()
         {
             try

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -386,6 +386,18 @@ namespace ChatServeur
             }
         }
 
+        public async Task UpdatePatientHoldTime(string id, DateTime newTime)
+        {
+            var patient = await _db.Patients.FindAsync(id);
+            if (patient != null)
+            {
+                patient.HoldTime = newTime;
+                _db.Patients.Update(patient);
+                await _db.SaveChangesAsync();
+                await Clients.All.SendAsync("PatientUpdated", patient);
+            }
+        }
+
         public async Task<List<Patient>> GetPatients()
         {
             var today = DateTime.Today;


### PR DESCRIPTION
## Summary
- ajout d'un sous-menu **Modification temps** dans le menu contextuel des patients
- ajout d'une boîte de dialogue de confirmation à la suppression
- implémentation des actions de déplacement (mettre en premier, monter/descendre d'un cran)
- ajout de la méthode `UpdatePatientHoldTimeAsync` coté client et `UpdatePatientHoldTime` coté serveur

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6864359de88883249693ded2ae1266d3