### PR TITLE
Reconnect button improvements

### DIFF
--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -418,6 +418,6 @@
                 <ThemeShadow/>
             </TextBox.Shadow>
         </TextBox>
-        <Button x:Name="ReconnectButton" Grid.Column="2" Grid.Row="1" Content="Reconnecter" Click="Reconnect_Click" HorizontalAlignment="Right"/>
+        <Button x:Name="ReconnectButton" Grid.Column="2" Grid.Row="1" Content="Reconnecter" Visibility="Collapsed" Click="Reconnect_Click" HorizontalAlignment="Right"/>
     </Grid>
 </Page>

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -56,6 +56,7 @@ namespace Client.Pages
             _service.OnMessageReceived += OnMessageReceived;
             _service.OnPatientRemoved += Service_OnPatientRemoved;
             _service.OnPatientUpdated += Service_OnPatientUpdated;
+            _service.ReconnectCountdownChanged += Service_ReconnectCountdownChanged;
             Loaded += ChatPage_Loaded;
             Unloaded += ChatPage_Unloaded;
         }
@@ -65,6 +66,7 @@ namespace Client.Pages
             _service.OnMessageReceived -= OnMessageReceived;
             _service.OnPatientRemoved -= Service_OnPatientRemoved;
             _service.OnPatientUpdated -= Service_OnPatientUpdated;
+            _service.ReconnectCountdownChanged -= Service_ReconnectCountdownChanged;
             ViewModel.ViewModel.SettingsViewModel.DisplayStyleChanged -= ApplyChatStyle;
             ViewModel.ViewModel.SettingsViewModel.BubbleColorModeChanged -= ApplyBubbleColorMode;
             Patients.CollectionChanged -= Patients_CollectionChanged;
@@ -90,6 +92,7 @@ namespace Client.Pages
 
             TryRestoreUserSelection();
             await WaitForConnectionReady();
+            UpdateReconnectButtonVisibility();
 
             if (!_service.IsHistoryLoaded && !Messages.OfType<ChatMessageModel>().Any())
             {
@@ -115,6 +118,18 @@ namespace Client.Pages
             }
 
             InputBox.Focus(FocusState.Programmatic);
+        }
+
+        private void UpdateReconnectButtonVisibility()
+        {
+            if (_service.Connection == null || _service.Connection.State != HubConnectionState.Connected)
+            {
+                ReconnectButton.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                ReconnectButton.Visibility = Visibility.Collapsed;
+            }
         }
 
         public void FocusInputBox()
@@ -545,6 +560,22 @@ namespace Client.Pages
         private void Service_OnPatientUpdated(Patient patient)
         {
             DispatcherQueue.TryEnqueue(UpdatePatientViews);
+        }
+
+        private void Service_ReconnectCountdownChanged(int seconds)
+        {
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                if (_service.Connection == null || _service.Connection.State != HubConnectionState.Connected)
+                {
+                    ReconnectButton.Visibility = Visibility.Visible;
+                    ReconnectButton.Content = $"Reconnecter ({seconds})";
+                }
+                else
+                {
+                    ReconnectButton.Visibility = Visibility.Collapsed;
+                }
+            });
         }
 
         private IEnumerable<Patient> GetPatientsForRoom(string room)

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -37,6 +37,9 @@ namespace Client.Services
         private string _avatar = string.Empty;
         private string _color = string.Empty;
         private Timer? _reconnectTimer;
+        private Timer? _reconnectCountdownTimer;
+        private int _reconnectCountdown;
+        public event Action<int>? ReconnectCountdownChanged;
         private bool _isConnecting;
 
         public bool IsHistoryLoaded => _historyLoaded;
@@ -431,6 +434,20 @@ namespace Client.Services
         private void StartReconnectTimer()
         {
             _reconnectTimer?.Dispose();
+            _reconnectCountdownTimer?.Dispose();
+
+            _reconnectCountdown = 10;
+            ReconnectCountdownChanged?.Invoke(_reconnectCountdown);
+
+            _reconnectCountdownTimer = new Timer(_ =>
+            {
+                _reconnectCountdown--;
+                if (_reconnectCountdown >= 0)
+                    ReconnectCountdownChanged?.Invoke(_reconnectCountdown);
+                if (_reconnectCountdown <= 0)
+                    _reconnectCountdown = 10;
+            }, null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+
             _reconnectTimer = new Timer(async _ =>
             {
                 await ReconnectAsync();
@@ -442,6 +459,10 @@ namespace Client.Services
             _reconnectTimer?.Change(Timeout.Infinite, Timeout.Infinite);
             _reconnectTimer?.Dispose();
             _reconnectTimer = null;
+            _reconnectCountdownTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+            _reconnectCountdownTimer?.Dispose();
+            _reconnectCountdownTimer = null;
+            ReconnectCountdownChanged?.Invoke(0);
         }
 
         public async Task ReconnectAsync()


### PR DESCRIPTION
## Summary
- start a countdown timer in `SignalRService` and notify listeners via `ReconnectCountdownChanged`
- expose countdown on `ChatPage` to update reconnect button
- hide reconnect button by default and only show when disconnected

## Testing
- `dotnet build WebApplication1.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873b200a034832483bd57b993f83468