### PR TITLE
Fix user color update

### DIFF
--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -652,6 +652,21 @@ namespace Client.Services
             }
         }
 
+        public async Task UpdateColorUserNameAsync(string color)
+        {
+            if (Connection != null && Connection.State == HubConnectionState.Connected)
+            {
+                try
+                {
+                    await Connection.InvokeAsync("SetColorUserName", color);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Erreur mise à jour couleur utilisateur : {ex.Message}");
+                }
+            }
+        }
+
         public async Task ArchiveTakenPatientsAsync()
         {
             if (Connection != null && Connection.State == HubConnectionState.Connected)

--- a/Client/ViewModel/SettingsViewModel.cs
+++ b/Client/ViewModel/SettingsViewModel.cs
@@ -99,6 +99,7 @@ namespace Client.ViewModel
                     _colorUserName = value;
                     OnPropertyChanged(nameof(ColorUserName));
                     Set("ColorUserName", value);
+                    App.ChatService?.UpdateColorUserNameAsync(value);
                 }
             }
         }

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -289,6 +289,18 @@ namespace ChatServeur
             }
         }
 
+        public async Task SetColorUserName(string color)
+        {
+            if (ConnectedUsers.TryGetValue(Context.ConnectionId, out var user))
+            {
+                user.ColorUserName = color;
+                AllUsers[user.Username] = user;
+
+                var userList = BaseUsers.Concat(AllUsers.Values).ToList();
+                await Clients.All.SendAsync("UserListUpdated", userList);
+            }
+        }
+
         public async Task SaveExamOptions(IEnumerable<ExamOption> options)
         {
             var json = JsonSerializer.Serialize(options);


### PR DESCRIPTION
## Summary
- update user color in SettingsViewModel through SignalR
- expose UpdateColorUserNameAsync in SignalRService
- add SetColorUserName method on the ChatHub server

## Testing
- `dotnet build WebApplication1.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687119c0b3a483249fb1635ac582dd77