### PR TITLE
Add IRC message context menu with delete option

### DIFF
--- a/Client/Models/ChatMessageModel.cs
+++ b/Client/Models/ChatMessageModel.cs
@@ -4,12 +4,14 @@ namespace Client.Models
 {
     public class ChatMessageModel
     {
+        public int Id { get; set; }
         public string Sender { get; set; } = string.Empty;
         public string Destinataire { get; set; } = string.Empty;
         public string Room { get; set; } = string.Empty;
         public string Content { get; set; } = string.Empty;
         public string Avatar { get; set; } = string.Empty;
         public DateTime Timestamp { get; set; }
+        public bool IsDeleted { get; set; }
 
         public string TimeFormatted => Timestamp.ToString("dd/MM/yy HH:mm");
         public string Header => $"{Sender} ({Room}) :";

--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -8,14 +8,19 @@
      x:Name="PageRoot">
 
     <Page.Resources>
+        <MenuFlyout x:Key="MessageContextMenu" Opened="MessageContextMenu_Opened">
+            <MenuFlyoutItem Text="Copier la sélection" Click="CopySelection_Click" />
+            <MenuFlyoutItem Text="Tout sélectionner" Click="SelectAll_Click" />
+            <MenuFlyoutItem Text="Supprimer" Click="DeleteMessage_Click" />
+        </MenuFlyout>
         <DataTemplate x:Key="OtherMessageTemplate" x:DataType="data:ChatMessageModel">
             <StackPanel HorizontalAlignment="Left">
-                <Border CornerRadius="10" Padding="10" Margin="5" MaxWidth="800" HorizontalAlignment="Left" Background="{ThemeResource OtherMessageColor}">
+                <Border CornerRadius="10" Padding="10" Margin="5" MaxWidth="800" HorizontalAlignment="Left" Background="{ThemeResource OtherMessageColor}" ContextFlyout="{StaticResource MessageContextMenu}">
                     <StackPanel Orientation="Horizontal" Spacing="10" MinWidth="180">
                         <Image Source="{x:Bind Avatar}" Width="40" Height="40"/>
                         <StackPanel MinWidth="200">
                             <TextBlock Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextOtherMessageColor}"/>
-                            <TextBlock Text="{x:Bind Content}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextOtherMessageColor}"/>
+                            <TextBlock Text="{x:Bind Content}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextOtherMessageColor}" IsTextSelectionEnabled="True"/>
                             <TextBlock Text="{x:Bind TimeFormatted}" FontSize="12" HorizontalAlignment="Right" Foreground="{ThemeResource TextOtherMessageColor}"/>
                         </StackPanel>
                     </StackPanel>
@@ -24,12 +29,12 @@
         </DataTemplate>
 
         <DataTemplate x:Key="MyMessageTemplate" x:DataType="data:ChatMessageModel">
-            <Border CornerRadius="10" Padding="10" Margin="5" MaxWidth="800" HorizontalAlignment="Right" Background="{ThemeResource MyMessageColor}">
+            <Border CornerRadius="10" Padding="10" Margin="5" MaxWidth="800" HorizontalAlignment="Right" Background="{ThemeResource MyMessageColor}" ContextFlyout="{StaticResource MessageContextMenu}">
                 <StackPanel Orientation="Horizontal" Spacing="10" MinWidth="180">
                     <Image Source="{x:Bind Avatar}" Width="40" Height="40" VerticalAlignment="Top"/>
                     <StackPanel MinWidth="200">
                         <TextBlock Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextMyMessageColor}"/>
-                        <TextBlock Text="{x:Bind Content}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}" MaxWidth="500" HorizontalAlignment="Left" Foreground="{ThemeResource TextMyMessageColor}"/>
+                        <TextBlock Text="{x:Bind Content}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}" MaxWidth="500" HorizontalAlignment="Left" Foreground="{ThemeResource TextMyMessageColor}" IsTextSelectionEnabled="True"/>
                         <TextBlock Text="{x:Bind TimeFormatted}" FontSize="12" HorizontalAlignment="Right" Foreground="{ThemeResource TextMyMessageColor}"/>
                     </StackPanel>
                 </StackPanel>
