### PR TITLE
Add sender color display mode

### DIFF
--- a/Client/Models/ChatMessageModel.cs
+++ b/Client/Models/ChatMessageModel.cs
@@ -1,5 +1,6 @@
 using System;
 
+
 namespace Client.Models
 {
     public class ChatMessageModel
@@ -10,6 +11,9 @@ namespace Client.Models
         public string Content { get; set; } = string.Empty;
         public string Avatar { get; set; } = string.Empty;
         public DateTime Timestamp { get; set; }
+
+        public string SenderColor => ColorUtils.ToHex(ColorUtils.GetPastelColor(Sender));
+        public string SenderTextColor => ColorUtils.ToHex(ColorUtils.GetContrastingTextColor(ColorUtils.GetPastelColor(Sender)));
 
         public string TimeFormatted => Timestamp.ToString("dd/MM/yy HH:mm");
         public string Header => $"{Sender} ({Room}) :";

--- a/Client/Models/ChatMessageTemplateSelector.cs
+++ b/Client/Models/ChatMessageTemplateSelector.cs
@@ -8,12 +8,15 @@ namespace Client.Models
     {
         public DataTemplate? MyMessageTemplate { get; set; }
         public DataTemplate? OtherMessageTemplate { get; set; }
+        public DataTemplate? MyColoredMessageTemplate { get; set; }
+        public DataTemplate? OtherColoredMessageTemplate { get; set; }
         public DataTemplate? LoadMoreTemplate { get; set; }
         public DataTemplate? EmptyTemplate { get; set; }
         public string MyUsername { get; set; } = string.Empty;
         public DataTemplate? IrcTemplate { get; set; }
 
         public ChatStyle DisplayMode { get; set; } = ChatStyle.Modern;
+        public bool UseSenderColors { get; set; }
 
         protected override DataTemplate? SelectTemplateCore(object item)
         {
@@ -28,6 +31,9 @@ namespace Client.Models
                 Debug.WriteLine($"[Selector] Style={DisplayMode}, Sender={message.Sender}, MyUsername={MyUsername}");
                 if (DisplayMode == ChatStyle.OldSchool)
                     return IrcTemplate;
+
+                if (UseSenderColors)
+                    return message.Sender == MyUsername ? MyColoredMessageTemplate : OtherColoredMessageTemplate;
                 else
                     return message.Sender == MyUsername ? MyMessageTemplate : OtherMessageTemplate;
             }

--- a/Client/Models/ColorUtils.cs
+++ b/Client/Models/ColorUtils.cs
@@ -49,5 +49,17 @@ namespace Client.Models
             double luminance = (0.299 * background.R + 0.587 * background.G + 0.114 * background.B) / 255;
             return luminance > 0.5 ? Colors.Black : Colors.White;
         }
+
+        public static Color GetPastelColor(string input)
+        {
+            var hash = input.GetHashCode();
+            byte r = (byte)((hash >> 16) & 0xFF);
+            byte g = (byte)((hash >> 8) & 0xFF);
+            byte b = (byte)(hash & 0xFF);
+            r = (byte)((r + 255) / 2);
+            g = (byte)((g + 255) / 2);
+            b = (byte)((b + 255) / 2);
+            return Color.FromArgb(0xFF, r, g, b);
+        }
     }
 }

--- a/Client/Pages/AppearanceSettingsPage.xaml
+++ b/Client/Pages/AppearanceSettingsPage.xaml
@@ -21,6 +21,9 @@
                     <ToggleSwitch x:Name="IrcModeToggle" Header="Affichage IRC (old school)"
                                    IsOn="{x:Bind ViewModelSettings.IsOldSchoolMode, Mode=TwoWay}" />
 
+                    <ToggleSwitch x:Name="ColorModeToggle" Header="Couleur des bulles par expéditeur"
+                                   IsOn="{x:Bind ViewModelSettings.UseSenderColors, Mode=TwoWay}" />
+
                     <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
                         <TextBlock Text="Taille du texte" VerticalAlignment="Center"/>
                         <Slider Minimum="12" Maximum="24" Width="200" Value="{x:Bind ViewModelSettings.MessageFontSize, Mode=TwoWay}"/>

--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -4,9 +4,11 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:data="using:Client.Models"
     Width="auto"
-    xmlns:local="using:Client.Pages">
+    xmlns:local="using:Client.Pages"
+    xmlns:helpers="using:Client.Helpers">
 
     <Page.Resources>
+        <helpers:StringToColorConverter x:Key="StringToColorConverter" />
         <DataTemplate x:Key="OtherMessageTemplate" x:DataType="data:ChatMessageModel">
             <StackPanel HorizontalAlignment="Left">
                 <Border CornerRadius="10" Padding="10" Margin="5" MaxWidth="800" HorizontalAlignment="Left" Background="{ThemeResource OtherMessageColor}">
