### PR TITLE
Add bubble color mode

### DIFF
--- a/Client/Models/ChatMessageTemplateSelector.cs
+++ b/Client/Models/ChatMessageTemplateSelector.cs
@@ -8,12 +8,15 @@ namespace Client.Models
     {
         public DataTemplate? MyMessageTemplate { get; set; }
         public DataTemplate? OtherMessageTemplate { get; set; }
+        public DataTemplate? MyColoredTemplate { get; set; }
+        public DataTemplate? OtherColoredTemplate { get; set; }
         public DataTemplate? LoadMoreTemplate { get; set; }
         public DataTemplate? EmptyTemplate { get; set; }
         public string MyUsername { get; set; } = string.Empty;
         public DataTemplate? IrcTemplate { get; set; }
 
         public ChatStyle DisplayMode { get; set; } = ChatStyle.Modern;
+        public bool UseSenderColor { get; set; }
 
         protected override DataTemplate? SelectTemplateCore(object item)
         {
@@ -25,9 +28,11 @@ namespace Client.Models
 
             if (item is ChatMessageModel message)
             {
-                Debug.WriteLine($"[Selector] Style={DisplayMode}, Sender={message.Sender}, MyUsername={MyUsername}");
+                Debug.WriteLine($"[Selector] Style={DisplayMode}, Sender={message.Sender}, MyUsername={MyUsername}, UseSenderColor={UseSenderColor}");
                 if (DisplayMode == ChatStyle.OldSchool)
                     return IrcTemplate;
+                else if (UseSenderColor)
+                    return message.Sender == MyUsername ? MyColoredTemplate : OtherColoredTemplate;
                 else
                     return message.Sender == MyUsername ? MyMessageTemplate : OtherMessageTemplate;
             }

--- a/Client/Pages/AppearanceSettingsPage.xaml
+++ b/Client/Pages/AppearanceSettingsPage.xaml
@@ -21,8 +21,11 @@
                         <TextBlock Text="Apparence" FontSize="18" FontWeight="Bold"/>
                     
 
-                    <ToggleSwitch x:Name="IrcModeToggle" Header="Affichage IRC (old school)"
+                   <ToggleSwitch x:Name="IrcModeToggle" Header="Affichage IRC (old school)"
                                    IsOn="{x:Bind ViewModelSettings.IsOldSchoolMode, Mode=TwoWay}" />
+
+                    <ToggleSwitch x:Name="SenderColorToggle" Header="Bulles colorées selon l'utilisateur"
+                                   IsOn="{x:Bind ViewModelSettings.UseSenderColorForBubbles, Mode=TwoWay}" />
 
                     <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
                         <TextBlock Text="Taille du texte" VerticalAlignment="Center"/>

--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -36,8 +36,48 @@
             </StackPanel>
         </DataTemplate>
 
+        <DataTemplate x:Key="OtherColoredMessageTemplate" x:DataType="data:ChatMessageModel">
+            <StackPanel HorizontalAlignment="Left">
+                <Border CornerRadius="10" Padding="10" Margin="5" MaxWidth="800" HorizontalAlignment="Left" Background="{x:Bind SenderColor, Converter={StaticResource StringToColorConverter}}" ContextFlyout="{StaticResource MessageContextMenu}">
+                    <StackPanel Orientation="Horizontal" Spacing="10" MinWidth="180">
+                        <Image Source="{x:Bind Avatar}" Width="40" Height="40"/>
+                        <StackPanel MinWidth="200">
+                            <RichTextBlock IsTextSelectionEnabled="True" MaxWidth="500" ContextFlyout="{StaticResource MessageContextMenu}"  Loaded="{x:Bind FormatContent}">
+                                <Paragraph>
+                                    <Run Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextOtherMessageColor}"/>
+                                </Paragraph>
+                                <Paragraph x:Name="ContentParagraph" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextOtherMessageColor}"/>
+                                <Paragraph TextAlignment="Right">
+                                    <Run Text="{x:Bind IrcTimestamp}" FontSize="12" Foreground="{ThemeResource TextOtherMessageColor}"/>
+                                </Paragraph>
+                            </RichTextBlock>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </DataTemplate>
+
         <DataTemplate x:Key="MyMessageTemplate" x:DataType="data:ChatMessageModel">
             <Border CornerRadius="10" Padding="10" Margin="5" MaxWidth="800" HorizontalAlignment="Right" Background="{ThemeResource MyMessageColor}" ContextFlyout="{StaticResource MessageContextMenu}">
