### PR TITLE
Fix message bubble binding and username

### DIFF
--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -13,11 +13,11 @@
             <StackPanel HorizontalAlignment="Left">
                 <Border CornerRadius="10" Padding="10" Margin="5" MaxWidth="800" HorizontalAlignment="Left" Background="{ThemeResource OtherMessageColor}">
                     <StackPanel Orientation="Horizontal" Spacing="10" MinWidth="180">
-                        <Image Source="{x:Bind Avatar}" Width="40" Height="40"/>
+                        <Image Source="{x:Bind Avatar, Mode=OneWay}" Width="40" Height="40"/>
                         <StackPanel MinWidth="200">
-                            <TextBlock Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextOtherMessageColor}"/>
-                            <TextBlock Text="{x:Bind Content}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextOtherMessageColor}"/>
-                            <TextBlock Text="{x:Bind TimeFormatted}" FontSize="12" HorizontalAlignment="Right" Foreground="{ThemeResource TextOtherMessageColor}"/>
+                            <TextBlock Text="{x:Bind Header, Mode=OneWay}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextOtherMessageColor}"/>
+                            <TextBlock Text="{x:Bind Content, Mode=OneWay}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextOtherMessageColor}"/>
+                            <TextBlock Text="{x:Bind TimeFormatted, Mode=OneWay}" FontSize="12" HorizontalAlignment="Right" Foreground="{ThemeResource TextOtherMessageColor}"/>
                         </StackPanel>
                     </StackPanel>
                 </Border>
@@ -27,11 +27,11 @@
         <DataTemplate x:Key="MyMessageTemplate" x:DataType="data:ChatMessageModel">
             <Border CornerRadius="10" Padding="10" Margin="5" MaxWidth="800" HorizontalAlignment="Right" Background="{ThemeResource MyMessageColor}">
                 <StackPanel Orientation="Horizontal" Spacing="10" MinWidth="180">
-                    <Image Source="{x:Bind Avatar}" Width="40" Height="40" VerticalAlignment="Top"/>
+                    <Image Source="{x:Bind Avatar, Mode=OneWay}" Width="40" Height="40" VerticalAlignment="Top"/>
                     <StackPanel MinWidth="200">
-                        <TextBlock Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextMyMessageColor}"/>
-                        <TextBlock Text="{x:Bind Content}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}" MaxWidth="500" HorizontalAlignment="Left" Foreground="{ThemeResource TextMyMessageColor}"/>
-                        <TextBlock Text="{x:Bind TimeFormatted}" FontSize="12" HorizontalAlignment="Right" Foreground="{ThemeResource TextMyMessageColor}"/>
+                        <TextBlock Text="{x:Bind Header, Mode=OneWay}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextMyMessageColor}"/>
+                        <TextBlock Text="{x:Bind Content, Mode=OneWay}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}" MaxWidth="500" HorizontalAlignment="Left" Foreground="{ThemeResource TextMyMessageColor}"/>
+                        <TextBlock Text="{x:Bind TimeFormatted, Mode=OneWay}" FontSize="12" HorizontalAlignment="Right" Foreground="{ThemeResource TextMyMessageColor}"/>
                     </StackPanel>
                 </StackPanel>
             </Border>
@@ -41,11 +41,11 @@
             <StackPanel HorizontalAlignment="Left">
                 <Border CornerRadius="10" Padding="10" Margin="5" MaxWidth="800" HorizontalAlignment="Left" Background="{x:Bind SenderColor, Converter={StaticResource StringToColorConverter}}">
                     <StackPanel Orientation="Horizontal" Spacing="10" MinWidth="180">
-                        <Image Source="{x:Bind Avatar}" Width="40" Height="40"/>
+                        <Image Source="{x:Bind Avatar, Mode=OneWay}" Width="40" Height="40"/>
                         <StackPanel MinWidth="200">
-                            <TextBlock Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{x:Bind SenderTextColor, Converter={StaticResource StringToColorConverter}}"/>
-                            <TextBlock Text="{x:Bind Content}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}" Foreground="{x:Bind SenderTextColor, Converter={StaticResource StringToColorConverter}}"/>
-                            <TextBlock Text="{x:Bind TimeFormatted}" FontSize="12" HorizontalAlignment="Right" Foreground="{x:Bind SenderTextColor, Converter={StaticResource StringToColorConverter}}"/>
+                            <TextBlock Text="{x:Bind Header, Mode=OneWay}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{x:Bind SenderTextColor, Converter={StaticResource StringToColorConverter}}"/>
+                            <TextBlock Text="{x:Bind Content, Mode=OneWay}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}" Foreground="{x:Bind SenderTextColor, Converter={StaticResource StringToColorConverter}}"/>
+                            <TextBlock Text="{x:Bind TimeFormatted, Mode=OneWay}" FontSize="12" HorizontalAlignment="Right" Foreground="{x:Bind SenderTextColor, Converter={StaticResource StringToColorConverter}}"/>
                         </StackPanel>
                     </StackPanel>
                 </Border>
