### PR TITLE
feat: upload avatars to server

### DIFF
--- a/Client/Pages/UserSettingsPage.xaml.cs
+++ b/Client/Pages/UserSettingsPage.xaml.cs
@@ -4,12 +4,12 @@ using Microsoft.UI.Xaml.Controls;
 using System.Diagnostics;
 using Client.Models;
 using System.Collections.ObjectModel;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Windows.Storage.Pickers;
 using Windows.Storage;
 using WinRT.Interop;
 using System;
+using System.IO;
 
 namespace Client.Pages
 {
@@ -18,7 +18,7 @@ namespace Client.Pages
         public SettingsViewModel ViewModelSettings { get; } = new();
         public ObservableCollection<ExamOption> ExamOptions { get; } = ExamOption.Load();
 
-        private readonly List<string> _defaultAvatars = new()
+        private readonly ObservableCollection<string> _defaultAvatars = new()
         {
             "ms-appx:///Assets/earth.png",
             "ms-appx:///Assets/secretaria.png"
@@ -87,8 +87,19 @@ namespace Client.Pages
             {
                 var folder = await ApplicationData.Current.LocalFolder.CreateFolderAsync("Avatars", CreationCollisionOption.OpenIfExists);
                 await file.CopyAsync(folder, file.Name, NameCollisionOption.ReplaceExisting);
-                var path = $"ms-appdata:///local/Avatars/{file.Name}";
+
+                using var stream = await file.OpenStreamForReadAsync();
+                using var ms = new MemoryStream();
+                await stream.CopyToAsync(ms);
+                var base64 = Convert.ToBase64String(ms.ToArray());
+                var serverPath = await App.ChatService.UploadAvatarAsync(file.Name, base64);
+                string path = string.IsNullOrEmpty(serverPath)
+                    ? $"ms-appdata:///local/Avatars/{file.Name}"
+                    : $"{App.ChatService.ServerAddress}{serverPath}";
+
                 ViewModelSettings.Avatar = path;
+                if (!_defaultAvatars.Contains(path))
+                    _defaultAvatars.Add(path);
                 list.SelectedItem = null;
             }
         }

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -844,6 +844,22 @@ namespace Client.Services
             }
         }
 
+        public async Task<string?> UploadAvatarAsync(string fileName, string base64)
+        {
+            if (Connection != null && Connection.State == HubConnectionState.Connected)
+            {
+                try
+                {
+                    return await Connection.InvokeAsync<string>("UploadAvatar", fileName, base64);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Erreur envoi avatar : {ex.Message}");
+                }
+            }
+            return null;
+        }
+
         public async Task UpdateAvatarAsync(string avatar)
         {
             if (Connection != null && Connection.State == HubConnectionState.Connected)

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -2,6 +2,8 @@ using System.Text.Json;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using static ChatServeur.PasswordHelper;
+using Microsoft.AspNetCore.Hosting;
+using System.IO;
 
 namespace ChatServeur
 {
@@ -63,10 +65,12 @@ namespace ChatServeur
         }
 
         private readonly ChatDbContext _db;
+        private readonly IWebHostEnvironment _env;
 
-        public ChatHub(ChatDbContext db)
+        public ChatHub(ChatDbContext db, IWebHostEnvironment env)
         {
             _db = db;
+            _env = env;
         }
 
         public override Task OnConnectedAsync()
@@ -390,6 +394,16 @@ namespace ChatServeur
                 var userList = BaseUsers.Concat(AllUsers.Values).ToList();
                 await Clients.All.SendAsync("UserListUpdated", userList);
             }
+        }
+
+        public async Task<string> UploadAvatar(string fileName, string base64)
+        {
+            var bytes = Convert.FromBase64String(base64);
+            var avatarsPath = Path.Combine(_env.WebRootPath, "avatars");
+            Directory.CreateDirectory(avatarsPath);
+            var filePath = Path.Combine(avatarsPath, fileName);
+            await File.WriteAllBytesAsync(filePath, bytes);
+            return $"/avatars/{fileName}";
         }
 
         public async Task SaveUserSettings(string username, string json)


### PR DESCRIPTION
## Summary
- allow clients to upload avatars to server and broadcast new URL
- add hub endpoint to store uploaded avatars on server filesystem
- refresh default avatar list when importing custom image

## Testing
- `~/.dotnet/dotnet build Serveur/Serveur.csproj`
- `~/.dotnet/dotnet build -p:EnableWindowsTargeting=true --no-restore` *(fails: XamlCompiler.exe exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_688da4e709288324ba19f0ce684bd122