### PR TITLE
Add synchronized pivots on history page

### DIFF
--- a/Client/Models/Patient.cs
+++ b/Client/Models/Patient.cs
@@ -23,6 +23,7 @@ namespace Client.Models
         public string Examinator { get; set; } = string.Empty;
         public string OperatorName { get; set; } = string.Empty;
         public bool IsTaken { get; set; }
+        public bool IsArchived { get; set; }
 
         public string HoldTimeFormatted => HoldTime.ToString("HH:mm");
         public string? PickUpTimeFormatted => PickUpTime?.ToString("HH:mm");

--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -296,7 +296,7 @@
 
         <Pivot x:Name="RoomsPivot"
                Grid.Column="0"
-               Grid.RowSpan="2"
+               Grid.Row="0"
                ItemContainerStyle="{StaticResource PivotTitleContentControlStyle}">
             <Pivot.Resources>
                 <Style TargetType="PivotHeaderItem"
@@ -328,6 +328,8 @@
 
         <ListView x:Name="MessagesList" Grid.Column="1" ItemTemplateSelector="{StaticResource MessageTemplateSelector}" SelectionMode="None"/>
 
+
+        <Button Grid.Column="0" Grid.Row="1" Content="Archiver" Click="ArchivePatients_Click" Margin="0,0,10,0"/>
 
         <TextBox x:Name="InputBox" Grid.Column="1" Grid.Row="1" PlaceholderText="Votre message..." KeyDown="InputBox_KeyDown"
          

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -412,10 +412,10 @@ namespace Client.Pages
         {
             if ((sender as MenuFlyoutItem)?.Tag is Patient patient)
             {
-                var lastTaken = Patients.Where(p => p.IsTaken)
+                var lastTaken = Patients.Where(p => p.IsTaken && !p.IsArchived)
                     .OrderBy(p => p.HoldTime)
                     .LastOrDefault();
-                var firstWaiting = Patients.Where(p => !p.IsTaken)
+                var firstWaiting = Patients.Where(p => !p.IsTaken && !p.IsArchived)
                     .OrderBy(p => p.HoldTime)
                     .FirstOrDefault();
 
@@ -444,7 +444,7 @@ namespace Client.Pages
         {
             if ((sender as MenuFlyoutItem)?.Tag is Patient patient)
             {
-                var list = Patients.Where(p => !p.IsTaken).OrderBy(p => p.HoldTime).ToList();
+                var list = Patients.Where(p => !p.IsTaken && !p.IsArchived).OrderBy(p => p.HoldTime).ToList();
                 var index = list.IndexOf(patient);
                 if (index > 0)
                 {
@@ -463,7 +463,7 @@ namespace Client.Pages
         {
             if ((sender as MenuFlyoutItem)?.Tag is Patient patient)
             {
-                var list = Patients.Where(p => !p.IsTaken).OrderBy(p => p.HoldTime).ToList();
+                var list = Patients.Where(p => !p.IsTaken && !p.IsArchived).OrderBy(p => p.HoldTime).ToList();
                 var index = list.IndexOf(patient);
                 if (index >= 0 && index < list.Count - 1)
                 {
@@ -476,6 +476,11 @@ namespace Client.Pages
                     await _service.UpdatePatientHoldTimeAsync(patient.Id, newTime);
                 }
             }
+        }
+
+        private async void ArchivePatients_Click(object sender, RoutedEventArgs e)
+        {
+            await _service.ArchiveTakenPatientsAsync();
         }
 
         private void Service_OnPatientRemoved(string id)
@@ -495,8 +500,8 @@ namespace Client.Pages
         private IEnumerable<Patient> GetPatientsForRoom(string room)
         {
             IEnumerable<Patient> query = room == "Toutes"
-              ? Patients
-              : Patients.Where(p => p.Position == room);
+              ? Patients.Where(p => !p.IsArchived)
+              : Patients.Where(p => p.Position == room && !p.IsArchived);
 
             return query
                 .OrderByDescending(p => p.IsTaken)

--- a/Client/Pages/HistoryPage.xaml
+++ b/Client/Pages/HistoryPage.xaml
@@ -1,8 +1,93 @@
 <Page
     x:Class="Client.Pages.HistoryPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-        <TextBlock Text="History" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:data="using:Client.Models">
+    <Page.Resources>
+        <DataTemplate x:Key="PatientItemTemplate" x:DataType="data:Patient">
+            <StackPanel Orientation="Horizontal" Spacing="8" Padding="4">
+                <TextBlock Text="{x:Bind HoldTimeFormatted}" Width="60"/>
+                <TextBlock Text="{x:Bind LastName}" Margin="4,0"/>
+                <TextBlock Text="{x:Bind FirstName}" Margin="4,0"/>
+                <TextBlock Text="{x:Bind Exams}" Margin="4,0"/>
+            </StackPanel>
+        </DataTemplate>
+
+        <Style TargetType="PivotItem">
+            <Setter Property="Foreground" Value="{ThemeResource PivotHeaderForeground}" />
+        </Style>
+        <Style x:Key="PivotHeaderItemStyle" TargetType="PivotHeaderItem">
+            <Setter Property="Foreground" Value="{ThemeResource PivotHeaderForeground}" />
+            <Setter Property="Margin" Value="8,0" />
+            <Setter Property="Padding" Value="12,8" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="PivotHeaderItem">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition />
+                                <RowDefinition Height="2" />
+                            </Grid.RowDefinitions>
+                            <VisualStateManager.VisualStateGroups>
+                                <VisualStateGroup x:Name="CommonStates">
+                                    <VisualState x:Name="Normal" />
+                                    <VisualState x:Name="PointerOver" />
+                                </VisualStateGroup>
+                                <VisualStateGroup x:Name="SelectionStates">
+                                    <VisualState x:Name="Unselected">
+                                        <VisualState.Setters>
+                                            <Setter Target="Underline.Visibility" Value="Collapsed" />
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                    <VisualState x:Name="Selected">
+                                        <VisualState.Setters>
+                                            <Setter Target="Underline.Visibility" Value="Visible" />
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                </VisualStateGroup>
+                            </VisualStateManager.VisualStateGroups>
+                            <ContentPresenter
+                                x:Name="ContentPresenter"
+                                Content="{TemplateBinding Content}"
+                                Foreground="{ThemeResource TextAppBackgroundColor}"
+                                FontWeight="Bold"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center" />
+                            <Rectangle x:Name="Underline" Grid.Row="1"
+                                       Height="2"
+                                       Fill="{ThemeResource AccentColor}"
+                                       HorizontalAlignment="Stretch"
+                                       VerticalAlignment="Bottom"
+                                       Visibility="Collapsed" />
+                        </Grid>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Page.Resources>
+
+    <Grid Padding="10" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+
+        <Button Content="Rafraîchir" HorizontalAlignment="Left" Click="Refresh_Click" Grid.ColumnSpan="2"/>
+
+        <Pivot x:Name="NotArchivedPivot" Grid.Row="1" Grid.Column="0" SelectionChanged="Pivot_SelectionChanged" ItemContainerStyle="{StaticResource PivotTitleContentControlStyle}">
+            <Pivot.Resources>
+                <Style TargetType="PivotHeaderItem" BasedOn="{StaticResource PivotHeaderItemStyle}" />
+            </Pivot.Resources>
+        </Pivot>
+
+        <Pivot x:Name="ArchivedPivot" Grid.Row="1" Grid.Column="1" SelectionChanged="Pivot_SelectionChanged" ItemContainerStyle="{StaticResource PivotTitleContentControlStyle}">
+            <Pivot.Resources>
+                <Style TargetType="PivotHeaderItem" BasedOn="{StaticResource PivotHeaderItemStyle}" />
+            </Pivot.Resources>
+        </Pivot>
     </Grid>
 </Page>

--- a/Client/Pages/HistoryPage.xaml.cs
+++ b/Client/Pages/HistoryPage.xaml.cs
@@ -1,12 +1,99 @@
 using Microsoft.UI.Xaml.Controls;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Threading.Tasks;
+using Client.Models;
+using Client.Services;
+using Client.Helpers;
+using Microsoft.UI.Xaml;
 
 namespace Client.Pages
 {
     public sealed partial class HistoryPage : Page
     {
+        public ObservableCollection<Patient> ArchivedPatients { get; } = new();
+        public ObservableCollection<Patient> NonArchivedPatients { get; } = new();
+        public ObservableCollection<string> Rooms { get; } = RoomList.Load();
+        private ObservableCollection<string> RoomsWithAll { get; } = new();
+        private readonly SignalRService _service;
+
         public HistoryPage()
         {
             this.InitializeComponent();
+            _service = App.ChatService;
+            DataContext = this;
+            Loaded += HistoryPage_Loaded;
+            Rooms.CollectionChanged += Rooms_CollectionChanged;
+        }
+
+        private async void HistoryPage_Loaded(object sender, RoutedEventArgs e)
+        {
+            await LoadPatientsAsync();
+        }
+
+        private async Task LoadPatientsAsync()
+        {
+            var notArchived = await _service.GetPatientsAsync();
+            NonArchivedPatients.Clear();
+            foreach (var p in notArchived.OrderBy(p => p.HoldTime))
+                NonArchivedPatients.Add(p);
+
+            var archived = await _service.GetArchivedPatientsAsync();
+            ArchivedPatients.Clear();
+            foreach (var p in archived.OrderBy(p => p.HoldTime))
+                ArchivedPatients.Add(p);
+
+            BuildRooms();
+        }
+
+        private void Rooms_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            BuildRooms();
+        }
+
+        private void BuildRooms()
+        {
+            RoomsWithAll.Clear();
+            foreach (var r in Rooms)
+                RoomsWithAll.Add(r);
+            RoomsWithAll.Add("Toutes");
+
+            NotArchivedPivot.Items.Clear();
+            ArchivedPivot.Items.Clear();
+            foreach (var room in RoomsWithAll)
+            {
+                var list1 = new ListView { SelectionMode = ListViewSelectionMode.None };
+                list1.ItemTemplate = (DataTemplate)Resources["PatientItemTemplate"];
+                list1.ItemsSource = GetPatientsForRoom(NonArchivedPatients, room).ToList();
+                var item1 = new PivotItem { Header = room, Content = list1 };
+                NotArchivedPivot.Items.Add(item1);
+
+                var list2 = new ListView { SelectionMode = ListViewSelectionMode.None };
+                list2.ItemTemplate = (DataTemplate)Resources["PatientItemTemplate"];
+                list2.ItemsSource = GetPatientsForRoom(ArchivedPatients, room).ToList();
+                var item2 = new PivotItem { Header = room, Content = list2 };
+                ArchivedPivot.Items.Add(item2);
+            }
+        }
+
+        private IEnumerable<Patient> GetPatientsForRoom(IEnumerable<Patient> source, string room)
+        {
+            IEnumerable<Patient> query = room == "Toutes" ? source : source.Where(p => p.Position == room);
+            return query.OrderByDescending(p => p.IsTaken).ThenBy(p => p.HoldTime);
+        }
+
+        private void Pivot_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (sender == NotArchivedPivot && ArchivedPivot.SelectedIndex != NotArchivedPivot.SelectedIndex)
+                ArchivedPivot.SelectedIndex = NotArchivedPivot.SelectedIndex;
+            else if (sender == ArchivedPivot && NotArchivedPivot.SelectedIndex != ArchivedPivot.SelectedIndex)
+                NotArchivedPivot.SelectedIndex = ArchivedPivot.SelectedIndex;
+        }
+
+        private async void Refresh_Click(object sender, RoutedEventArgs e)
+        {
+            await LoadPatientsAsync();
         }
     }
 }

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -615,5 +615,39 @@ namespace Client.Services
                 }
             }
         }
+
+        public async Task ArchiveTakenPatientsAsync()
+        {
+            if (Connection != null && Connection.State == HubConnectionState.Connected)
+            {
+                try
+                {
+                    await Connection.InvokeAsync("ArchiveTakenPatients");
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Erreur archivage patients : {ex.Message}");
+                }
+            }
+        }
+
+        public async Task<List<Patient>> GetArchivedPatientsAsync()
+        {
+            if (Connection is null || Connection.State != HubConnectionState.Connected)
+            {
+                var connected = await TryReconnectAsync();
+                if (!connected) return new List<Patient>();
+            }
+
+            try
+            {
+                return await Connection.InvokeAsync<List<Patient>>("GetArchivedPatients");
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur récupération archives : {ex.Message}");
+                return new List<Patient>();
+            }
+        }
     }
 }

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -401,6 +401,7 @@ namespace ChatServeur
 
         public async Task DeclarePatient(Patient patient)
         {
+            patient.IsArchived = false;
             _db.Patients.Add(patient);
             await _db.SaveChangesAsync();
             await Clients.All.SendAsync("NewPatient", patient);
@@ -446,9 +447,31 @@ namespace ChatServeur
         {
             var today = DateTime.Today;
             return await _db.Patients
-                .Where(p => p.HoldTime.Date == today)
+                .Where(p => p.HoldTime.Date == today && !p.IsArchived)
                 .OrderBy(p => p.HoldTime)
                 .ToListAsync();
+        }
+
+        public async Task<List<Patient>> GetArchivedPatients()
+        {
+            return await _db.Patients
+                .Where(p => p.IsArchived)
+                .OrderBy(p => p.HoldTime)
+                .ToListAsync();
+        }
+
+        public async Task ArchiveTakenPatients()
+        {
+            var patients = await _db.Patients.Where(p => p.IsTaken && !p.IsArchived).ToListAsync();
+            if (patients.Any())
+            {
+                foreach (var p in patients)
+                    p.IsArchived = true;
+                _db.Patients.UpdateRange(patients);
+                await _db.SaveChangesAsync();
+                foreach (var p in patients)
+                    await Clients.All.SendAsync("PatientUpdated", p);
+            }
         }
     }
 }

