### PR TITLE
Share user settings across clients

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -125,7 +125,8 @@ namespace Client
             if (!string.IsNullOrWhiteSpace(machine.RoomName) )
             {
                 ChatService.RoomName = machine.RoomName;
-                _ = ChatService.InitializeAsync();
+                await ChatService.InitializeAsync();
+                await SyncUserSettingsAsync(root);
             }
         }
 
@@ -213,6 +214,29 @@ namespace Client
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"❌ Toast error: {ex.Message}");
+            }
+        }
+
+        private async Task SyncUserSettingsAsync(FrameworkElement root)
+        {
+            try
+            {
+                var json = await ChatService.GetUserSettingsAsync(App.UserName);
+                if (!string.IsNullOrWhiteSpace(json))
+                {
+                    AppSettings.Import(json);
+                    ApplySavedAppearance(root);
+                }
+                else
+                {
+                    var local = AppSettings.Export();
+                    if (!string.IsNullOrWhiteSpace(local))
+                        await ChatService.SaveUserSettingsAsync(App.UserName, local);
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"❌ Sync settings error: {ex.Message}");
             }
         }
 

--- a/Client/Helpers/AppSettings.cs
+++ b/Client/Helpers/AppSettings.cs
@@ -94,6 +94,34 @@ namespace Client.Helpers
             Save();
         }
 
+        public static string Export()
+        {
+            try
+            {
+                return JsonSerializer.Serialize(_settings, new JsonSerializerOptions { WriteIndented = true });
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        public static void Import(string json)
+        {
+            try
+            {
+                var dict = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+                if (dict != null)
+                {
+                    _settings = dict;
+                    Save();
+                }
+            }
+            catch
+            {
+            }
+        }
+
         private static void Save()
         {
             try

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -693,6 +693,40 @@ namespace Client.Services
             }
         }
 
+        public async Task SaveUserSettingsAsync(string username, string json)
+        {
+            if (Connection is null || Connection.State != HubConnectionState.Connected)
+                throw new InvalidOperationException("Connexion SignalR non établie.");
+
+            try
+            {
+                await Connection.InvokeAsync("SaveUserSettings", username, json);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur envoi paramètres : {ex.Message}");
+            }
+        }
+
+        public async Task<string> GetUserSettingsAsync(string username)
+        {
+            if (Connection is null || Connection.State != HubConnectionState.Connected)
+            {
+                var connected = await TryReconnectAsync();
+                if (!connected) return string.Empty;
+            }
+
+            try
+            {
+                return await Connection.InvokeAsync<string?>("GetUserSettings", username) ?? string.Empty;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur récupération paramètres : {ex.Message}");
+                return string.Empty;
+            }
+        }
+
 
         public async Task<List<Patient>> GetPatientsAsync()
         {

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -302,6 +302,25 @@ namespace ChatServeur
             }
         }
 
+        public async Task SaveUserSettings(string username, string json)
+        {
+            var setting = await _db.UserSettings.FirstOrDefaultAsync(s => s.Username == username);
+            if (setting == null)
+            {
+                setting = new UserSetting { Username = username };
+                _db.UserSettings.Add(setting);
+            }
+
+            setting.SettingsJson = json;
+            await _db.SaveChangesAsync();
+        }
+
+        public async Task<string?> GetUserSettings(string username)
+        {
+            var setting = await _db.UserSettings.FirstOrDefaultAsync(s => s.Username == username);
+            return setting?.SettingsJson;
+        }
+
         public async Task SaveExamOptions(IEnumerable<ExamOption> options)
         {
             var json = JsonSerializer.Serialize(options);

--- a/Serveur/Models/ChatDbContext.cs
+++ b/Serveur/Models/ChatDbContext.cs
@@ -13,5 +13,6 @@ namespace ChatServeur
         public DbSet<SecureGroup> SecureGroups => Set<SecureGroup>();
         public DbSet<ServerConfig> ServerConfigs => Set<ServerConfig>();
         public DbSet<Patient> Patients => Set<Patient>();
+        public DbSet<UserSetting> UserSettings => Set<UserSetting>();
     }
 }

--- a/Serveur/Models/UserSetting.cs
+++ b/Serveur/Models/UserSetting.cs
@@ -1,0 +1,9 @@
+namespace ChatServeur
+{
+    public class UserSetting
+    {
+        public int Id { get; set; }
+        public string Username { get; set; } = string.Empty;
+        public string SettingsJson { get; set; } = string.Empty;
+    }
+}

--- a/Serveur/Program.cs
+++ b/Serveur/Program.cs
@@ -35,6 +35,7 @@ using (var scope = app.Services.CreateScope())
     db.Database.EnsureCreated();
     EnsureArchivedColumn(db);
     EnsureIsDeletedColumn(db);
+    EnsureUserSettingsTable(db);
     if (!db.ServerConfigs.Any())
     {
         db.ServerConfigs.Add(new ServerConfig());
@@ -95,6 +96,27 @@ void EnsureIsDeletedColumn(ChatDbContext db)
         if (!exists)
         {
             cmd.CommandText = "ALTER TABLE Messages ADD COLUMN IsDeleted INTEGER NOT NULL DEFAULT 0";
+            cmd.ExecuteNonQuery();
+        }
+    }
+    finally
+    {
+        connection.Close();
+    }
+}
+
+void EnsureUserSettingsTable(ChatDbContext db)
+{
+    var connection = db.Database.GetDbConnection();
+    connection.Open();
+    try
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name='UserSettings'";
+        var result = cmd.ExecuteScalar();
+        if (result == null)
+        {
+            cmd.CommandText = "CREATE TABLE UserSettings (Id INTEGER PRIMARY KEY AUTOINCREMENT, Username TEXT NOT NULL UNIQUE, SettingsJson TEXT NOT NULL)";
             cmd.ExecuteNonQuery();
         }
     }

--- a/docs/Personnalisation.md
+++ b/docs/Personnalisation.md
@@ -4,7 +4,7 @@ Cette page décrit les principaux éléments personnalisables de l'application *
 
 ## Couleurs de l'interface
 
-Le client permet de personnaliser les couleurs de la barre de titre, du menu de navigation, ainsi que les couleurs des bulles de messages. Ces valeurs sont sauvegardées localement dans un fichier *settings.json* lié à l'utilisateur courant et sont appliquées via `AppSettings.SetObject("Colors", ...)`.
+Le client permet de personnaliser les couleurs de la barre de titre, du menu de navigation, ainsi que les couleurs des bulles de messages. Ces valeurs sont sauvegardées localement dans un fichier *settings.json* lié à l'utilisateur courant et sont appliquées via `AppSettings.SetObject("Colors", ...)`. Depuis la version 2.0, ce fichier est synchronisé avec le serveur afin que chaque poste dispose du même `{utilisateur}_settings.json`.
 
 Les propriétés concernées se trouvent dans `AppColorSettings` :
 
@@ -136,3 +136,4 @@ public bool UseSenderColorForBubbles
 * Initiales affichées dans la barre de titre (`Initials`).
 
 Ces paramètres sont tous stockés localement afin d'être conservés entre les sessions de l'application.
+Ils sont également envoyés au serveur pour être partagés entre plusieurs clients.


### PR DESCRIPTION
## Summary
- add `UserSetting` entity and wire up EF context
- ensure `UserSettings` table is created on startup
- allow saving and retrieving user settings via SignalR hub
- add client helpers to export/import settings and sync with server
- document server sync for `{user}_settings.json`

## Testing
- `dotnet build Serveur/Serveur.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6888588384a0832485bf4fb698274237