### PR TITLE
Fix chat template after user switch

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -266,6 +266,12 @@ namespace Client
 
             await ChatService.InitializeAsync();
             await SyncUserSettingsAsync(root);
+
+            if (MainWindow is MainWindow mw)
+            {
+                var chat = mw.ShowChatPage();
+                chat?.RefreshUsername();
+            }
         }
 
         public async Task LogoutAsync()

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -811,6 +811,17 @@ namespace Client.Pages
                 }
             }
         }
+
+        public void RefreshUsername()
+        {
+            if (Resources["MessageTemplateSelector"] is ChatMessageTemplateSelector selector)
+            {
+                selector.MyUsername = App.UserName;
+                MessagesList.ItemTemplateSelector = null;
+                MessagesList.ItemTemplateSelector = selector;
+                MessagesList.UpdateLayout();
+            }
+        }
     }
 
     public static class ObservableCollectionExtensions


### PR DESCRIPTION
## Summary
- update chat template selector with new username when account changes
- expose `RefreshUsername` on chat page to reset the template

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not installed)*
- `apt-get update`

------
https://chatgpt.com/codex/tasks/task_e_6889eff4d2848324a6ea90fda8250b42