### PR TITLE
Fix message rendering after deletions master 2

### DIFF
--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -21,7 +21,7 @@
                     <StackPanel Orientation="Horizontal" Spacing="10" MinWidth="180">
                         <Image Source="{x:Bind Avatar}" Width="40" Height="40"/>
                         <StackPanel MinWidth="200">
-                            <RichTextBlock IsTextSelectionEnabled="True" MaxWidth="500" ContextFlyout="{StaticResource MessageContextMenu}"  Loaded="{x:Bind FormatContent}">
+                            <RichTextBlock IsTextSelectionEnabled="True" MaxWidth="500" ContextFlyout="{StaticResource MessageContextMenu}"  Loaded="{x:Bind FormatContent}" DataContextChanged="Message_DataContextChanged">
                                 <Paragraph>
                                     <Run Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextOtherMessageColor}"/>
                                 </Paragraph>
@@ -42,7 +42,7 @@
                     <StackPanel Orientation="Horizontal" Spacing="10" MinWidth="180">
                         <Image Source="{x:Bind Avatar}" Width="40" Height="40"/>
                         <StackPanel MinWidth="200">
-                            <RichTextBlock IsTextSelectionEnabled="True" MaxWidth="500" ContextFlyout="{StaticResource MessageContextMenu}"  Loaded="{x:Bind FormatContent}">
+                            <RichTextBlock IsTextSelectionEnabled="True" MaxWidth="500" ContextFlyout="{StaticResource MessageContextMenu}"  Loaded="{x:Bind FormatContent}" DataContextChanged="Message_DataContextChanged">
                                 <Paragraph>
                                     <Run Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{x:Bind ForegroundColor}"/>
                                 </Paragraph>
@@ -62,7 +62,7 @@
                 <StackPanel Orientation="Horizontal" Spacing="10" MinWidth="180">
                     <Image Source="{x:Bind Avatar}" Width="40" Height="40" VerticalAlignment="Top"/>
                     <StackPanel MinWidth="200">
-                        <RichTextBlock IsTextSelectionEnabled="True" MaxWidth="500" ContextFlyout="{StaticResource MessageContextMenu}"  Loaded="{x:Bind FormatContent}">
+                        <RichTextBlock IsTextSelectionEnabled="True" MaxWidth="500" ContextFlyout="{StaticResource MessageContextMenu}"  Loaded="{x:Bind FormatContent}" DataContextChanged="Message_DataContextChanged">
                             <Paragraph>
                                 <Run Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{ThemeResource TextMyMessageColor}"/>
                             </Paragraph>
@@ -81,7 +81,7 @@
                 <StackPanel Orientation="Horizontal" Spacing="10" MinWidth="180">
                     <Image Source="{x:Bind Avatar}" Width="40" Height="40" VerticalAlignment="Top"/>
                     <StackPanel MinWidth="200">
-                        <RichTextBlock IsTextSelectionEnabled="True" MaxWidth="500" ContextFlyout="{StaticResource MessageContextMenu}"  Loaded="{x:Bind FormatContent}">
+                        <RichTextBlock IsTextSelectionEnabled="True" MaxWidth="500" ContextFlyout="{StaticResource MessageContextMenu}"  Loaded="{x:Bind FormatContent}" DataContextChanged="Message_DataContextChanged">
                             <Paragraph>
                                 <Run Text="{x:Bind Header}" FontWeight="Bold" FontSize="{ThemeResource MessageFontSize}" Foreground="{x:Bind ForegroundColor}"/>
                             </Paragraph>
@@ -124,7 +124,7 @@
                            MaxWidth="1000"
                            IsTextSelectionEnabled="True"
                            ContextFlyout="{StaticResource MessageContextMenu}"
-                           Loaded="{x:Bind FormatContent}">
+                           Loaded="{x:Bind FormatContent}" DataContextChanged="Message_DataContextChanged">
                 <Paragraph>
                     <Run Text="{x:Bind IrcTimestampWithBrackets}" Foreground="DarkViolet" />
                     <Run Text="&lt;" />

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -785,6 +785,14 @@ namespace Client.Pages
             await dialog.ShowAsync();
         }
 
+        private void Message_DataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
+        {
+            if (sender is RichTextBlock block && args.NewValue is ChatMessageModel msg)
+            {
+                msg.FormatContent(block, new RoutedEventArgs());
+            }
+        }
+
         private async void DeleteMessage_Click(object sender, RoutedEventArgs e)
         {
             if (_currentMessageTarget?.DataContext is ChatMessageModel msg)


### PR DESCRIPTION
## Summary
- ensure `RichTextBlock` refreshes when a message item changes
- add handler for `DataContextChanged`

## Testing
- `dotnet build Serveur/Serveur.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68865f1f8a9c8324a0a46d4aa92664b8