@@ -30,6 +32,34 @@
                         <TextBlock Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextMyMessageColor}"/>
                         <TextBlock Text="{x:Bind Content}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}" MaxWidth="500" HorizontalAlignment="Left" Foreground="{ThemeResource TextMyMessageColor}"/>
                         <TextBlock Text="{x:Bind TimeFormatted}" FontSize="12" HorizontalAlignment="Right" Foreground="{ThemeResource TextMyMessageColor}"/>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+        </DataTemplate>
+
+        <DataTemplate x:Key="OtherColoredTemplate" x:DataType="data:ChatMessageModel">
+            <StackPanel HorizontalAlignment="Left">
+                <Border CornerRadius="10" Padding="10" Margin="5" MaxWidth="800" HorizontalAlignment="Left" Background="{x:Bind SenderColor, Converter={StaticResource StringToColorConverter}}">
+                    <StackPanel Orientation="Horizontal" Spacing="10" MinWidth="180">
+                        <Image Source="{x:Bind Avatar}" Width="40" Height="40"/>
+                        <StackPanel MinWidth="200">
+                            <TextBlock Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{x:Bind SenderTextColor, Converter={StaticResource StringToColorConverter}}"/>
+                            <TextBlock Text="{x:Bind Content}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}" Foreground="{x:Bind SenderTextColor, Converter={StaticResource StringToColorConverter}}"/>
+                            <TextBlock Text="{x:Bind TimeFormatted}" FontSize="12" HorizontalAlignment="Right" Foreground="{x:Bind SenderTextColor, Converter={StaticResource StringToColorConverter}}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </DataTemplate>
+
+        <DataTemplate x:Key="MyColoredTemplate" x:DataType="data:ChatMessageModel">
+            <Border CornerRadius="10" Padding="10" Margin="5" MaxWidth="800" HorizontalAlignment="Right" Background="{x:Bind SenderColor, Converter={StaticResource StringToColorConverter}}">
+                <StackPanel Orientation="Horizontal" Spacing="10" MinWidth="180">
+                    <Image Source="{x:Bind Avatar}" Width="40" Height="40" VerticalAlignment="Top"/>
+                    <StackPanel MinWidth="200">
+                        <TextBlock Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{x:Bind SenderTextColor, Converter={StaticResource StringToColorConverter}}"/>
+                        <TextBlock Text="{x:Bind Content}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}" MaxWidth="500" HorizontalAlignment="Left" Foreground="{x:Bind SenderTextColor, Converter={StaticResource StringToColorConverter}}"/>
+                        <TextBlock Text="{x:Bind TimeFormatted}" FontSize="12" HorizontalAlignment="Right" Foreground="{x:Bind SenderTextColor, Converter={StaticResource StringToColorConverter}}"/>
                     </StackPanel>
                 </StackPanel>
             </Border>
@@ -67,9 +97,12 @@
             MyUsername="Moi"
             MyMessageTemplate="{StaticResource MyMessageTemplate}"
             OtherMessageTemplate="{StaticResource OtherMessageTemplate}"
+            MyColoredMessageTemplate="{StaticResource MyColoredTemplate}"
+            OtherColoredMessageTemplate="{StaticResource OtherColoredTemplate}"
             IrcTemplate="{StaticResource IrcMessageTemplate}"
             LoadMoreTemplate="{StaticResource LoadMoreTemplate}"
-            EmptyTemplate="{StaticResource EmptyTemplate}" />
+            EmptyTemplate="{StaticResource EmptyTemplate}"
+            UseSenderColors="False"/>
 
         <Style x:Key="CompactItemStyle" TargetType="ListViewItem">
             <Setter Property="Padding" Value="0"/>

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -40,6 +40,7 @@ namespace Client.Pages
             _service.Dispatcher = DispatcherQueue;
 
             ViewModel.ViewModel.SettingsViewModel.DisplayStyleChanged += ApplyChatStyle;
+            ViewModel.ViewModel.SettingsViewModel.SenderColorModeChanged += ApplyColorMode;
             _service.ConnectedUsers.CollectionChanged += (_, _) => DispatcherQueue.TryEnqueue(TryRestoreUserSelection);
 
             _service.OnMessageReceived += OnMessageReceived;
