### PR TITLE
Add /getallsalon debug command

### DIFF
--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -226,7 +226,16 @@ namespace Client.Pages
             if (e.Key == Windows.System.VirtualKey.Enter)
             {
                 e.Handled = true;
-                Send_Click(sender, e);
+                var text = InputBox.Text.Trim();
+                if (string.Equals(text, "/getallsalon", StringComparison.OrdinalIgnoreCase))
+                {
+                    _ = ShowAllGroupsDialog();
+                    InputBox.Text = string.Empty;
+                }
+                else
+                {
+                    Send_Click(sender, e);
+                }
             }
         }
 
@@ -675,6 +684,25 @@ namespace Client.Pages
             }
         }
 
+        private async Task ShowAllGroupsDialog()
+        {
+            var groups = await _service.GetAllGroupsAsync();
+            var sb = new StringBuilder();
+            foreach (var kvp in groups)
+            {
+                sb.AppendLine($"{kvp.Key}: {string.Join(", ", kvp.Value)}");
+            }
+
+            var dialog = new ContentDialog
+            {
+                Title = "Groupes",
+                Content = new ScrollViewer { Content = new TextBlock { Text = sb.ToString() } },
+                CloseButtonText = "Fermer",
+                XamlRoot = (this.Content as FrameworkElement)?.XamlRoot
+            };
+
+            await dialog.ShowAsync();
+        }
 
         private async void DeleteMessage_Click(object sender, RoutedEventArgs e)
         {

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -800,5 +800,24 @@ namespace Client.Services
                 }
             }
         }
+
+        public async Task<Dictionary<string, List<string>>> GetAllGroupsAsync()
+        {
+            if (Connection is null || Connection.State != HubConnectionState.Connected)
+            {
+                var connected = await TryReconnectAsync();
+                if (!connected) return new Dictionary<string, List<string>>();
+            }
+
+            try
+            {
+                return await Connection.InvokeAsync<Dictionary<string, List<string>>>("GetAllGroupMembers");
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur r\u00e9cup\u00e9ration groupes : {ex.Message}");
+                return new Dictionary<string, List<string>>();
+            }
+        }
     }
 }

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -531,5 +531,11 @@ namespace ChatServeur
                 await Clients.All.SendAsync("PatientUpdated", patient);
             }
         }
+
+        public Task<Dictionary<string, List<string>>> GetAllGroupMembers()
+        {
+            var result = GroupMembers.ToDictionary(g => g.Key, g => g.Value.ToList());
+            return Task.FromResult(result);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- expose server-side method to return all group members
- add SignalR client wrapper for retrieving groups
- add `/getallsalon` command in chat page to show group membership

## Testing
- `dotnet build Serveur/Serveur.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6886244e66a48324958506f277f5a8db