### PR TITLE
Implement user list ordering

### DIFF
--- a/Client/Helpers/AppSettings.cs
+++ b/Client/Helpers/AppSettings.cs
@@ -30,6 +30,12 @@ namespace Client.Helpers
             }
         }
 
+        public static List<string> UserOrder
+        {
+            get => GetObject<List<string>>("UserOrder");
+            set => SetObject("UserOrder", value);
+        }
+
         static AppSettings()
         {
             Load();

--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -213,6 +213,8 @@
         <!-- Menu contextuel des utilisateurs -->
         <MenuFlyout x:Key="UserContextMenu">
             <MenuFlyoutItem Text="Message"/>
+            <MenuFlyoutItem Text="Monter" Click="MoveUserUp_Click"/>
+            <MenuFlyoutItem Text="Descendre" Click="MoveUserDown_Click"/>
         </MenuFlyout>
         <DataTemplate x:Key="UserTemplate" x:DataType="data:UserInfo">
             <StackPanel Orientation="Horizontal" Spacing="8" Padding="4">

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -31,6 +31,7 @@ namespace Client.Pages
         private DateTime _currentDate = DateTime.Today;
         private FrameworkElement? _currentMessageTarget;
         private bool _ignoreSelectionChanged;
+        private bool _ignoreOrderChange;
         public bool ShowTimeModification { get; private set; }
         public Visibility TimeModificationVisibility => ShowTimeModification ? Visibility.Visible : Visibility.Collapsed;
         public ChatPage()
@@ -50,7 +51,11 @@ namespace Client.Pages
 
             ViewModel.ViewModel.SettingsViewModel.DisplayStyleChanged += ApplyChatStyle;
             ViewModel.ViewModel.SettingsViewModel.BubbleColorModeChanged += ApplyBubbleColorMode;
-            _service.ConnectedUsers.CollectionChanged += (_, _) => DispatcherQueue.TryEnqueue(TryRestoreUserSelection);
+            _service.ConnectedUsers.CollectionChanged += (_, _) => DispatcherQueue.TryEnqueue(() =>
+            {
+                ApplySavedUserOrder();
+                TryRestoreUserSelection();
+            });
 
             _service.OnMessageReceived += OnMessageReceived;
             _service.OnPatientRemoved += Service_OnPatientRemoved;
@@ -93,6 +98,7 @@ namespace Client.Pages
             await WaitForConnectionReady();
             UpdateReconnectButtonVisibility();
             await _service.RefreshGroupsAsync();
+            ApplySavedUserOrder();
 
             if (!_service.IsHistoryLoaded && !Messages.OfType<ChatMessageModel>().Any())
             {
@@ -297,6 +303,7 @@ namespace Client.Pages
                 var response = await App.ChatService.Connection.InvokeAsync<string>("JoinProtectedGroup", groupName, password);
                 Debug.WriteLine($"🔐 Groupe {groupName} : {response}");
                 await _service.RefreshGroupsAsync();
+                ApplySavedUserOrder();
             }
         }
 
@@ -313,6 +320,7 @@ namespace Client.Pages
             ConnectedUsers.Clear();
             foreach (var u in sorted)
                 ConnectedUsers.Add(u);
+            SaveUserOrder();
         }
 
         private async void LoadMore_Click(object sender, RoutedEventArgs e)
@@ -821,6 +829,66 @@ namespace Client.Pages
                 MessagesList.ItemTemplateSelector = selector;
                 MessagesList.UpdateLayout();
             }
+        }
+
+        private void MoveUserUp_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as FrameworkElement)?.DataContext is UserInfo user)
+            {
+                var index = ConnectedUsers.IndexOf(user);
+                if (index > 0)
+                {
+                    _ignoreOrderChange = true;
+                    ConnectedUsers.Move(index, index - 1);
+                    _ignoreOrderChange = false;
+                    SaveUserOrder();
+                }
+            }
+        }
+
+        private void MoveUserDown_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as FrameworkElement)?.DataContext is UserInfo user)
+            {
+                var index = ConnectedUsers.IndexOf(user);
+                if (index >= 0 && index < ConnectedUsers.Count - 1)
+                {
+                    _ignoreOrderChange = true;
+                    ConnectedUsers.Move(index, index + 1);
+                    _ignoreOrderChange = false;
+                    SaveUserOrder();
+                }
+            }
+        }
+
+        private void ApplySavedUserOrder()
+        {
+            if (_ignoreOrderChange)
+                return;
+
+            var order = AppSettings.UserOrder;
+            if (order.Count == 0)
+                return;
+
+            var sorted = ConnectedUsers.OrderBy(u =>
+            {
+                int idx = order.IndexOf(u.Username);
+                return idx >= 0 ? idx : int.MaxValue;
+            }).ToList();
+
+            if (sorted.SequenceEqual(ConnectedUsers))
+                return;
+
+            _ignoreOrderChange = true;
+            ConnectedUsers.Clear();
+            foreach (var u in sorted)
+                ConnectedUsers.Add(u);
+            _ignoreOrderChange = false;
+        }
+
+        private void SaveUserOrder()
+        {
+            AppSettings.UserOrder = ConnectedUsers.Select(u => u.Username).ToList();
         }
     }
 


### PR DESCRIPTION
## Summary
- add UserOrder setting
- enable moving users up and down
- remember user order per local settings

## Testing
- `dotnet build --no-restore -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe exec format error)*
- `dotnet test --no-build -p:EnableWindowsTargeting=true` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6889f4dcfc5c83249675fe37c30202e7