### PR TITLE
Preserve user avatar when syncing settings

### DIFF
--- a/Client/Helpers/AppSettings.cs
+++ b/Client/Helpers/AppSettings.cs
@@ -119,7 +119,12 @@ namespace Client.Helpers
                 var dict = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
                 if (dict != null)
                 {
-                    _settings = dict;
+                    foreach (var kvp in dict)
+                    {
+                        if (kvp.Value.ValueKind == JsonValueKind.Null)
+                            continue;
+                        _settings[kvp.Key] = kvp.Value;
+                    }
                     Save();
                 }
             }


### PR DESCRIPTION
## Summary
- Prevent server sync from overwriting existing settings by merging imported values

## Testing
- `dotnet build Client/Client.csproj -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_688e3f94fd048324b2edb4760b54043a