--- a/Serveur/Models/Patient.cs
+++ b/Serveur/Models/Patient.cs
@@ -18,6 +18,7 @@
         public string Examinator { get; set; } = string.Empty;
         public string OperatorName { get; set; } = string.Empty;
         public bool IsTaken { get; set; }
+        public bool IsArchived { get; set; }
 
         public string? PickUpTimeFormatted => PickUpTime?.ToString("HH:mm");
 

--- a/Serveur/Program.cs
+++ b/Serveur/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using ChatServeur;
+using Microsoft.Data.Sqlite;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -32,10 +33,42 @@ using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<ChatDbContext>();
     db.Database.EnsureCreated();
+    EnsureArchivedColumn(db);
     if (!db.ServerConfigs.Any())
     {
         db.ServerConfigs.Add(new ServerConfig());
         db.SaveChanges();
+    }
+}
+
+void EnsureArchivedColumn(ChatDbContext db)
+{
+    var connection = db.Database.GetDbConnection();
+    connection.Open();
+    try
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "PRAGMA table_info('Patients')";
+        using var reader = cmd.ExecuteReader();
+        bool exists = false;
+        while (reader.Read())
+        {
+            if (string.Equals(reader.GetString(1), "IsArchived", StringComparison.OrdinalIgnoreCase))
+            {
+                exists = true;
+                break;
+            }
+        }
+        reader.Close();
+        if (!exists)
+        {
+            cmd.CommandText = "ALTER TABLE Patients ADD COLUMN IsArchived INTEGER NOT NULL DEFAULT 0";
+            cmd.ExecuteNonQuery();
+        }
+    }
+    finally
+    {
+        connection.Close();
     }
 }
 


### PR DESCRIPTION
## Summary
- overhaul History page to show non archived vs archived patients
- build room pivots for both lists and keep them synchronized

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c1a9cbc083248c4113f25f07689d