@@ -51,12 +52,15 @@ namespace Client.Pages
         {
             _service.OnMessageReceived -= OnMessageReceived;
             ViewModel.ViewModel.SettingsViewModel.DisplayStyleChanged -= ApplyChatStyle;
+            ViewModel.ViewModel.SettingsViewModel.SenderColorModeChanged -= ApplyColorMode;
         }
 
         private async void ChatPage_Loaded(object sender, RoutedEventArgs e)
         {
             var style = AppSettings.Get("ChatDisplayStyle", "Modern");
             ApplyChatStyle(style == "OldSchool" ? ChatStyle.OldSchool : ChatStyle.Modern);
+            var colorMode = AppSettings.Get("UseSenderColors", "False") == "True";
+            ApplyColorMode(colorMode);
 
             if (_service.Connection == null || _service.Connection.State != HubConnectionState.Connected)
             {
@@ -294,6 +298,17 @@ namespace Client.Pages
                 MessagesList.ItemContainerStyle = itemStyle;
             }
 
+            MessagesList.ItemsSource = Messages;
+            MessagesList.UpdateLayout();
+        }
+
+        private void ApplyColorMode(bool useSenderColors)
+        {
+            Debug.WriteLine($"[ChatPage] ApplyColorMode: {useSenderColors}");
+            if (Resources["MessageTemplateSelector"] is ChatMessageTemplateSelector selector)
+            {
+                selector.UseSenderColors = useSenderColors;
+            }
             MessagesList.ItemsSource = Messages;
             MessagesList.UpdateLayout();
         }

--- a/Client/ViewModel/SettingsViewModel.cs
+++ b/Client/ViewModel/SettingsViewModel.cs
@@ -9,6 +9,7 @@ namespace Client.ViewModel
     public class SettingsViewModel : INotifyPropertyChanged
     {
         private bool _isOldSchoolMode;
+        private bool _useSenderColors;
         private double _messageFontSize = 14;
         private string _shortcutF5Refraction = string.Empty;
         private string _shortcutF5Lentilles = string.Empty;
@@ -40,6 +41,7 @@ namespace Client.ViewModel
         private string _shiftF12Exam = string.Empty;
 
         public event Action<ChatStyle>? DisplayStyleChanged;
+        public event Action<bool>? SenderColorModeChanged;
         public event PropertyChangedEventHandler? PropertyChanged;
 
         public bool IsOldSchoolMode
@@ -53,6 +55,21 @@ namespace Client.ViewModel
                     OnPropertyChanged(nameof(IsOldSchoolMode));
                     AppSettings.Set("ChatDisplayStyle", value ? "OldSchool" : "Modern");
                     DisplayStyleChanged?.Invoke(value ? ChatStyle.OldSchool : ChatStyle.Modern);
+                }
+            }
+        }
+
+        public bool UseSenderColors
+        {
+            get => _useSenderColors;
+            set
+            {
+                if (_useSenderColors != value)
+                {
+                    _useSenderColors = value;
+                    OnPropertyChanged(nameof(UseSenderColors));
+                    AppSettings.Set("UseSenderColors", value.ToString());
+                    SenderColorModeChanged?.Invoke(value);
                 }
             }
         }
@@ -223,6 +240,7 @@ namespace Client.ViewModel
         {
             var style = AppSettings.Get("ChatDisplayStyle", "Modern");
             _isOldSchoolMode = style == "OldSchool";
+            _useSenderColors = AppSettings.Get("UseSenderColors", "False") == "True";
             if (double.TryParse(AppSettings.Get("MessageFontSize", "14"), out var size))
             {
                 _messageFontSize = size;

--- a/docs/Personnalisation.md
+++ b/docs/Personnalisation.md
@@ -77,12 +77,32 @@ public bool IsOldSchoolMode
             _isOldSchoolMode = value;
             OnPropertyChanged(nameof(IsOldSchoolMode));
             AppSettings.Set("ChatDisplayStyle", value ? "OldSchool" : "Modern");
-            DisplayStyleChanged?.Invoke(value ? ChatStyle.OldSchool : ChatStyle.Modern);
+           DisplayStyleChanged?.Invoke(value ? ChatStyle.OldSchool : ChatStyle.Modern);
         }
     }
 }
 ```
-【F:Client/ViewModel/SettingsViewModel.cs†L10-L36】
+【F:Client/ViewModel/SettingsViewModel.cs†L46-L58】
+
+Un second réglage (`UseSenderColors`) permet d'utiliser automatiquement une couleur différente pour chaque expéditeur. Cette option est exposée via la propriété `UseSenderColors` :
+
+```csharp
+public bool UseSenderColors
+{
+    get => _useSenderColors;
+    set
+    {
+        if (_useSenderColors != value)
+        {
+            _useSenderColors = value;
+            OnPropertyChanged(nameof(UseSenderColors));
+            AppSettings.Set("UseSenderColors", value.ToString());
+            SenderColorModeChanged?.Invoke(value);
+        }
+    }
+}
+```
+【F:Client/ViewModel/SettingsViewModel.cs†L62-L75】
 
 ## Autres réglages
 


### PR DESCRIPTION
## Summary
- support colorizing chat bubbles per sender
- toggle new setting from appearance page
- extend settings view model with `UseSenderColors`
- update template selector and data templates
- document the new option

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871336d3be08324a7530adf4622ec7e