### PR TITLE
Handle dynamic text contrast in colored chat bubbles

### DIFF
--- a/Client/Models/ChatMessageModel.cs
+++ b/Client/Models/ChatMessageModel.cs
@@ -29,7 +29,8 @@ namespace Client.Models
                 if (_senderColor != value)
                 {
                     _senderColor = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(SenderColor)));
+                    OnPropertyChanged(nameof(SenderColor));
+                    OnPropertyChanged(nameof(ForegroundColor));
                 }
             }
         }
@@ -43,10 +44,15 @@ namespace Client.Models
                 if (_destinataireColor != value)
                 {
                     _destinataireColor = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(DestinataireColor)));
+                    OnPropertyChanged(nameof(DestinataireColor));
                 }
             }
         }
+
+        public string ForegroundColor =>
+            ColorUtils.ToHex(
+                ColorUtils.GetContrastingTextColor(
+                    ColorUtils.FromHex(SenderColor)));
 
         public DateTime Timestamp { get; set; }
         public bool IsDeleted { get; set; }
@@ -122,5 +128,8 @@ namespace Client.Models
             if (last < text.Length)
                 container.Add(new Run { Text = text[last..] });
         }
+
+        private void OnPropertyChanged(string propertyName) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 }

--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -83,11 +83,11 @@
                     <StackPanel MinWidth="200">
                         <RichTextBlock IsTextSelectionEnabled="True" MaxWidth="500" ContextFlyout="{StaticResource MessageContextMenu}"  Loaded="{x:Bind FormatContent}">
                             <Paragraph>
-                                <Run Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextMyMessageColor}"/>
+                                <Run Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{x:Bind ForegroundColor}"/>
                             </Paragraph>
-                            <Paragraph x:Name="ContentParagraph" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextMyMessageColor}"/>
+                            <Paragraph x:Name="ContentParagraph" FontSize="{ThemeResource MessageFontSize}" Foreground="{x:Bind ForegroundColor}"/>
                             <Paragraph TextAlignment="Right">
-                                <Run Text="{x:Bind IrcTimestamp}" FontSize="12" Foreground="{ThemeResource TextMyMessageColor}"/>
+                                <Run Text="{x:Bind IrcTimestamp}" FontSize="12" Foreground="{x:Bind ForegroundColor}"/>
                             </Paragraph>
                         </RichTextBlock>
                     </StackPanel>


### PR DESCRIPTION
## Summary
- compute text color automatically for colored chat bubbles
- use new `ForegroundColor` property from `ChatMessageModel` in colored templates

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68722df9814483249cf6a4dbe3d9c37a