### PR TITLE
Implement /setroom debug command

### DIFF
--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -232,6 +232,11 @@ namespace Client.Pages
                     _ = ShowAllGroupsDialog();
                     InputBox.Text = string.Empty;
                 }
+                else if (string.Equals(text, "/setroom", StringComparison.OrdinalIgnoreCase))
+                {
+                    _ = ShowSetRoomDialog();
+                    InputBox.Text = string.Empty;
+                }
                 else
                 {
                     Send_Click(sender, e);
@@ -701,6 +706,71 @@ namespace Client.Pages
                 XamlRoot = (this.Content as FrameworkElement)?.XamlRoot
             };
 
+            await dialog.ShowAsync();
+        }
+
+        private async Task ShowSetRoomDialog()
+        {
+            var groups = await _service.GetAllGroupsAsync();
+
+            var dialog = new ContentDialog
+            {
+                Title = "Edition de salle",
+                CloseButtonText = "Fermer",
+                XamlRoot = (this.Content as FrameworkElement)?.XamlRoot
+            };
+
+            var stack = new StackPanel { Spacing = 10 };
+            var roomBox = new ComboBox { ItemsSource = groups.Keys.ToList(), PlaceholderText = "Salle" };
+            var nameBox = new TextBox { PlaceholderText = "Nouveau nom" };
+            var pwdBox = new PasswordBox { PlaceholderText = "Nouveau mot de passe" };
+            var membersList = new ListView { Height = 100 };
+
+            roomBox.SelectionChanged += (s, e) =>
+            {
+                if (roomBox.SelectedItem is string sel && groups.TryGetValue(sel, out var list))
+                    membersList.ItemsSource = list;
+            };
+
+            var renameBtn = new Button { Content = "Renommer" };
+            renameBtn.Click += async (s, e) =>
+            {
+                if (roomBox.SelectedItem is string sel && !string.IsNullOrWhiteSpace(nameBox.Text))
+                {
+                    await _service.RenameGroupAsync(sel, nameBox.Text);
+                }
+            };
+
+            var passBtn = new Button { Content = "Changer mot de passe" };
+            passBtn.Click += async (s, e) =>
+            {
+                if (roomBox.SelectedItem is string sel)
+                {
+                    await _service.ChangeGroupPasswordAsync(sel, pwdBox.Password);
+                }
+            };
+
+            var removeBtn = new Button { Content = "Supprimer utilisateur" };
+            removeBtn.Click += async (s, e) =>
+            {
+                if (roomBox.SelectedItem is string sel && membersList.SelectedItem is string user)
+                {
+                    await _service.RemoveUserFromGroupAsync(sel, user);
+                }
+            };
+
+            var btns = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 10 };
+            btns.Children.Add(renameBtn);
+            btns.Children.Add(passBtn);
+            btns.Children.Add(removeBtn);
+
+            stack.Children.Add(roomBox);
+            stack.Children.Add(nameBox);
+            stack.Children.Add(pwdBox);
+            stack.Children.Add(membersList);
+            stack.Children.Add(btns);
+
+            dialog.Content = stack;
             await dialog.ShowAsync();
         }
 

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -819,5 +819,59 @@ namespace Client.Services
                 return new Dictionary<string, List<string>>();
             }
         }
+
+        public async Task RenameGroupAsync(string oldName, string newName)
+        {
+            if (Connection is null || Connection.State != HubConnectionState.Connected)
+            {
+                var connected = await TryReconnectAsync();
+                if (!connected) return;
+            }
+
+            try
+            {
+                await Connection.InvokeAsync("RenameGroup", oldName, newName);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur renommage groupe : {ex.Message}");
+            }
+        }
+
+        public async Task ChangeGroupPasswordAsync(string groupName, string password)
+        {
+            if (Connection is null || Connection.State != HubConnectionState.Connected)
+            {
+                var connected = await TryReconnectAsync();
+                if (!connected) return;
+            }
+
+            try
+            {
+                await Connection.InvokeAsync("ChangeGroupPassword", groupName, password);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur changement mot de passe groupe : {ex.Message}");
+            }
+        }
+
+        public async Task RemoveUserFromGroupAsync(string groupName, string username)
+        {
+            if (Connection is null || Connection.State != HubConnectionState.Connected)
+            {
+                var connected = await TryReconnectAsync();
+                if (!connected) return;
+            }
+
+            try
+            {
+                await Connection.InvokeAsync("RemoveUserFromGroup", groupName, username);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur suppression utilisateur groupe : {ex.Message}");
+            }
+        }
     }
 }

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -537,5 +537,71 @@ namespace ChatServeur
             var result = GroupMembers.ToDictionary(g => g.Key, g => g.Value.ToList());
             return Task.FromResult(result);
         }
+
+        public async Task RenameGroup(string oldName, string newName)
+        {
+            var secure = await _db.SecureGroups.FirstOrDefaultAsync(g => g.Name == oldName);
+            if (secure != null)
+            {
+                secure.Name = newName;
+                _db.SecureGroups.Update(secure);
+            }
+
+            var memberships = await _db.GroupMemberships.Where(m => m.GroupName == oldName).ToListAsync();
+            foreach (var m in memberships)
+                m.GroupName = newName;
+            if (memberships.Count > 0)
+                _db.GroupMemberships.UpdateRange(memberships);
+
+            await _db.SaveChangesAsync();
+
+            if (GroupMembers.TryGetValue(oldName, out var members))
+            {
+                GroupMembers.Remove(oldName);
+                GroupMembers[newName] = members;
+
+                foreach (var user in members)
+                {
+                    if (_userToConnectionId.TryGetValue(user, out var conn))
+                    {
+                        await Groups.RemoveFromGroupAsync(conn, oldName);
+                        await Groups.AddToGroupAsync(conn, newName);
+                    }
+                }
+            }
+        }
+
+        public async Task ChangeGroupPassword(string groupName, string password)
+        {
+            var group = await _db.SecureGroups.FirstOrDefaultAsync(g => g.Name == groupName);
+            if (group == null)
+            {
+                group = new SecureGroup { Name = groupName, PasswordHash = HashPassword(password) };
+                _db.SecureGroups.Add(group);
+            }
+            else
+            {
+                group.PasswordHash = HashPassword(password);
+                _db.SecureGroups.Update(group);
+            }
+
+            await _db.SaveChangesAsync();
+        }
+
+        public async Task RemoveUserFromGroup(string groupName, string username)
+        {
+            var member = await _db.GroupMemberships.FirstOrDefaultAsync(m => m.GroupName == groupName && m.Username == username);
+            if (member != null)
+            {
+                _db.GroupMemberships.Remove(member);
+                await _db.SaveChangesAsync();
+            }
+
+            if (GroupMembers.TryGetValue(groupName, out var list))
+                list.Remove(username);
+
+            if (_userToConnectionId.TryGetValue(username, out var conn))
+                await Groups.RemoveFromGroupAsync(conn, groupName);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add RenameGroup, ChangeGroupPassword and RemoveUserFromGroup in `ChatHub`
- expose new methods from `SignalRService`
- implement `/setroom` debug command and dialog in `ChatPage`

## Testing
- `dotnet build Serveur/Serveur.csproj -c Release`
- `dotnet build WebApplication1.sln -c Release` *(fails: XamlCompiler.exe exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68862972e51483249caf6bb33957407d