@@ -61,8 +66,10 @@
             <TextBlock FontFamily="Consolas"
                FontSize="{ThemeResource MessageFontSize}"
                HorizontalAlignment="Left"
-                       TextWrapping="Wrap"
-                       MaxWidth="1000">
+               TextWrapping="Wrap"
+               MaxWidth="1000"
+               IsTextSelectionEnabled="True"
+               ContextFlyout="{StaticResource MessageContextMenu}">
                 <Run Text="[" Foreground="DarkViolet" /><Run Text="{x:Bind IrcTimestamp}" Foreground="DarkViolet" /><Run Text="]"  Foreground="DarkViolet" />
                 <Run Text="&lt;"/><Run Text="{x:Bind Sender}" /><Run Text="(" /><Run Text="{x:Bind Room}" /><Run Text=")&gt;" />
                 <Run Text="&lt;"/><Run Text="{x:Bind Destinataire}" /><Run Text="&gt;" />

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -13,6 +13,7 @@ using Client.Models;
 using Client.Services;
 using Client.Helpers;
 using Client;
+using Windows.ApplicationModel.DataTransfer;
 
 namespace Client.Pages
 {
@@ -26,6 +27,7 @@ namespace Client.Pages
         private ObservableCollection<string> RoomsWithAll { get; } = new();
 
         private DateTime _currentDate = DateTime.Today;
+        private FrameworkElement? _currentMessageTarget;
         public bool ShowTimeModification { get; private set; }
         public Visibility TimeModificationVisibility => ShowTimeModification ? Visibility.Visible : Visibility.Collapsed;
         public ChatPage()
@@ -513,6 +515,40 @@ namespace Client.Pages
                 .OrderByDescending(p => p.IsTaken)
                 .ThenBy(p => p.HoldTime);
         }
+
+        private void MessageContextMenu_Opened(object sender, object e)
+        {
+            if (sender is MenuFlyout menu)
+                _currentMessageTarget = menu.Target as FrameworkElement;
+        }
+
+        private void CopySelection_Click(object sender, RoutedEventArgs e)
+        {
+            if (_currentMessageTarget is TextBlock tb)
+            {
+                var text = string.IsNullOrEmpty(tb.SelectedText) ? tb.Text : tb.SelectedText;
+                var data = new DataPackage();
+                data.SetText(text);
+                Clipboard.SetContent(data);
+            }
+        }
+
+        private void SelectAll_Click(object sender, RoutedEventArgs e)
+        {
+            if (_currentMessageTarget is TextBlock tb)
+            {
+                tb.SelectAll();
+            }
+        }
+
+        private async void DeleteMessage_Click(object sender, RoutedEventArgs e)
+        {
+            if (_currentMessageTarget?.DataContext is ChatMessageModel msg)
+            {
+                Messages.Remove(msg);
+                await _service.DeleteMessageAsync(msg.Id);
+            }
+        }
     }
 
     public static class ObservableCollectionExtensions
@@ -524,5 +560,4 @@ namespace Client.Pages
                 collection.Remove(item);
         }
 
-    }
-}
+    }}

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -196,10 +196,11 @@ namespace Client.Services
                 });
             });
 
-            Connection.On<string, string, string, string, string, DateTime>("ReceiveMessage", (user, room, destinataire, msg, avatar, time) =>
+            Connection.On<int, string, string, string, string, string, DateTime>("ReceiveMessage", (id, user, room, destinataire, msg, avatar, time) =>
             {
                 var chat = new ChatMessageModel
                 {
+                    Id = id,
                     Sender = user,
                     Destinataire = destinataire,
                     Room = room,
@@ -215,6 +216,16 @@ namespace Client.Services
                     Messages.Add(chat);
                     OnMessageReceived?.Invoke(chat);
                     await SaveTodayMessagesToDiskAsync();
+                });
+            });
+
+            Connection.On<int>("MessageDeleted", id =>
+            {
+                Dispatcher?.TryEnqueue(() =>
+                {
+                    var message = Messages.OfType<ChatMessageModel>().FirstOrDefault(m => m.Id == id);
+                    if (message != null)
+                        Messages.Remove(message);
                 });
             });
 