+                <StackPanel Orientation="Horizontal" Spacing="10" MinWidth="180">
+                    <Image Source="{x:Bind Avatar}" Width="40" Height="40" VerticalAlignment="Top"/>
+                    <StackPanel MinWidth="200">
+                        <RichTextBlock IsTextSelectionEnabled="True" MaxWidth="500" ContextFlyout="{StaticResource MessageContextMenu}"  Loaded="{x:Bind FormatContent}">
+                            <Paragraph>
+                                <Run Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextMyMessageColor}"/>
+                            </Paragraph>
+                            <Paragraph x:Name="ContentParagraph" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextMyMessageColor}"/>
+                            <Paragraph TextAlignment="Right">
+                                <Run Text="{x:Bind IrcTimestamp}" FontSize="12" Foreground="{ThemeResource TextMyMessageColor}"/>
+                            </Paragraph>
+                        </RichTextBlock>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+        </DataTemplate>
+
+        <DataTemplate x:Key="MyColoredMessageTemplate" x:DataType="data:ChatMessageModel">
+            <Border CornerRadius="10" Padding="10" Margin="5" MaxWidth="800" HorizontalAlignment="Right" Background="{x:Bind SenderColor, Converter={StaticResource StringToColorConverter}}" ContextFlyout="{StaticResource MessageContextMenu}">
                 <StackPanel Orientation="Horizontal" Spacing="10" MinWidth="180">
                     <Image Source="{x:Bind Avatar}" Width="40" Height="40" VerticalAlignment="Top"/>
                     <StackPanel MinWidth="200">
@@ -105,6 +145,8 @@
             MyUsername="Moi"
             MyMessageTemplate="{StaticResource MyMessageTemplate}"
             OtherMessageTemplate="{StaticResource OtherMessageTemplate}"
+            MyColoredTemplate="{StaticResource MyColoredMessageTemplate}"
+            OtherColoredTemplate="{StaticResource OtherColoredMessageTemplate}"
             IrcTemplate="{StaticResource IrcMessageTemplate}"
             LoadMoreTemplate="{StaticResource LoadMoreTemplate}"
             EmptyTemplate="{StaticResource EmptyTemplate}" />

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -50,6 +50,7 @@ namespace Client.Pages
             _service.Dispatcher = DispatcherQueue;
 
             ViewModel.ViewModel.SettingsViewModel.DisplayStyleChanged += ApplyChatStyle;
+            ViewModel.ViewModel.SettingsViewModel.BubbleColorModeChanged += ApplyBubbleColorMode;
             _service.ConnectedUsers.CollectionChanged += (_, _) => DispatcherQueue.TryEnqueue(TryRestoreUserSelection);
 
             _service.OnMessageReceived += OnMessageReceived;
@@ -65,13 +66,19 @@ namespace Client.Pages
             _service.OnPatientRemoved -= Service_OnPatientRemoved;
             _service.OnPatientUpdated -= Service_OnPatientUpdated;
             ViewModel.ViewModel.SettingsViewModel.DisplayStyleChanged -= ApplyChatStyle;
