### PR TITLE
Add archive and time edit options in history page

### DIFF
--- a/Client/Pages/HistoryPage.xaml
+++ b/Client/Pages/HistoryPage.xaml
@@ -1,5 +1,6 @@
 <Page
     x:Class="Client.Pages.HistoryPage"
+    x:Name="PageRoot"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:data="using:Client.Models">
@@ -11,6 +12,11 @@
                     <MenuFlyout>
                         <MenuFlyoutItem Text="{x:Bind ToggleExamLabel}" Tag="{x:Bind}" Click="TogglePatientTaken_Click" />
                         <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
+                        <MenuFlyoutSubItem Text="Modification temps" Visibility="{Binding TimeModificationVisibility, ElementName=PageRoot}">
+                            <MenuFlyoutItem Text="Mettre en premier" Tag="{x:Bind}" Click="MovePatientFirst_Click" />
+                            <MenuFlyoutItem Text="Monter d'un cran" Tag="{x:Bind}" Click="MovePatientUp_Click" />
+                            <MenuFlyoutItem Text="Descendre d'un cran" Tag="{x:Bind}" Click="MovePatientDown_Click" />
+                        </MenuFlyoutSubItem>
                     </MenuFlyout>
                 </Border.ContextFlyout>
                 <Grid Padding="4">
@@ -183,6 +189,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
@@ -205,5 +212,10 @@
                 <Style TargetType="PivotHeaderItem" BasedOn="{StaticResource PivotHeaderItemStyle}" />
             </Pivot.Resources>
         </Pivot>
+
+        <StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="8">
+            <Button Content="Archiver" Click="ArchivePatients_Click"/>
+            <Button Content="Désarchiver" Click="UnarchivePatients_Click"/>
+        </StackPanel>
     </Grid>
 </Page>

--- a/Client/Pages/HistoryPage.xaml.cs
+++ b/Client/Pages/HistoryPage.xaml.cs
@@ -20,10 +20,15 @@ namespace Client.Pages
         private ObservableCollection<string> RoomsWithAll { get; } = new();
         private readonly SignalRService _service;
 
+        public bool ShowTimeModification { get; private set; }
+        public Visibility TimeModificationVisibility => ShowTimeModification ? Visibility.Visible : Visibility.Collapsed;
+
         public HistoryPage()
         {
             this.InitializeComponent();
             _service = App.ChatService;
+            var cfg = MachineConfig.Load();
+            ShowTimeModification = cfg.ShowTimeModification;
             DataContext = this;
             Loaded += HistoryPage_Loaded;
             Rooms.CollectionChanged += Rooms_CollectionChanged;
@@ -144,6 +149,88 @@ namespace Client.Pages
                     await _service.RemovePatientAsync(patient.Id);
                 }
             }
+        }
+
+        private async void MovePatientFirst_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as MenuFlyoutItem)?.Tag is Patient patient)
+            {
+                var lastTaken = NonArchivedPatients.Where(p => p.IsTaken)
+                    .OrderBy(p => p.HoldTime)
+                    .LastOrDefault();
+                var firstWaiting = NonArchivedPatients.Where(p => !p.IsTaken)
+                    .OrderBy(p => p.HoldTime)
+                    .FirstOrDefault();
+
+                if (firstWaiting != null)
+                {
+                    DateTime newTime;
+
+                    if (lastTaken != null)
+                    {
+                        var avgTicks = (lastTaken.HoldTime.Ticks + firstWaiting.HoldTime.Ticks) / 2;
+                        newTime = new DateTime(avgTicks);
+                    }
+                    else
+                    {
+                        newTime = firstWaiting.HoldTime.AddSeconds(-1);
+                    }
+
+                    patient.HoldTime = newTime;
+                    BuildRooms();
+                    await _service.UpdatePatientHoldTimeAsync(patient.Id, newTime);
+                }
+            }
+        }
+
+        private async void MovePatientUp_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as MenuFlyoutItem)?.Tag is Patient patient)
+            {
+                var list = NonArchivedPatients.Where(p => !p.IsTaken).OrderBy(p => p.HoldTime).ToList();
+                var index = list.IndexOf(patient);
+                if (index > 0)
+                {
+                    var h1 = list[Math.Max(index - 1, 0)].HoldTime;
+                    var h2 = list[Math.Max(index - 2, 0)].HoldTime;
+                    var avgTicks = (h1.Ticks + h2.Ticks) / 2;
+                    var newTime = new DateTime(avgTicks);
+                    patient.HoldTime = newTime;
+                    BuildRooms();
+                    await _service.UpdatePatientHoldTimeAsync(patient.Id, newTime);
+                }
+            }
+        }
+
+        private async void MovePatientDown_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as MenuFlyoutItem)?.Tag is Patient patient)
+            {
+                var list = NonArchivedPatients.Where(p => !p.IsTaken).OrderBy(p => p.HoldTime).ToList();
+                var index = list.IndexOf(patient);
+                if (index >= 0 && index < list.Count - 1)
+                {
+                    var h1 = list[Math.Min(index + 1, list.Count - 1)].HoldTime;
+                    var h2 = list[Math.Min(index + 2, list.Count - 1)].HoldTime;
+                    var avgTicks = (h1.Ticks + h2.Ticks) / 2;
+                    var newTime = new DateTime(avgTicks);
+                    patient.HoldTime = newTime;
+                    BuildRooms();
+                    await _service.UpdatePatientHoldTimeAsync(patient.Id, newTime);
+                }
+            }
+        }
+
+        private async void ArchivePatients_Click(object sender, RoutedEventArgs e)
+        {
+            await _service.ArchiveTakenPatientsAsync();
+            await LoadPatientsAsync();
+        }
+
+        private async void UnarchivePatients_Click(object sender, RoutedEventArgs e)
+        {
+            await _service.UnarchiveAllPatientsAsync();
+            await LoadPatientsAsync();
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow editing patient order in HistoryPage via new context menu
- show archive/unarchive controls on history page
- bind visibility of time edit commands to MachineConfig setting

## Testing
- `dotnet build WebApplication1.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686816b9de3c8324b3f9cc6eee5c471f