@@ -314,12 +325,14 @@ namespace Client.Services
 
                 var messages = raw.Select(m => new ChatMessageModel
                 {
+                    Id = m.Id,
                     Sender = m.Sender,
                     Destinataire = m.Destinataire,
                     Room = m.Room,
                     Content = m.Content,
                     Avatar = m.Avatar,
-                    Timestamp = m.Timestamp
+                    Timestamp = m.Timestamp,
+                    IsDeleted = m.IsDeleted
                 }).ToList();
 
                 return Result<List<ChatMessageModel>>.Ok(messages);
@@ -343,12 +356,14 @@ namespace Client.Services
                 return Result<List<ChatMessageModel>>.Ok(
                     raw.Select(m => new ChatMessageModel
                     {
+                        Id = m.Id,
                         Sender = m.Sender,
                         Destinataire = m.Destinataire,
                         Room = m.Room,
                         Content = m.Content,
                         Avatar = m.Avatar,
-                        Timestamp = m.Timestamp
+                        Timestamp = m.Timestamp,
+                        IsDeleted = m.IsDeleted
                     }).ToList()
                 );
             }
@@ -418,6 +433,12 @@ namespace Client.Services
         {
             if (Connection != null && Connection.State == HubConnectionState.Connected)
                 await Connection.InvokeAsync("UpdatePatientHoldTime", id, newTime);
+        }
+
+        public async Task DeleteMessageAsync(int id)
+        {
+            if (Connection != null && Connection.State == HubConnectionState.Connected)
+                await Connection.InvokeAsync("DeleteMessage", id);
         }
         public async Task<List<ChatMessageModel>> LoadTodayMessagesFromDiskAsync()
         {

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -135,7 +135,8 @@ namespace ChatServeur
                 Room = room,
                 Content = content,
                 Avatar = avatar,
-                Timestamp = timestamp
+                Timestamp = timestamp,
+                IsDeleted = false
             };
 
             _db.Messages.Add(message);
@@ -143,26 +144,26 @@ namespace ChatServeur
 
             if (destinataire == "A Tous")
             {
-                await Clients.All.SendAsync("ReceiveMessage", sender, room, destinataire, content, avatar, timestamp);
+                await Clients.All.SendAsync("ReceiveMessage", message.Id, sender, room, destinataire, content, avatar, timestamp);
             }
             else if (destinataire == "Secrétariat")
             {
-                await Clients.Group("Secrétariat").SendAsync("ReceiveMessage", sender, room, destinataire, content, avatar, timestamp);
+                await Clients.Group("Secrétariat").SendAsync("ReceiveMessage", message.Id, sender, room, destinataire, content, avatar, timestamp);
 
                 if (!GroupMembers.TryGetValue("Secrétariat", out var membres) || !membres.Contains(sender))
                 {
-                    await Clients.Caller.SendAsync("ReceiveMessage", sender, room, "Secrétariat", content, avatar, timestamp);
+                    await Clients.Caller.SendAsync("ReceiveMessage", message.Id, sender, room, "Secrétariat", content, avatar, timestamp);
                 }
             }
             else if (_userToConnectionId.TryGetValue(destinataire, out var targetConnectionId))
             {
-                await Clients.Client(targetConnectionId).SendAsync("ReceiveMessage", sender, room, destinataire, content, avatar, timestamp);
-                await Clients.Caller.SendAsync("ReceiveMessage", sender, room, destinataire, content, avatar, timestamp);
+                await Clients.Client(targetConnectionId).SendAsync("ReceiveMessage", message.Id, sender, room, destinataire, content, avatar, timestamp);
+                await Clients.Caller.SendAsync("ReceiveMessage", message.Id, sender, room, destinataire, content, avatar, timestamp);
             }
             else
             {
-                await Clients.Group(destinataire).SendAsync("ReceiveMessage", sender, room, destinataire, content, avatar, timestamp);
-                await Clients.Caller.SendAsync("ReceiveMessage", sender, room, destinataire, content, avatar, timestamp);
+                await Clients.Group(destinataire).SendAsync("ReceiveMessage", message.Id, sender, room, destinataire, content, avatar, timestamp);
+                await Clients.Caller.SendAsync("ReceiveMessage", message.Id, sender, room, destinataire, content, avatar, timestamp);
             }
         }
 