+            ViewModel.ViewModel.SettingsViewModel.BubbleColorModeChanged -= ApplyBubbleColorMode;
             Patients.CollectionChanged -= Patients_CollectionChanged;
         }
 
         private async void ChatPage_Loaded(object sender, RoutedEventArgs e)
         {
             if (Resources["MessageTemplateSelector"] is ChatMessageTemplateSelector sel)
+            {
                 sel.MyUsername = App.UserName;
+                var useSenderColor = AppSettings.Get("UseSenderColorForBubbles", "False") == "True";
+                sel.UseSenderColor = useSenderColor;
+                ApplyBubbleColorMode(useSenderColor);
+            }
 
             var style = AppSettings.Get("ChatDisplayStyle", "Modern");
             ApplyChatStyle(style == "OldSchool" ? ChatStyle.OldSchool : ChatStyle.Modern);
@@ -326,6 +333,17 @@ namespace Client.Pages
             if (Resources[styleKey] is Style itemStyle)
             {
                 MessagesList.ItemContainerStyle = itemStyle;
+            }
+
+            MessagesList.ItemsSource = Messages;
+            MessagesList.UpdateLayout();
+        }
+
+        private void ApplyBubbleColorMode(bool useSenderColor)
+        {
+            if (Resources["MessageTemplateSelector"] is ChatMessageTemplateSelector selector)
+            {
+                selector.UseSenderColor = useSenderColor;
             }
 
             MessagesList.ItemsSource = Messages;

--- a/Client/ViewModel/SettingsViewModel.cs
+++ b/Client/ViewModel/SettingsViewModel.cs
@@ -41,7 +41,10 @@ namespace Client.ViewModel
         private string _ctrlF12Exam = string.Empty;
         private string _shiftF12Exam = string.Empty;
 
+        private bool _useSenderColorForBubbles;
+
         public event Action<ChatStyle>? DisplayStyleChanged;
+        public event Action<bool>? BubbleColorModeChanged;
         public event PropertyChangedEventHandler? PropertyChanged;
 
         public bool IsOldSchoolMode
@@ -100,6 +103,21 @@ namespace Client.ViewModel
                     OnPropertyChanged(nameof(ColorUserName));
                     Set("ColorUserName", value);
                     App.ChatService?.UpdateColorUserNameAsync(value);
+                }
+            }
+        }
+
+        public bool UseSenderColorForBubbles
+        {
+            get => _useSenderColorForBubbles;
+            set
+            {
+                if (_useSenderColorForBubbles != value)
+                {
+                    _useSenderColorForBubbles = value;
+                    OnPropertyChanged(nameof(UseSenderColorForBubbles));
+                    AppSettings.Set("UseSenderColorForBubbles", value ? "True" : "False");
+                    BubbleColorModeChanged?.Invoke(value);
                 }
             }
         }
@@ -262,6 +280,7 @@ namespace Client.ViewModel
             _appTheme = AppSettings.Get("AppTheme", "Dark");
             ApplyTheme(_appTheme);
             _colorUserName = Get("ColorUserName");
+            _useSenderColorForBubbles = AppSettings.Get("UseSenderColorForBubbles", "False") == "True";
 
             _shortcutF5Refraction = Get("ShortcutF5Refraction");
             _shortcutF5Lentilles = Get("ShortcutF5Lentilles");

--- a/docs/Personnalisation.md
+++ b/docs/Personnalisation.md
@@ -109,10 +109,29 @@ public bool IsOldSchoolMode
 ```
 【F:Client/ViewModel/SettingsViewModel.cs†L10-L36】
 
+```csharp
+public bool UseSenderColorForBubbles
+{
+    get => _useSenderColorForBubbles;
+    set
+    {
+        if (_useSenderColorForBubbles != value)
+        {
+            _useSenderColorForBubbles = value;
+            OnPropertyChanged(nameof(UseSenderColorForBubbles));
+            AppSettings.Set("UseSenderColorForBubbles", value ? "True" : "False");
+            BubbleColorModeChanged?.Invoke(value);
+        }
+    }
+}
+```
+【F:Client/ViewModel/SettingsViewModel.cs†L110-L123】
+
 ## Autres réglages
 
 * Taille de la police des messages (`MessageFontSize`).
 * Adresse du serveur SignalR (chargée au démarrage dans `SignalRService`).
 * Mémorisation de l'utilisateur sélectionné pour l'envoi des messages (`AppSettings.CurrentSelectedUser`).
+* Couleur des bulles basée sur celle de l'expéditeur (`UseSenderColorForBubbles`).
 
 Ces paramètres sont tous stockés localement afin d'être conservés entre les sessions de l'application.


### PR DESCRIPTION
## Summary
- support colorizing bubbles with sender color
- expose toggle in appearance settings
- document new `UseSenderColorForBubbles` setting

## Testing
- `dotnet build WebApplication1.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687138e039e483249a74a327d40fbd99