### PR TITLE
Add avatar customization support

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -8,6 +8,7 @@ using Client.Helpers;
 using Microsoft.UI.Xaml.Controls;
 using System.Linq;
 using System.IO;
+using Microsoft.UI.Xaml.Media.Imaging;
 using Client.Pages;
 using System.Threading.Tasks;
 
@@ -154,6 +155,12 @@ namespace Client
                         .Select(s => char.ToUpperInvariant(s[0])));
                 }
                 pic.Initials = initials;
+                var avatar = AppSettings.Get("Avatar", string.Empty);
+                if (!string.IsNullOrWhiteSpace(avatar))
+                {
+                    try { pic.ProfilePicture = new BitmapImage(new Uri(avatar)); }
+                    catch { }
+                }
             }
 
             AppearanceSettingsPage.ApplyColors(colors, titleBar, nav, titleText);

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -844,6 +844,21 @@ namespace Client.Services
             }
         }
 
+        public async Task UpdateAvatarAsync(string avatar)
+        {
+            if (Connection != null && Connection.State == HubConnectionState.Connected)
+            {
+                try
+                {
+                    await Connection.InvokeAsync("SetAvatar", avatar);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Erreur mise à jour avatar : {ex.Message}");
+                }
+            }
+        }
+
         public async Task ArchiveTakenPatientsAsync()
         {
             if (Connection != null && Connection.State == HubConnectionState.Connected)

--- a/Client/ViewModel/SettingsViewModel.cs
+++ b/Client/ViewModel/SettingsViewModel.cs
@@ -15,6 +15,7 @@ namespace Client.ViewModel
         private string _appTheme = "Dark";
         private string _colorUserName = "Black";
         private string _initials = string.Empty;
+        private string _avatar = "ms-appx:///Assets/earth.png";
         private string _shortcutF5Refraction = string.Empty;
         private string _shortcutF5Lentilles = string.Empty;
         private string _shortcutF5Pathologies = string.Empty;
@@ -125,6 +126,21 @@ namespace Client.ViewModel
                     {
                         pic.Initials = value;
                     }
+                }
+            }
+        }
+
+        public string Avatar
+        {
+            get => _avatar;
+            set
+            {
+                if (_avatar != value)
+                {
+                    _avatar = value;
+                    OnPropertyChanged(nameof(Avatar));
+                    Set("Avatar", value);
+                    App.ChatService?.UpdateAvatarAsync(value);
                 }
             }
         }
@@ -303,6 +319,7 @@ namespace Client.ViewModel
             ApplyTheme(_appTheme);
             _colorUserName = Get("ColorUserName");
             _initials = Get("Initials");
+            _avatar = Get("Avatar");
             if (string.IsNullOrWhiteSpace(_initials))
             {
                 _initials = string.Concat(App.UserName.Split(' ', StringSplitOptions.RemoveEmptyEntries)

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -371,6 +371,27 @@ namespace ChatServeur
             }
         }
 
+        public async Task SetAvatar(string avatar)
+        {
+            EnsureUsersLoaded();
+            if (ConnectedUsers.TryGetValue(Context.ConnectionId, out var user))
+            {
+                user.Avatar = avatar;
+                AllUsers[user.Username] = user;
+
+                var dbUser = await _db.KnownUsers.FirstOrDefaultAsync(u => u.Username == user.Username);
+                if (dbUser != null)
+                {
+                    dbUser.Avatar = avatar;
+                    _db.KnownUsers.Update(dbUser);
+                    await _db.SaveChangesAsync();
+                }
+
+                var userList = BaseUsers.Concat(AllUsers.Values).ToList();
+                await Clients.All.SendAsync("UserListUpdated", userList);
+            }
+        }
+
         public async Task SaveUserSettings(string username, string json)
         {
             var setting = await _db.UserSettings.FirstOrDefaultAsync(s => s.Username == username);

--- a/docs/Personnalisation.md
+++ b/docs/Personnalisation.md
@@ -134,6 +134,11 @@ public bool UseSenderColorForBubbles
 * Mémorisation de l'utilisateur sélectionné pour l'envoi des messages (`AppSettings.CurrentSelectedUser`).
 * Couleur des bulles basée sur celle de l'expéditeur (`UseSenderColorForBubbles`).
 * Initiales affichées dans la barre de titre (`Initials`).
+* Avatar de l'utilisateur (`Avatar`).
+
+L'avatar peut provenir d'une image intégrée ou d'un fichier importé. Le chemin
+de ce fichier est mémorisé dans le *settings.json* de l'utilisateur et envoyé au
+serveur afin de s'afficher de la même façon sur chaque poste.
 
 Ces paramètres sont tous stockés localement afin d'être conservés entre les sessions de l'application.
 Ils sont également envoyés au serveur pour être partagés entre plusieurs clients.


### PR DESCRIPTION
## Summary
- support avatar path in user settings
- expose avatar update via SignalR and hub
- display avatar in title bar
- document avatar setting

## Testing
- `dotnet build WebApplication1.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c90ab5c948324a482e16e94456426