### PR TITLE
Ajout déclaration patient via code examen

### DIFF
--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -240,7 +240,10 @@ namespace Client.Pages
                 if (exam != null)
                 {
                     var name = text.Substring(exam.CodeMSG.Length).Trim();
-                    _ = HotKeyService.ShowPatientDialogAsync(exam.Name, name);
+                    if (string.IsNullOrEmpty(name))
+                        _ = HotKeyService.ShowPatientDialogAsync(exam.Name);
+                    else
+                        _ = HotKeyService.DeclarePatientAsync(exam.Name, name);
                     InputBox.Text = string.Empty;
                     return;
                 }

--- a/Client/Services/HotKeyService.cs
+++ b/Client/Services/HotKeyService.cs
@@ -284,6 +284,39 @@ namespace Client.Services
             }
         }
 
+        public static async Task DeclarePatientAsync(string examName, string patientName)
+        {
+            var options = ExamOption.Load();
+            var opt = options.FirstOrDefault(o => o.Name.Equals(examName, StringComparison.OrdinalIgnoreCase));
+
+            PatientStringHelper.ExtractInfoFromInput(patientName.Trim(),
+                out var title, out var lastName, out var firstName);
+
+            var patient = new Patient
+            {
+                Id = Guid.NewGuid().ToString(),
+                Colors = opt?.Color ?? string.Empty,
+                Title = title,
+                LastName = lastName,
+                FirstName = firstName,
+                Exams = examName,
+                Eye = "ODG",
+                Annotation = opt?.Annotation ?? string.Empty,
+                Position = opt?.Floor ?? string.Empty,
+                HoldTime = DateTime.Now,
+                Examinator = App.UserName,
+            };
+
+            try
+            {
+                await App.ChatService.DeclarePatient(patient);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[HotKeyService] Error declaring patient: {ex.Message}");
+            }
+        }
+
         private static void AddLabeledControl(Grid grid, int row, string label, UIElement control)
         {
             var tb = new TextBlock { Text = label, VerticalAlignment = VerticalAlignment.Center };


### PR DESCRIPTION
## Summary
- Allow declaring patient by entering exam code prefix in chat input
- Expose HotKeyService.ShowPatientDialogAsync with optional patient name

## Testing
- `~/.dotnet/dotnet build -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_688f3c9419c48324acb096c456627ee8