### PR TITLE
feat: fetch available avatars from server

### DIFF
--- a/Client/Pages/UserSettingsPage.xaml.cs
+++ b/Client/Pages/UserSettingsPage.xaml.cs
@@ -18,11 +18,7 @@ namespace Client.Pages
         public SettingsViewModel ViewModelSettings { get; } = new();
         public ObservableCollection<ExamOption> ExamOptions { get; } = ExamOption.Load();
 
-        private readonly ObservableCollection<string> _defaultAvatars = new()
-        {
-            "ms-appx:///Assets/earth.png",
-            "ms-appx:///Assets/secretaria.png"
-        };
+        private readonly ObservableCollection<string> _defaultAvatars = new();
 
         public UserSettingsPage()
         {
@@ -41,6 +37,23 @@ namespace Client.Pages
 
         private async void ChangeAvatar_Click(object sender, RoutedEventArgs e)
         {
+            var serverAvatars = await App.ChatService.GetAvailableAvatarsAsync();
+            _defaultAvatars.Clear();
+            foreach (var avatar in serverAvatars)
+                _defaultAvatars.Add(avatar);
+
+            var folder = await ApplicationData.Current.LocalFolder.CreateFolderAsync("Avatars", CreationCollisionOption.OpenIfExists);
+            var files = await folder.GetFilesAsync();
+            foreach (var file in files)
+            {
+                var path = $"ms-appdata:///local/Avatars/{file.Name}";
+                if (!_defaultAvatars.Contains(path))
+                    _defaultAvatars.Add(path);
+            }
+
+            if (!string.IsNullOrEmpty(ViewModelSettings.Avatar) && !_defaultAvatars.Contains(ViewModelSettings.Avatar))
+                _defaultAvatars.Add(ViewModelSettings.Avatar);
+
             var dialog = new ContentDialog
             {
                 Title = "Choisir un avatar",

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -907,6 +907,23 @@ namespace Client.Services
             return null;
         }
 
+        public async Task<List<string>> GetAvailableAvatarsAsync()
+        {
+            if (Connection != null && Connection.State == HubConnectionState.Connected)
+            {
+                try
+                {
+                    var avatars = await Connection.InvokeAsync<List<string>>("GetAvailableAvatars");
+                    return avatars.Select(ToClientAvatar).ToList();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Erreur récupération avatars : {ex.Message}");
+                }
+            }
+            return new List<string>();
+        }
+
         public async Task UpdateAvatarAsync(string avatar)
         {
             if (Connection != null && Connection.State == HubConnectionState.Connected)

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -4,6 +4,8 @@ using Microsoft.EntityFrameworkCore;
 using static ChatServeur.PasswordHelper;
 using Microsoft.AspNetCore.Hosting;
 using System.IO;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace ChatServeur
 {
@@ -435,6 +437,20 @@ namespace ChatServeur
             await File.WriteAllBytesAsync(filePath, bytes);
             //return $"/avatars/{fileName}";
             return $"/avatars/{safeName}";
+        }
+
+        public Task<List<string>> GetAvailableAvatars()
+        {
+            var webRoot = _env.WebRootPath;
+            if (string.IsNullOrEmpty(webRoot))
+                webRoot = Path.Combine(AppContext.BaseDirectory, "wwwroot");
+            var avatarsPath = Path.Combine(webRoot, "avatars");
+            if (!Directory.Exists(avatarsPath))
+                return Task.FromResult(new List<string>());
+            var files = Directory.GetFiles(avatarsPath)
+                .Select(f => $"/avatars/{Path.GetFileName(f)}")
+                .ToList();
+            return Task.FromResult(files);
         }
 
         public async Task SaveUserSettings(string username, string json)


### PR DESCRIPTION
## Summary
- allow client to request avatar list from server and local storage
- expose hub method returning avatar files from server avatar folder

## Testing
- `dotnet build Serveur/Serveur.csproj`
- `dotnet build Client/Client.csproj` *(fails: NETSDK1100, Windows targeting not enabled)*

------
https://chatgpt.com/codex/tasks/task_e_688e34b2677c8324ac3e8490eda445f7