### PR TITLE
Enable user switch without deleting settings

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -9,6 +9,7 @@ using Microsoft.UI.Xaml.Controls;
 using System.Linq;
 using System.IO;
 using Client.Pages;
+using System.Threading.Tasks;
 
 namespace Client
 {
@@ -238,6 +239,33 @@ namespace Client
             {
                 System.Diagnostics.Debug.WriteLine($"❌ Sync settings error: {ex.Message}");
             }
+        }
+
+        public async Task ChangeUserAsync(string username)
+        {
+            if (MainWindow?.Content is not FrameworkElement root)
+                return;
+
+            try
+            {
+                if (ChatService.Connection != null)
+                    await ChatService.Connection.StopAsync();
+            }
+            catch { }
+
+            ChatService.ClearLocalData();
+
+            UserName = username;
+            AppSettings.Reload();
+            ApplySavedAppearance(root);
+            AppSettings.CurrentSelectedUser = new UserInfo { Username = username };
+
+            var machine = MachineConfig.Load();
+            machine.LastUser = username;
+            MachineConfig.Save(machine);
+
+            await ChatService.InitializeAsync();
+            await SyncUserSettingsAsync(root);
         }
 
         private Window? m_window;

--- a/Client/Helpers/AppSettings.cs
+++ b/Client/Helpers/AppSettings.cs
@@ -138,5 +138,15 @@ namespace Client.Helpers
                 System.Diagnostics.Debug.WriteLine($"❌ Sauvegarde échouée : {ex.Message}");
             }
         }
+
+        public static void DeleteSettingsFile()
+        {
+            try
+            {
+                if (File.Exists(FilePath))
+                    File.Delete(FilePath);
+            }
+            catch { }
+        }
     }
 }

--- a/Client/MainWindow.xaml
+++ b/Client/MainWindow.xaml
@@ -69,7 +69,7 @@
             </Grid.ColumnDefinitions>
             <Image x:Name="TitleBarIcon" Source="/Assets/EyeChat.png" Grid.Column="1" Width="32" Height="32" Margin="8,0,4,0"/>
             <TextBlock x:Name="TitleBarTextBlock" Text="EyeChat" FontSize="16" VerticalAlignment="Center" Grid.Column="2" />
-            <PersonPicture x:Name="PersonPic" Grid.Column="4" Height="32" Margin="0,0,150,0" />
+            <PersonPicture x:Name="PersonPic" Grid.Column="4" Height="32" Margin="0,0,150,0" Tapped="PersonPic_Tapped" />
         </Grid>
         <NavigationView x:Name="nvSample" Grid.Row="1" PaneDisplayMode="LeftCompact" IsPaneToggleButtonVisible="False" SelectionChanged="nvSample_SelectionChanged" IsBackEnabled="False" MenuItemContainerStyle="{StaticResource NavItemStyle}">
             <NavigationView.MenuItems>

--- a/Client/MainWindow.xaml.cs
+++ b/Client/MainWindow.xaml.cs
@@ -2,6 +2,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
 using System.Linq;
+using System.IO;
 using Microsoft.UI.Windowing;
 using WinRT.Interop;
 using Windows.UI;
@@ -83,6 +84,39 @@ namespace Client
             if (contentFrame.Content is Pages.ChatPage chat)
             {
                 chat.ScrollToLastMessage();
+            }
+        }
+
+        private async void PersonPic_Tapped(object sender, Microsoft.UI.Xaml.Input.TappedRoutedEventArgs e)
+        {
+            var appFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat");
+            Directory.CreateDirectory(appFolder);
+            var settingsFiles = Directory.GetFiles(appFolder, "*_settings.json");
+            var users = settingsFiles.Select(f => Path.GetFileNameWithoutExtension(f).Replace("_settings", "")).ToList();
+
+            var dialog = new ContentDialog
+            {
+                Title = "Choisir l'utilisateur",
+                PrimaryButtonText = "OK",
+                CloseButtonText = "Annuler",
+                XamlRoot = this.Content.XamlRoot
+            };
+
+            var stack = new StackPanel { Spacing = 10 };
+            var combo = new ComboBox { ItemsSource = users, PlaceholderText = "Utilisateur" };
+            var newBox = new TextBox { PlaceholderText = "Nouvel utilisateur" };
+            stack.Children.Add(combo);
+            stack.Children.Add(newBox);
+            dialog.Content = stack;
+
+            var result = await dialog.ShowAsync();
+            if (result == ContentDialogResult.Primary)
+            {
+                var name = !string.IsNullOrWhiteSpace(newBox.Text) ? newBox.Text.Trim() : combo.SelectedItem as string;
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    await ((App)Application.Current).ChangeUserAsync(name);
+                }
             }
         }
     }

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -596,6 +596,32 @@ namespace Client.Services
                 Debug.WriteLine($"Erreur sauvegarde users cache : {ex.Message}");
             }
         }
+
+        public void ClearLocalData()
+        {
+            try
+            {
+                var folder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat");
+                if (Directory.Exists(folder))
+                {
+                    foreach (var file in Directory.GetFiles(folder, "chat_*.json"))
+                        File.Delete(file);
+
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur nettoyage cache : {ex.Message}");
+            }
+
+            Dispatcher?.TryEnqueue(() =>
+            {
+                ConnectedUsers.Clear();
+                Patients.Clear();
+                Messages.Clear();
+                Messages.Add(new LoadMorePlaceholder());
+            });
+        }
         public async Task SendExamOptionsAsync(IEnumerable<ExamOption> options)
         {
             if (Connection is null || Connection.State != HubConnectionState.Connected)


### PR DESCRIPTION
## Summary
- keep the user settings file when switching accounts
- only clear cached chat messages when logging out

## Testing
- `dotnet restore -p:EnableWindowsTargeting=true`
- `dotnet build -p:EnableWindowsTargeting=true --no-restore` *(fails: Xaml compiler exec format error)*
- `dotnet build Serveur/Serveur.csproj --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6888a35f1d848324b79b053947ad8f3a