### PR TITLE
Handle offline users in chat

### DIFF
--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -87,6 +87,15 @@ namespace Client.Services
             var color = AppSettings.Get("ColorUserName", "Black");
             await ConnectAsync(App.UserName, @"E:\benoit.png", RoomName, color);
 
+            var serverUsers = await GetAllUsersAsync();
+            if (serverUsers.Count > 0)
+            {
+                var finalList = await BuildUserListWithGroupsAsync(serverUsers);
+                ConnectedUsers.Clear();
+                foreach (var u in finalList)
+                    ConnectedUsers.Add(u);
+            }
+
             Messages.Clear();
             Messages.Add(new LoadMorePlaceholder());
 
@@ -728,6 +737,25 @@ namespace Client.Services
             {
                 Debug.WriteLine($"Erreur récupération salles : {ex.Message}");
                 return new List<string>();
+            }
+        }
+
+        public async Task<List<UserInfo>> GetAllUsersAsync()
+        {
+            if (Connection is null || Connection.State != HubConnectionState.Connected)
+            {
+                var connected = await TryReconnectAsync();
+                if (!connected) return new List<UserInfo>();
+            }
+
+            try
+            {
+                return await Connection.InvokeAsync<List<UserInfo>>("GetAllUsers");
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur récupération utilisateurs : {ex.Message}");
+                return new List<UserInfo>();
             }
         }
 

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -321,6 +321,12 @@ namespace ChatServeur
             return setting?.SettingsJson;
         }
 
+        public Task<List<UserInfo>> GetAllUsers()
+        {
+            var userList = BaseUsers.Concat(AllUsers.Values).ToList();
+            return Task.FromResult(userList);
+        }
+
         public async Task SaveExamOptions(IEnumerable<ExamOption> options)
         {
             var json = JsonSerializer.Serialize(options);


### PR DESCRIPTION
## Summary
- add `GetAllUsers` server-side
- add `GetAllUsersAsync` for the client and use it when initializing

## Testing
- `dotnet build WebApplication1.sln -property:EnableWindowsTargeting=true` *(fails: XamlCompiler exited with code 126)*

------
https://chatgpt.com/codex/tasks/task_e_688b9ec474f48324a86f71ac289c7a8b