@@ -55,11 +55,11 @@
         <DataTemplate x:Key="MyColoredTemplate" x:DataType="data:ChatMessageModel">
             <Border CornerRadius="10" Padding="10" Margin="5" MaxWidth="800" HorizontalAlignment="Right" Background="{x:Bind SenderColor, Converter={StaticResource StringToColorConverter}}">
                 <StackPanel Orientation="Horizontal" Spacing="10" MinWidth="180">
-                    <Image Source="{x:Bind Avatar}" Width="40" Height="40" VerticalAlignment="Top"/>
+                    <Image Source="{x:Bind Avatar, Mode=OneWay}" Width="40" Height="40" VerticalAlignment="Top"/>
                     <StackPanel MinWidth="200">
-                        <TextBlock Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{x:Bind SenderTextColor, Converter={StaticResource StringToColorConverter}}"/>
-                        <TextBlock Text="{x:Bind Content}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}" MaxWidth="500" HorizontalAlignment="Left" Foreground="{x:Bind SenderTextColor, Converter={StaticResource StringToColorConverter}}"/>
-                        <TextBlock Text="{x:Bind TimeFormatted}" FontSize="12" HorizontalAlignment="Right" Foreground="{x:Bind SenderTextColor, Converter={StaticResource StringToColorConverter}}"/>
+                        <TextBlock Text="{x:Bind Header, Mode=OneWay}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{x:Bind SenderTextColor, Converter={StaticResource StringToColorConverter}}"/>
+                        <TextBlock Text="{x:Bind Content, Mode=OneWay}" TextWrapping="Wrap" FontSize="{ThemeResource MessageFontSize}" MaxWidth="500" HorizontalAlignment="Left" Foreground="{x:Bind SenderTextColor, Converter={StaticResource StringToColorConverter}}"/>
+                        <TextBlock Text="{x:Bind TimeFormatted, Mode=OneWay}" FontSize="12" HorizontalAlignment="Right" Foreground="{x:Bind SenderTextColor, Converter={StaticResource StringToColorConverter}}"/>
                     </StackPanel>
                 </StackPanel>
             </Border>
@@ -75,7 +75,7 @@
 
         <!-- 📭 Placeholder vide -->
         <DataTemplate x:Key="EmptyTemplate" x:DataType="data:EmptyPlaceholder">
-            <TextBlock Text="{x:Bind Message}"
+            <TextBlock Text="{x:Bind Message, Mode=OneWay}"
                HorizontalAlignment="Center"
                FontStyle="Italic"
                Foreground="Gray"
@@ -89,12 +89,12 @@
                HorizontalAlignment="Left"
                        TextWrapping="Wrap"
                        MaxWidth="1000"
-               Text="{x:Bind IrcHeader}">
+               Text="{x:Bind IrcHeader, Mode=OneWay}">
             </TextBlock>
         </DataTemplate>
         
         <data:ChatMessageTemplateSelector x:Key="MessageTemplateSelector"
-            MyUsername="Moi"
+            MyUsername="Benoit"
             MyMessageTemplate="{StaticResource MyMessageTemplate}"
             OtherMessageTemplate="{StaticResource OtherMessageTemplate}"
             MyColoredMessageTemplate="{StaticResource MyColoredTemplate}"
@@ -160,8 +160,8 @@
         </MenuFlyout>
         <DataTemplate x:Key="UserTemplate" x:DataType="data:UserInfo">
             <StackPanel Orientation="Horizontal" Spacing="8" Padding="4">
-                <Image Source="{x:Bind Avatar}" Width="32" Height="32"/>
-                <TextBlock Text="{x:Bind Name}" VerticalAlignment="Center"/>
+                <Image Source="{x:Bind Avatar, Mode=OneWay}" Width="32" Height="32"/>
+                <TextBlock Text="{x:Bind Name, Mode=OneWay}" VerticalAlignment="Center"/>
             </StackPanel>
         </DataTemplate>
         
@@ -185,7 +185,7 @@
 
         <ListView x:Name="UsersList"
                   Grid.Column="2"
-                  ItemsSource="{x:Bind ConnectedUsers}"
+                  ItemsSource="{x:Bind ConnectedUsers, Mode=OneWay}"
                   ItemContainerStyle="{StaticResource UserListItemStyle}"
                   SelectionChanged="UsersList_SelectionChanged"
                   SelectionMode="Single">
@@ -195,10 +195,10 @@
                                 Spacing="10"
                                 Padding="5"
                                 ContextFlyout="{StaticResource UserContextMenu}">
-                        <Image Source="{x:Bind Avatar}" Width="40" Height="40"/>
+                        <Image Source="{x:Bind Avatar, Mode=OneWay}" Width="40" Height="40"/>
                         <StackPanel>
