### PR TITLE
Add username color support

### DIFF
--- a/Client/Models/ChatMessageModel.cs
+++ b/Client/Models/ChatMessageModel.cs
@@ -16,6 +16,8 @@ namespace Client.Models
         public string Room { get; set; } = string.Empty;
         public string Content { get; set; } = string.Empty;
         public string Avatar { get; set; } = string.Empty;
+        public string SenderColor { get; set; } = string.Empty;
+        public string DestinataireColor { get; set; } = string.Empty;
         public DateTime Timestamp { get; set; }
         public bool IsDeleted { get; set; }
 

--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -3,11 +3,13 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:data="using:Client.Models"
+    xmlns:helpers="using:Client.Helpers"
     Width="auto"
     xmlns:local="using:Client.Pages"
      x:Name="PageRoot">
 
     <Page.Resources>
+        <helpers:StringToColorConverter x:Key="StringToColorConverter" />
         <MenuFlyout x:Key="MessageContextMenu" Opened="MessageContextMenu_Opened">
             <MenuFlyoutItem Text="Copier la sélection" Click="CopySelection_Click" />
             <MenuFlyoutItem Text="Tout sélectionner" Click="SelectAll_Click" />
@@ -86,12 +88,12 @@
                 <Paragraph>
                     <Run Text="{x:Bind IrcTimestampWithBrackets}" Foreground="DarkViolet" />
                     <Run Text="&lt;" />
-                    <Run Text="{x:Bind Sender}" />
+                    <Run Text="{x:Bind Sender}" Foreground="{x:Bind SenderColor, Converter={StaticResource StringToColorConverter}}" />
                     <Run Text="(" />
                     <Run Text="{x:Bind Room}" />
                     <Run Text=")&gt;" />
                     <Run Text="&lt;" />
-                    <Run Text="{x:Bind Destinataire}" />
+                    <Run Text="{x:Bind Destinataire}" Foreground="{x:Bind DestinataireColor, Converter={StaticResource StringToColorConverter}}" />
                     <Run Text="&gt;" />
                     <Run Text=": " />
                     <Span x:Name="ContentSpan" />
@@ -173,7 +175,8 @@
         <DataTemplate x:Key="UserTemplate" x:DataType="data:UserInfo">
             <StackPanel Orientation="Horizontal" Spacing="8" Padding="4">
                 <Image Source="{x:Bind Avatar}" Width="32" Height="32"/>
-                <TextBlock Text="{x:Bind Name}" VerticalAlignment="Center"/>
+                <TextBlock Text="{x:Bind Name}" VerticalAlignment="Center"
+                           Foreground="{x:Bind ColorUserName, Converter={StaticResource StringToColorConverter}}"/>
             </StackPanel>
         </DataTemplate>
 

--- a/Client/Pages/UserSettingsPage.xaml
+++ b/Client/Pages/UserSettingsPage.xaml
@@ -5,12 +5,28 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:vm="using:Client.ViewModel"
+    xmlns:helpers="using:Client.Helpers"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Page.Resources>
+        <helpers:StringToColorConverter x:Key="StringToColorConverter" />
+    </Page.Resources>
     <ScrollViewer>
         <StackPanel Padding="20" Spacing="20">
             <Button Content="← Retour" Click="Back_Click" HorizontalAlignment="Left"/>
             <TextBlock Text="Utilisateur" FontSize="24" FontWeight="Bold"/>
+            <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                <TextBlock Text="Couleur du nom:" VerticalAlignment="Center"/>
+                <Button>
+                    <Rectangle Width="32" Height="16" Stroke="Black"
+                               Fill="{x:Bind ViewModelSettings.ColorUserName, Mode=OneWay, Converter={StaticResource StringToColorConverter}}"/>
+                    <Button.Flyout>
+                        <Flyout>
+                            <ColorPicker Color="{x:Bind ViewModelSettings.ColorUserName, Mode=TwoWay, Converter={StaticResource StringToColorConverter}}"/>
+                        </Flyout>
+                    </Button.Flyout>
+                </Button>
+            </StackPanel>
             <Border CornerRadius="8" Padding="20">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Raccourcis en tête" FontSize="18" FontWeight="Bold"/>

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -72,7 +72,8 @@ namespace Client.Services
                 ConnectedUsers.Add(user);
             }
 
-            await ConnectAsync(App.UserName, @"E:\benoit.png", RoomName);
+            var color = AppSettings.Get("ColorUserName", "Black");
+            await ConnectAsync(App.UserName, @"E:\benoit.png", RoomName, color);
 
             Messages.Clear();
             Messages.Add(new LoadMorePlaceholder());
@@ -98,7 +99,7 @@ namespace Client.Services
                 Patients.Add(p);
         }
 