@@ -242,7 +243,9 @@ namespace ChatServeur
             var today = DateTime.Today;
 
             return await _db.Messages
-                .Where(m => (m.Sender == username || m.Destinataire == username || m.Destinataire == "A Tous") && m.Timestamp.Date == today)
+                .Where(m => !m.IsDeleted &&
+                            (m.Sender == username || m.Destinataire == username || m.Destinataire == "A Tous") &&
+                            m.Timestamp.Date == today)
                 .OrderBy(m => m.Timestamp)
                 .ToListAsync();
         }
@@ -252,9 +255,23 @@ namespace ChatServeur
             var day = date.Date;
 
             return await _db.Messages
-                .Where(m => (m.Sender == username || m.Destinataire == username || m.Destinataire == "A Tous") && m.Timestamp.Date == day)
+                .Where(m => !m.IsDeleted &&
+                            (m.Sender == username || m.Destinataire == username || m.Destinataire == "A Tous") &&
+                            m.Timestamp.Date == day)
                 .OrderBy(m => m.Timestamp)
                 .ToListAsync();
+        }
+
+        public async Task DeleteMessage(int id)
+        {
+            var message = await _db.Messages.FindAsync(id);
+            if (message != null)
+            {
+                message.IsDeleted = true;
+                _db.Messages.Update(message);
+                await _db.SaveChangesAsync();
+                await Clients.All.SendAsync("MessageDeleted", id);
+            }
         }
 
         public async Task SetRoomName(string roomName)

--- a/Serveur/Models/ChatMessage.cs
+++ b/Serveur/Models/ChatMessage.cs
@@ -9,5 +9,6 @@ namespace ChatServeur
         public string Content { get; set; } = string.Empty;
         public string Avatar { get; set; } = string.Empty;
         public DateTime Timestamp { get; set; }
+        public bool IsDeleted { get; set; }
     }
 }

--- a/Serveur/Program.cs
+++ b/Serveur/Program.cs
@@ -34,6 +34,7 @@ using (var scope = app.Services.CreateScope())
     var db = scope.ServiceProvider.GetRequiredService<ChatDbContext>();
     db.Database.EnsureCreated();
     EnsureArchivedColumn(db);
+    EnsureIsDeletedColumn(db);
     if (!db.ServerConfigs.Any())
     {
         db.ServerConfigs.Add(new ServerConfig());
@@ -63,6 +64,37 @@ void EnsureArchivedColumn(ChatDbContext db)
         if (!exists)
         {
             cmd.CommandText = "ALTER TABLE Patients ADD COLUMN IsArchived INTEGER NOT NULL DEFAULT 0";
+            cmd.ExecuteNonQuery();
+        }
+    }
+    finally
+    {
+        connection.Close();
+    }
+}
+
+void EnsureIsDeletedColumn(ChatDbContext db)
+{
+    var connection = db.Database.GetDbConnection();
+    connection.Open();
+    try
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "PRAGMA table_info('Messages')";
+        using var reader = cmd.ExecuteReader();
+        bool exists = false;
+        while (reader.Read())
+        {
+            if (string.Equals(reader.GetString(1), "IsDeleted", StringComparison.OrdinalIgnoreCase))
+            {
+                exists = true;
+                break;
+            }
+        }
+        reader.Close();
+        if (!exists)
+        {
+            cmd.CommandText = "ALTER TABLE Messages ADD COLUMN IsDeleted INTEGER NOT NULL DEFAULT 0";
             cmd.ExecuteNonQuery();
         }
     }


### PR DESCRIPTION
## Summary
- track message `Id` and deleted status on client and server
- allow hiding messages by marking them deleted server-side
- expose `DeleteMessage` hub method and broadcast deleted messages
- add message context menu to copy/select/delete text in IRC view

## Testing
- `dotnet build Serveur/Serveur.csproj -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686e7e9943348324bdee42a3c3b81e5a