-                            <TextBlock Text="{x:Bind Username}" FontWeight="Bold"/>
-                            <TextBlock Text="{x:Bind Room, FallbackValue='Offline'}"/>
+                            <TextBlock Text="{x:Bind Username, Mode=OneWay}" FontWeight="Bold"/>
+                            <TextBlock Text="{x:Bind Room, Mode=OneWay, FallbackValue='Offline'}"/>
                         </StackPanel>
                     </StackPanel>
                 </DataTemplate>

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -39,6 +39,11 @@ namespace Client.Pages
             MessagesList.ItemsSource = Messages;
             _service.Dispatcher = DispatcherQueue;
 
+            if (Resources["MessageTemplateSelector"] is ChatMessageTemplateSelector selector)
+            {
+                selector.MyUsername = _service.Username;
+            }
+
             ViewModel.ViewModel.SettingsViewModel.DisplayStyleChanged += ApplyChatStyle;
             ViewModel.ViewModel.SettingsViewModel.SenderColorModeChanged += ApplyColorMode;
             _service.ConnectedUsers.CollectionChanged += (_, _) => DispatcherQueue.TryEnqueue(TryRestoreUserSelection);
@@ -65,6 +70,10 @@ namespace Client.Pages
             if (_service.Connection == null || _service.Connection.State != HubConnectionState.Connected)
             {
                 await _service.InitializeAsync();
+                if (Resources["MessageTemplateSelector"] is ChatMessageTemplateSelector selector)
+                {
+                    selector.MyUsername = _service.Username;
+                }
             }
 
             TryRestoreUserSelection();
@@ -79,7 +88,7 @@ namespace Client.Pages
                 foreach (var msg in cachedMessages)
                     Messages.Add(msg);
 
-                var result = await _service.LoadTodayMessagesAsync("Benoit");
+                var result = await _service.LoadTodayMessagesAsync(_service.Username);
                 if (result.Success)
                 {
                     foreach (var item in Messages.OfType<ChatMessageModel>().ToList())
@@ -162,7 +171,7 @@ namespace Client.Pages
             {
                 if (user != null)
                 {
-                    await _service.SendMessage("Benoit", "RDC", user.Username, text, @"E:\benoit.png", DateTime.Now);
+                    await _service.SendMessage(_service.Username, "RDC", user.Username, text, @"E:\benoit.png", DateTime.Now);
                     Debug.WriteLine($"📤 Message envoyé à {user.Username}: {text}");
                     InputBox.Text = string.Empty;
                 }
@@ -180,7 +189,7 @@ namespace Client.Pages
 
         private async Task LoadHistoryAsync(string withUser)
         {
-            var username = "Benoit";
+            var username = _service.Username;
 
             try
             {
@@ -258,7 +267,7 @@ namespace Client.Pages
                 _currentDate = _currentDate.AddDays(-1);
                 tryCount++;
 
-                var result = await _service.LoadMessagesForDateAsync("Moi", _currentDate);
+                var result = await _service.LoadMessagesForDateAsync(_service.Username, _currentDate);
 
                 if (result.Success && result.Value.Any())
                 {

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -28,6 +28,8 @@ namespace Client.Services
         public ObservableCollection<Patient> Patients { get; } = new();
         public ObservableCollection<object> Messages { get; } = new();
 
+        public string Username { get; private set; } = "Benoit";
+
         private bool _initialized;
         private bool _historyLoaded;
 
@@ -66,7 +68,7 @@ namespace Client.Services
                 ConnectedUsers.Add(user);
             }
 
-            await ConnectAsync("Benoit", @"E:\benoit.png", "RDC");
+            await ConnectAsync(Username, @"E:\benoit.png", "RDC");
 
             Messages.Clear();
             Messages.Add(new LoadMorePlaceholder());
@@ -75,7 +77,7 @@ namespace Client.Services
             foreach (var msg in cached)
                 Messages.Add(msg);
 
-            var result = await LoadTodayMessagesAsync("Benoit");
+            var result = await LoadTodayMessagesAsync(Username);
             if (result.Success)
             {
                 foreach (var item in Messages.OfType<ChatMessageModel>().ToList())
@@ -102,6 +104,8 @@ namespace Client.Services
                     Debug.WriteLine($"❌ Error disposing previous connection: {ex.Message}");
                 }
             }
+
+            Username = username;
 
             Connection = new HubConnectionBuilder()
                 .WithUrl($"{ServerAddress}/chatHub")


### PR DESCRIPTION
## Summary
- ensure messages use OneWay bindings in ChatPage templates to avoid recycling issues
- update message template selector with correct username
- expose username in `SignalRService` and use it for message operations

## Testing
- `dotnet build Serveur/Serveur.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68864006366c832486a7beeada50c598