### PR TITLE
Add avatar selection dialog

### DIFF
--- a/Client/Pages/UserSettingsPage.xaml
+++ b/Client/Pages/UserSettingsPage.xaml
@@ -10,6 +10,9 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
     <Page.Resources>
         <helpers:StringToColorConverter x:Key="StringToColorConverter" />
+        <DataTemplate x:Key="AvatarTemplate">
+            <Image Source="{Binding}" Width="60" Height="60"/>
+        </DataTemplate>
     </Page.Resources>
     <ScrollViewer>
         <StackPanel Padding="20" Spacing="20">
@@ -30,6 +33,11 @@
             <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
                 <TextBlock Text="Initiales:" VerticalAlignment="Center"/>
                 <TextBox Text="{x:Bind ViewModelSettings.Initials, Mode=TwoWay}" Width="60"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                <TextBlock Text="Avatar:" VerticalAlignment="Center"/>
+                <Image Source="{x:Bind ViewModelSettings.Avatar}" Width="40" Height="40"/>
+                <Button Content="Changer..." Click="ChangeAvatar_Click"/>
             </StackPanel>
             <Border CornerRadius="8" Padding="20">
                 <StackPanel Spacing="10">

--- a/Client/Pages/UserSettingsPage.xaml.cs
+++ b/Client/Pages/UserSettingsPage.xaml.cs
@@ -4,6 +4,11 @@ using Microsoft.UI.Xaml.Controls;
 using System.Diagnostics;
 using Client.Models;
 using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Windows.Storage.Pickers;
+using Windows.Storage;
+using WinRT.Interop;
 
 namespace Client.Pages
 {
@@ -11,6 +16,12 @@ namespace Client.Pages
     {
         public SettingsViewModel ViewModelSettings { get; } = new();
         public ObservableCollection<ExamOption> ExamOptions { get; } = ExamOption.Load();
+
+        private readonly List<string> _defaultAvatars = new()
+        {
+            "ms-appx:///Assets/earth.png",
+            "ms-appx:///Assets/secretaria.png"
+        };
 
         public UserSettingsPage()
         {
@@ -24,6 +35,60 @@ namespace Client.Pages
             if (Frame.CanGoBack)
             {
                 Frame.GoBack();
+            }
+        }
+
+        private async void ChangeAvatar_Click(object sender, RoutedEventArgs e)
+        {
+            var dialog = new ContentDialog
+            {
+                Title = "Choisir un avatar",
+                PrimaryButtonText = "Valider",
+                CloseButtonText = "Annuler",
+                XamlRoot = this.XamlRoot
+            };
+
+            var list = new ListView
+            {
+                ItemsSource = _defaultAvatars,
+                SelectionMode = ListViewSelectionMode.Single,
+                ItemTemplate = (DataTemplate)this.Resources["AvatarTemplate"],
+                MaxHeight = 200
+            };
+            list.SelectedIndex = _defaultAvatars.IndexOf(ViewModelSettings.Avatar);
+
+            var importButton = new Button { Content = "Importer une image..." };
+            importButton.Click += async (s, args) => await ImportAvatarAsync(list);
+
+            var panel = new StackPanel { Spacing = 10 };
+            panel.Children.Add(list);
+            panel.Children.Add(importButton);
+
+            dialog.Content = panel;
+            var result = await dialog.ShowAsync();
+            if (result == ContentDialogResult.Primary)
+            {
+                if (list.SelectedItem is string avatar)
+                    ViewModelSettings.Avatar = avatar;
+            }
+        }
+
+        private async Task ImportAvatarAsync(ListView list)
+        {
+            var picker = new FileOpenPicker();
+            picker.FileTypeFilter.Add(".png");
+            picker.FileTypeFilter.Add(".jpg");
+            picker.FileTypeFilter.Add(".jpeg");
+            var hwnd = WindowNative.GetWindowHandle(App.MainWindow);
+            InitializeWithWindow.Initialize(picker, hwnd);
+            var file = await picker.PickSingleFileAsync();
+            if (file != null)
+            {
+                var folder = await ApplicationData.Current.LocalFolder.CreateFolderAsync("Avatars", CreationCollisionOption.OpenIfExists);
+                await file.CopyAsync(folder, file.Name, NameCollisionOption.ReplaceExisting);
+                var path = $"ms-appdata:///local/Avatars/{file.Name}";
+                ViewModelSettings.Avatar = path;
+                list.SelectedItem = null;
             }
         }
     }

--- a/docs/Personnalisation.md
+++ b/docs/Personnalisation.md
@@ -139,6 +139,8 @@ public bool UseSenderColorForBubbles
 L'avatar peut provenir d'une image intégrée ou d'un fichier importé. Le chemin
 de ce fichier est mémorisé dans le *settings.json* de l'utilisateur et envoyé au
 serveur afin de s'afficher de la même façon sur chaque poste.
+La sélection s'effectue depuis la page **Utilisateur** via le bouton "Changer..."
+qui propose plusieurs icônes intégrées ou l'import d'une image personnelle.
 
 Ces paramètres sont tous stockés localement afin d'être conservés entre les sessions de l'application.
 Ils sont également envoyés au serveur pour être partagés entre plusieurs clients.


### PR DESCRIPTION
## Summary
- allow picking an avatar in *UserSettingsPage*
- persist chosen image in settings
- document avatar selection in docs

## Testing
- `dotnet build Serveur/Serveur.csproj -c Release`
- `dotnet build WebApplication1.sln -c Release /p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_688c968b5b948324a75c70117a7b03ab