-        public async Task ConnectAsync(string username, string avatar, string room)
+        public async Task ConnectAsync(string username, string avatar, string room, string color)
         {
             if (Connection != null)
             {
@@ -198,6 +199,8 @@ namespace Client.Services
 
             Connection.On<int, string, string, string, string, string, DateTime>("ReceiveMessage", (id, user, room, destinataire, msg, avatar, time) =>
             {
+                var senderColor = ConnectedUsers.FirstOrDefault(u => u.Username == user)?.ColorUserName ?? "Black";
+                var destColor = ConnectedUsers.FirstOrDefault(u => u.Username == destinataire)?.ColorUserName ?? "Black";
                 var chat = new ChatMessageModel
                 {
                     Id = id,
@@ -206,7 +209,9 @@ namespace Client.Services
                     Room = room,
                     Content = msg,
                     Timestamp = time,
-                    Avatar = avatar
+                    Avatar = avatar,
+                    SenderColor = senderColor,
+                    DestinataireColor = destColor
                 };
 
                 Debug.WriteLine($"✅ Message reçu de {user} dans la salle {room} : {msg} ({time})");
@@ -281,7 +286,7 @@ namespace Client.Services
             try
             {
                 await Connection.StartAsync();
-                await Connection.InvokeAsync("RegisterUser", username, avatar, room);
+                await Connection.InvokeAsync("RegisterUser", username, avatar, room, color);
             }
             catch (Exception ex)
             {
@@ -332,7 +337,9 @@ namespace Client.Services
                     Content = m.Content,
                     Avatar = m.Avatar,
                     Timestamp = m.Timestamp,
-                    IsDeleted = m.IsDeleted
+                    IsDeleted = m.IsDeleted,
+                    SenderColor = ConnectedUsers.FirstOrDefault(u => u.Username == m.Sender)?.ColorUserName ?? "Black",
+                    DestinataireColor = ConnectedUsers.FirstOrDefault(u => u.Username == m.Destinataire)?.ColorUserName ?? "Black"
                 }).ToList();
 
                 return Result<List<ChatMessageModel>>.Ok(messages);
@@ -363,7 +370,9 @@ namespace Client.Services
                         Content = m.Content,
                         Avatar = m.Avatar,
                         Timestamp = m.Timestamp,
-                        IsDeleted = m.IsDeleted
+                        IsDeleted = m.IsDeleted,
+                        SenderColor = ConnectedUsers.FirstOrDefault(u => u.Username == m.Sender)?.ColorUserName ?? "Black",
+                        DestinataireColor = ConnectedUsers.FirstOrDefault(u => u.Username == m.Destinataire)?.ColorUserName ?? "Black"
                     }).ToList()
                 );
             }
@@ -448,7 +457,13 @@ namespace Client.Services
                 if (File.Exists(path))
                 {
                     var json = await File.ReadAllTextAsync(path);
-                    return JsonConvert.DeserializeObject<List<ChatMessageModel>>(json) ?? new();
+                    var list = JsonConvert.DeserializeObject<List<ChatMessageModel>>(json) ?? new();
+                    foreach (var m in list)
+                    {
+                        m.SenderColor = ConnectedUsers.FirstOrDefault(u => u.Username == m.Sender)?.ColorUserName ?? "Black";
+                        m.DestinataireColor = ConnectedUsers.FirstOrDefault(u => u.Username == m.Destinataire)?.ColorUserName ?? "Black";
+                    }
+                    return list;
                 }
             }
             catch (Exception ex)

--- a/Client/ViewModel/SettingsViewModel.cs
+++ b/Client/ViewModel/SettingsViewModel.cs
@@ -11,6 +11,7 @@ namespace Client.ViewModel
         private bool _isOldSchoolMode;
         private double _messageFontSize = 14;
         private string _appTheme = "Dark";
+        private string _colorUserName = "Black";
         private string _shortcutF5Refraction = string.Empty;
         private string _shortcutF5Lentilles = string.Empty;
         private string _shortcutF5Pathologies = string.Empty;
@@ -84,6 +85,20 @@ namespace Client.ViewModel
                     OnPropertyChanged(nameof(AppTheme));
                     AppSettings.Set("AppTheme", value);
                     ApplyTheme(value);
+                }
+            }
+        }
+
+        public string ColorUserName
+        {
+            get => _colorUserName;
+            set
+            {
+                if (_colorUserName != value)
+                {
+                    _colorUserName = value;
+                    OnPropertyChanged(nameof(ColorUserName));
+                    Set("ColorUserName", value);
                 }
             }
         }
@@ -245,6 +260,7 @@ namespace Client.ViewModel
             }
             _appTheme = AppSettings.Get("AppTheme", "Dark");
             ApplyTheme(_appTheme);
+            _colorUserName = Get("ColorUserName");
 
             _shortcutF5Refraction = Get("ShortcutF5Refraction");
             _shortcutF5Lentilles = Get("ShortcutF5Lentilles");

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -21,6 +21,7 @@ namespace ChatServeur
                 Avatar = "ms-appx:///Assets/earth.png",
                 Room = string.Empty,
                 DisplayName = "A Tous",
+                ColorUserName = "Red",
                 IsOnline = true,
                 Note = string.Empty
             },
@@ -31,6 +32,7 @@ namespace ChatServeur
                 Avatar = "ms-appx:///Assets/secretaria.png",
                 Room = string.Empty,
                 DisplayName = "Secrétariat",
+                ColorUserName = "Blue",
                 IsOnline = true,
                 Note = string.Empty
             }
@@ -72,7 +74,7 @@ namespace ChatServeur
             await base.OnDisconnectedAsync(ex);
         }
 
-        public async Task RegisterUser(string username, string avatar, string room)
+        public async Task RegisterUser(string username, string avatar, string room, string color)
         {
             try
             {
@@ -85,6 +87,7 @@ namespace ChatServeur
                     Avatar = avatar,
                     Room = room,
                     DisplayName = username,
+                    ColorUserName = color,
                     IsOnline = true,
                     Note = string.Empty
                 };


### PR DESCRIPTION
## Summary
- allow users to select a name color in settings
- track sender and recipient colors in chat messages
- show user names with their custom color
- color names in IRC chat view
- add default colors for "A Tous" and "Secrétariat"

## Testing
- `dotnet build WebApplication1.sln -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870d886ab788324a8d5942646512aa3