### PR TITLE
Add user initials setting

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -6,6 +6,7 @@ using Microsoft.Windows.AppNotifications.Builder;
 using Client.Models;
 using Client.Helpers;
 using Microsoft.UI.Xaml.Controls;
+using System.Linq;
 using System.IO;
 using Client.Pages;
 
@@ -142,6 +143,16 @@ namespace Client
             var titleBar = root.FindName("AppTitleBar") as Grid;
             var nav = root.FindName("nvSample") as NavigationView;
             var titleText = root.FindName("TitleBarTextBlock") as TextBlock;
+            if (root.FindName("PersonPic") is PersonPicture pic)
+            {
+                var initials = AppSettings.Get("Initials", string.Empty);
+                if (string.IsNullOrWhiteSpace(initials))
+                {
+                    initials = string.Concat(App.UserName.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                        .Select(s => char.ToUpperInvariant(s[0])));
+                }
+                pic.Initials = initials;
+            }
 
             AppearanceSettingsPage.ApplyColors(colors, titleBar, nav, titleText);
         }

--- a/Client/Pages/UserSettingsPage.xaml
+++ b/Client/Pages/UserSettingsPage.xaml
@@ -27,6 +27,10 @@
                     </Button.Flyout>
                 </Button>
             </StackPanel>
+            <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                <TextBlock Text="Initiales:" VerticalAlignment="Center"/>
+                <TextBox Text="{x:Bind ViewModelSettings.Initials, Mode=TwoWay}" Width="60"/>
+            </StackPanel>
             <Border CornerRadius="8" Padding="20">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Raccourcis en tête" FontSize="18" FontWeight="Bold"/>

--- a/Client/ViewModel/SettingsViewModel.cs
+++ b/Client/ViewModel/SettingsViewModel.cs
@@ -1,6 +1,8 @@
 using System;
 using System.ComponentModel;
+using System.Linq;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using Client.Helpers;
 using Client.Models;
 
@@ -12,6 +14,7 @@ namespace Client.ViewModel
         private double _messageFontSize = 14;
         private string _appTheme = "Dark";
         private string _colorUserName = "Black";
+        private string _initials = string.Empty;
         private string _shortcutF5Refraction = string.Empty;
         private string _shortcutF5Lentilles = string.Empty;
         private string _shortcutF5Pathologies = string.Empty;
@@ -103,6 +106,25 @@ namespace Client.ViewModel
                     OnPropertyChanged(nameof(ColorUserName));
                     Set("ColorUserName", value);
                     App.ChatService?.UpdateColorUserNameAsync(value);
+                }
+            }
+        }
+
+        public string Initials
+        {
+            get => _initials;
+            set
+            {
+                if (_initials != value)
+                {
+                    _initials = value;
+                    OnPropertyChanged(nameof(Initials));
+                    Set("Initials", value);
+                    if (App.MainWindow?.Content is FrameworkElement root &&
+                        root.FindName("PersonPic") is Microsoft.UI.Xaml.Controls.PersonPicture pic)
+                    {
+                        pic.Initials = value;
+                    }
                 }
             }
         }
@@ -280,6 +302,12 @@ namespace Client.ViewModel
             _appTheme = AppSettings.Get("AppTheme", "Dark");
             ApplyTheme(_appTheme);
             _colorUserName = Get("ColorUserName");
+            _initials = Get("Initials");
+            if (string.IsNullOrWhiteSpace(_initials))
+            {
+                _initials = string.Concat(App.UserName.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                    .Select(s => char.ToUpperInvariant(s[0])));
+            }
             _useSenderColorForBubbles = AppSettings.Get("UseSenderColorForBubbles", "False") == "True";
 
             _shortcutF5Refraction = Get("ShortcutF5Refraction");
@@ -313,6 +341,11 @@ namespace Client.ViewModel
 
             // update resources with loaded values
             Application.Current.Resources["MessageFontSize"] = _messageFontSize;
+            if (App.MainWindow?.Content is FrameworkElement root &&
+                root.FindName("PersonPic") is Microsoft.UI.Xaml.Controls.PersonPicture pic)
+            {
+                pic.Initials = _initials;
+            }
             OnPropertyChanged(string.Empty);
         }
 

--- a/docs/Personnalisation.md
+++ b/docs/Personnalisation.md
@@ -45,7 +45,7 @@ public string AppTheme
     }
 }
 ```
-【F:Client/ViewModel/SettingsViewModel.cs†L76-L89】
+【F:Client/ViewModel/SettingsViewModel.cs†L82-L95】
 
 Ces paramètres sont modifiables dans la page `AppearanceSettingsPage` où des sélecteurs de couleurs permettent de choisir la teinte voulue.
 
@@ -125,7 +125,7 @@ public bool UseSenderColorForBubbles
     }
 }
 ```
-【F:Client/ViewModel/SettingsViewModel.cs†L110-L123】
+【F:Client/ViewModel/SettingsViewModel.cs†L132-L145】
 
 ## Autres réglages
 
@@ -133,5 +133,6 @@ public bool UseSenderColorForBubbles
 * Adresse du serveur SignalR (chargée au démarrage dans `SignalRService`).
 * Mémorisation de l'utilisateur sélectionné pour l'envoi des messages (`AppSettings.CurrentSelectedUser`).
 * Couleur des bulles basée sur celle de l'expéditeur (`UseSenderColorForBubbles`).
+* Initiales affichées dans la barre de titre (`Initials`).
 
 Ces paramètres sont tous stockés localement afin d'être conservés entre les sessions de l'application.


### PR DESCRIPTION
## Summary
- allow setting initials for PersonPicture
- show initials in the title bar on load
- document the new `Initials` setting

## Testing
- `dotnet build WebApplication1.sln -p:EnableWindowsTargeting=true` *(fails: Xaml compiler exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_6887ae9cf3f483249f37c258a4df361a