### PR TITLE
Add persistent user list

### DIFF
--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -11,6 +11,7 @@ namespace ChatServeur
         private static readonly Dictionary<string, string> _userToConnectionId = new();
         private static readonly Dictionary<string, UserInfo> AllUsers = new();
         private static readonly Dictionary<string, HashSet<string>> GroupMembers = new();
+        private static bool _usersLoaded;
 
         private static readonly List<UserInfo> BaseUsers = new()
         {
@@ -38,6 +39,29 @@ namespace ChatServeur
             }
         };
 
+        private void EnsureUsersLoaded()
+        {
+            if (_usersLoaded)
+                return;
+
+            foreach (var u in _db.KnownUsers)
+            {
+                AllUsers[u.Username] = new UserInfo
+                {
+                    ConnectionId = u.ConnectionId,
+                    Username = u.Username,
+                    Avatar = u.Avatar,
+                    Room = u.Room,
+                    DisplayName = u.DisplayName,
+                    ColorUserName = u.ColorUserName,
+                    IsOnline = u.IsOnline,
+                    Note = u.Note
+                };
+            }
+
+            _usersLoaded = true;
+        }
+
         private readonly ChatDbContext _db;
 
         public ChatHub(ChatDbContext db)
@@ -52,11 +76,22 @@ namespace ChatServeur
 
         public override async Task OnDisconnectedAsync(Exception? ex)
         {
+            EnsureUsersLoaded();
             if (ConnectedUsers.Remove(Context.ConnectionId, out var user))
             {
                 user.IsOnline = false;
                 user.Room = "Hors ligne";
                 AllUsers[user.Username] = user;
+
+                var dbUser = await _db.KnownUsers.FirstOrDefaultAsync(u => u.Username == user.Username);
+                if (dbUser != null)
+                {
+                    dbUser.ConnectionId = string.Empty;
+                    dbUser.Room = "Hors ligne";
+                    dbUser.IsOnline = false;
+                    _db.KnownUsers.Update(dbUser);
+                    await _db.SaveChangesAsync();
+                }
 
                 await Clients.All.SendAsync("UserDisconnected", user.Username);
 
@@ -78,6 +113,7 @@ namespace ChatServeur
         {
             try
             {
+                EnsureUsersLoaded();
                 Console.WriteLine($"[SERVER] RegisterUser : {username}");
 
                 var user = new UserInfo
@@ -95,6 +131,21 @@ namespace ChatServeur
                 ConnectedUsers[Context.ConnectionId] = user;
                 _userToConnectionId[username] = Context.ConnectionId;
                 AllUsers[username] = user;
+
+                var dbUser = await _db.KnownUsers.FirstOrDefaultAsync(u => u.Username == username);
+                if (dbUser == null)
+                {
+                    dbUser = new KnownUser { Username = username };
+                    _db.KnownUsers.Add(dbUser);
+                }
+                dbUser.ConnectionId = Context.ConnectionId;
+                dbUser.Avatar = avatar;
+                dbUser.Room = room;
+                dbUser.DisplayName = username;
+                dbUser.ColorUserName = color;
+                dbUser.IsOnline = true;
+                dbUser.Note = string.Empty;
+                await _db.SaveChangesAsync();
 
                 await Groups.AddToGroupAsync(Context.ConnectionId, "A Tous");
                 if (!GroupMembers.ContainsKey("A Tous"))
@@ -280,10 +331,19 @@ namespace ChatServeur
 
         public async Task SetRoomName(string roomName)
         {
+            EnsureUsersLoaded();
             if (ConnectedUsers.TryGetValue(Context.ConnectionId, out var user))
             {
                 user.Room = roomName;
                 AllUsers[user.Username] = user;
+
+                var dbUser = await _db.KnownUsers.FirstOrDefaultAsync(u => u.Username == user.Username);
+                if (dbUser != null)
+                {
+                    dbUser.Room = roomName;
+                    _db.KnownUsers.Update(dbUser);
+                    await _db.SaveChangesAsync();
+                }
 
                 var userList = BaseUsers.Concat(AllUsers.Values).ToList();
                 await Clients.All.SendAsync("UserListUpdated", userList);
@@ -292,10 +352,19 @@ namespace ChatServeur
 
         public async Task SetColorUserName(string color)
         {
+            EnsureUsersLoaded();
             if (ConnectedUsers.TryGetValue(Context.ConnectionId, out var user))
             {
                 user.ColorUserName = color;
                 AllUsers[user.Username] = user;
+
+                var dbUser = await _db.KnownUsers.FirstOrDefaultAsync(u => u.Username == user.Username);
+                if (dbUser != null)
+                {
+                    dbUser.ColorUserName = color;
+                    _db.KnownUsers.Update(dbUser);
+                    await _db.SaveChangesAsync();
+                }
 
                 var userList = BaseUsers.Concat(AllUsers.Values).ToList();
                 await Clients.All.SendAsync("UserListUpdated", userList);
@@ -323,6 +392,7 @@ namespace ChatServeur
 
         public Task<List<UserInfo>> GetAllUsers()
         {
+            EnsureUsersLoaded();
             var userList = BaseUsers.Concat(AllUsers.Values).ToList();
             return Task.FromResult(userList);
         }

--- a/Serveur/Models/ChatDbContext.cs
+++ b/Serveur/Models/ChatDbContext.cs
@@ -14,5 +14,6 @@ namespace ChatServeur
         public DbSet<ServerConfig> ServerConfigs => Set<ServerConfig>();
         public DbSet<Patient> Patients => Set<Patient>();
         public DbSet<UserSetting> UserSettings => Set<UserSetting>();
+        public DbSet<KnownUser> KnownUsers => Set<KnownUser>();
     }
 }

--- a/Serveur/Models/KnownUser.cs
+++ b/Serveur/Models/KnownUser.cs
@@ -1,0 +1,15 @@
+namespace ChatServeur
+{
+    public class KnownUser
+    {
+        public int Id { get; set; }
+        public string ConnectionId { get; set; } = string.Empty;
+        public string Username { get; set; } = string.Empty;
+        public string Avatar { get; set; } = string.Empty;
+        public string Room { get; set; } = string.Empty;
+        public string DisplayName { get; set; } = string.Empty;
+        public string ColorUserName { get; set; } = string.Empty;
+        public bool IsOnline { get; set; }
+        public string Note { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary
- persist user info in SQLite using `KnownUser`
- expose `KnownUsers` in `ChatDbContext`
- load and update users in SignalR hub

## Testing
- `dotnet build Serveur/Serveur.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688c43e15c148324b8e24b3ec8362899