### PR TITLE
Fix color update for existing chat messages

### DIFF
--- a/Client/Models/ChatMessageModel.cs
+++ b/Client/Models/ChatMessageModel.cs
@@ -5,19 +5,49 @@ using System;
 using System.Text.RegularExpressions;
 using Windows.System;
 using Microsoft.UI.Xaml.Media;
+using System.ComponentModel;
 
 namespace Client.Models
 {
-    public class ChatMessageModel
+    public class ChatMessageModel : INotifyPropertyChanged
     {
+        public event PropertyChangedEventHandler? PropertyChanged;
+
         public int Id { get; set; }
         public string Sender { get; set; } = string.Empty;
         public string Destinataire { get; set; } = string.Empty;
         public string Room { get; set; } = string.Empty;
         public string Content { get; set; } = string.Empty;
         public string Avatar { get; set; } = string.Empty;
-        public string SenderColor { get; set; } = string.Empty;
-        public string DestinataireColor { get; set; } = string.Empty;
+
+        private string _senderColor = string.Empty;
+        public string SenderColor
+        {
+            get => _senderColor;
+            set
+            {
+                if (_senderColor != value)
+                {
+                    _senderColor = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(SenderColor)));
+                }
+            }
+        }
+
+        private string _destinataireColor = string.Empty;
+        public string DestinataireColor
+        {
+            get => _destinataireColor;
+            set
+            {
+                if (_destinataireColor != value)
+                {
+                    _destinataireColor = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(DestinataireColor)));
+                }
+            }
+        }
+
         public DateTime Timestamp { get; set; }
         public bool IsDeleted { get; set; }
 

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -176,6 +176,12 @@ namespace Client.Services
                         Debug.WriteLine($"✅ User list ajoutée : {user.Username} ({user.Room})");
                     }
 
+                    foreach (var msg in Messages.OfType<ChatMessageModel>())
+                    {
+                        msg.SenderColor = ConnectedUsers.FirstOrDefault(u => u.Username == msg.Sender)?.ColorUserName ?? "Black";
+                        msg.DestinataireColor = ConnectedUsers.FirstOrDefault(u => u.Username == msg.Destinataire)?.ColorUserName ?? "Black";
+                    }
+
                     await SaveUsersToDiskAsync();
                 });
             });


### PR DESCRIPTION
## Summary
- implement INotifyPropertyChanged on `ChatMessageModel`
- refresh message colors when the server sends a new user list

## Testing
- `dotnet build WebApplication1.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68712fa3797c8324adb9752814125ffb