### PR TITLE
Fix reconnect issues on user logout

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -249,7 +249,7 @@ namespace Client
             try
             {
                 if (ChatService.Connection != null)
-                    await ChatService.Connection.StopAsync();
+                    await ChatService.DisconnectAsync();
             }
             catch { }
 

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -42,6 +42,7 @@ namespace Client.Services
         private int _reconnectCountdown;
         public event Action<int>? ReconnectCountdownChanged;
         private bool _isConnecting;
+        public bool EnableReconnect { get; set; } = true;
 
         public bool IsHistoryLoaded => _historyLoaded;
         public IReadOnlyList<UserInfo> KnownUsers => _lastServerUserList;
@@ -115,6 +116,7 @@ namespace Client.Services
             if (_isConnecting)
                 return;
             _isConnecting = true;
+            EnableReconnect = true;
 
             _username = username;
             _avatar = avatar;
@@ -162,7 +164,8 @@ namespace Client.Services
                 }
                 await SaveUsersToDiskAsync();
                 await Task.Delay(3000);
-                StartReconnectTimer();
+                if (EnableReconnect)
+                    StartReconnectTimer();
             };
 
             Connection.On<UserInfo>("UserConnected", user =>
@@ -336,7 +339,8 @@ namespace Client.Services
                 {
                     Debug.WriteLine($"❌ Toast error: {toastEx.Message}");
                 }
-                StartReconnectTimer();
+                if (EnableReconnect)
+                    StartReconnectTimer();
             }
 
             _isConnecting = false;
@@ -419,6 +423,8 @@ namespace Client.Services
         }
         private async Task<bool> TryReconnectAsync()
         {
+            if (!EnableReconnect)
+                return false;
             try
             {
                 if (Connection == null)
@@ -441,6 +447,8 @@ namespace Client.Services
 
         private void StartReconnectTimer()
         {
+            if (!EnableReconnect)
+                return;
             _reconnectTimer?.Dispose();
             _reconnectCountdownTimer?.Dispose();
 
@@ -475,7 +483,7 @@ namespace Client.Services
 
         public async Task ReconnectAsync()
         {
-            if (_isConnecting || string.IsNullOrEmpty(_username))
+            if (!EnableReconnect || _isConnecting || string.IsNullOrEmpty(_username))
                 return;
 
             await ConnectAsync(_username, _avatar, RoomName, _color);
@@ -975,8 +983,10 @@ namespace Client.Services
             return result;
         }
 
-        public async Task DisconnectAsync()
+        public async Task DisconnectAsync(bool disableReconnect = true)
         {
+            if (disableReconnect)
+                EnableReconnect = false;
             StopReconnectTimer();
             if (Connection != null)
             {


### PR DESCRIPTION
## Summary
- avoid auto-reconnect when disconnecting
- fix user switching to disconnect cleanly

## Testing
- `dotnet restore -p:EnableWindowsTargeting=true`
- `dotnet build -p:EnableWindowsTargeting=true --no-restore` *(fails: Xaml compiler requires Windows)*


------
https://chatgpt.com/codex/tasks/task_e_6889a6b141ac8324a339b74a57d84abe