### PR TITLE
Fix toast when switching user

### DIFF
--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -142,19 +142,22 @@ namespace Client.Services
 
             Connection.Closed += async (error) =>
             {
-                try
+                if (EnableReconnect)
                 {
-                    AppNotification notification = new AppNotificationBuilder()
-                        .AddText("Serveur indisponible")
-                        .AddText("Le serveur est actuellement injoignable.")
-                        .SetDuration(AppNotificationDuration.Long)
-                        .BuildNotification();
+                    try
+                    {
+                        AppNotification notification = new AppNotificationBuilder()
+                            .AddText("Serveur indisponible")
+                            .AddText("Le serveur est actuellement injoignable.")
+                            .SetDuration(AppNotificationDuration.Long)
+                            .BuildNotification();
 
-                    AppNotificationManager.Default.Show(notification);
-                }
-                catch (Exception ex)
-                {
-                    Debug.WriteLine($"❌ Toast error: {ex.Message}");
+                        AppNotificationManager.Default.Show(notification);
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"❌ Toast error: {ex.Message}");
+                    }
                 }
 
                 foreach (var u in ConnectedUsers)


### PR DESCRIPTION
## Summary
- avoid showing "Serveur indisponible" toast when connection is closed intentionally

## Testing
- `dotnet build Serveur/Serveur.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688a4ce7ab94832492cef62ea0b1ea47