### PR TITLE
Enable single-block selection in chat bubbles

### DIFF
--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -19,9 +19,17 @@
                     <StackPanel Orientation="Horizontal" Spacing="10" MinWidth="180">
                         <Image Source="{x:Bind Avatar}" Width="40" Height="40"/>
                         <StackPanel MinWidth="200">
-                            <TextBlock Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextOtherMessageColor}"/>
-                            <TextBlock Text="{x:Bind Content}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextOtherMessageColor}" IsTextSelectionEnabled="True"/>
-                            <TextBlock Text="{x:Bind TimeFormatted}" FontSize="12" HorizontalAlignment="Right" Foreground="{ThemeResource TextOtherMessageColor}"/>
+                            <RichTextBlock IsTextSelectionEnabled="True" MaxWidth="500">
+                                <Paragraph>
+                                    <Run Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextOtherMessageColor}"/>
+                                </Paragraph>
+                                <Paragraph>
+                                    <Run Text="{x:Bind Content}" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextOtherMessageColor}"/>
+                                </Paragraph>
+                                <Paragraph TextAlignment="Right">
+                                    <Run Text="{x:Bind TimeFormatted}" FontSize="12" Foreground="{ThemeResource TextOtherMessageColor}"/>
+                                </Paragraph>
+                            </RichTextBlock>
                         </StackPanel>
                     </StackPanel>
                 </Border>
@@ -33,9 +41,17 @@
                 <StackPanel Orientation="Horizontal" Spacing="10" MinWidth="180">
                     <Image Source="{x:Bind Avatar}" Width="40" Height="40" VerticalAlignment="Top"/>
                     <StackPanel MinWidth="200">
-                        <TextBlock Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextMyMessageColor}"/>
-                        <TextBlock Text="{x:Bind Content}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}" MaxWidth="500" HorizontalAlignment="Left" Foreground="{ThemeResource TextMyMessageColor}" IsTextSelectionEnabled="True"/>
-                        <TextBlock Text="{x:Bind TimeFormatted}" FontSize="12" HorizontalAlignment="Right" Foreground="{ThemeResource TextMyMessageColor}"/>
+                        <RichTextBlock IsTextSelectionEnabled="True" MaxWidth="500">
+                            <Paragraph>
+                                <Run Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextMyMessageColor}"/>
+                            </Paragraph>
+                            <Paragraph>
+                                <Run Text="{x:Bind Content}" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextMyMessageColor}"/>
+                            </Paragraph>
+                            <Paragraph TextAlignment="Right">
+                                <Run Text="{x:Bind TimeFormatted}" FontSize="12" Foreground="{ThemeResource TextMyMessageColor}"/>
+                            </Paragraph>
+                        </RichTextBlock>
                     </StackPanel>
                 </StackPanel>
             </Border>

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -14,6 +14,7 @@ using Client.Services;
 using Client.Helpers;
 using Client;
 using Windows.ApplicationModel.DataTransfer;
+using Microsoft.UI.Xaml.Documents;
 
 namespace Client.Pages
 {
@@ -541,9 +542,24 @@ namespace Client.Pages
 
         private void CopySelection_Click(object sender, RoutedEventArgs e)
         {
+            string? text = null;
             if (_currentMessageTarget is TextBlock tb)
             {
-                var text = string.IsNullOrEmpty(tb.SelectedText) ? tb.Text : tb.SelectedText;
+                text = string.IsNullOrEmpty(tb.SelectedText) ? tb.Text : tb.SelectedText;
+            }
+            else if (_currentMessageTarget is RichTextBlock rtb)
+            {
+                text = rtb.Selection.Text;
+                if (string.IsNullOrEmpty(text))
+                {
+                    rtb.SelectAll();
+                    text = rtb.Selection.Text;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(text))
+            {
+                text = text.Replace("\r", string.Empty).Replace("\n", " ");
                 var data = new DataPackage();
                 data.SetText(text);
                 Clipboard.SetContent(data);
@@ -555,6 +571,10 @@ namespace Client.Pages
             if (_currentMessageTarget is TextBlock tb)
             {
                 tb.SelectAll();
+            }
+            else if (_currentMessageTarget is RichTextBlock rtb)
+            {
+                rtb.SelectAll();
             }
         }
 
@@ -576,5 +596,4 @@ namespace Client.Pages
             foreach (var item in toRemove)
                 collection.Remove(item);
         }
-
     }}


### PR DESCRIPTION
## Summary
- display message header, content and time in one `RichTextBlock`
- allow context menu copy/select-all on `RichTextBlock`
- strip line breaks when copying text

## Testing
- `dotnet test --no-restore` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686e8c0d1c788324903d1d7049b10222