### PR TITLE
Ajout déclaration patient via code examen

### DIFF
--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -234,6 +234,20 @@ namespace Client.Pages
             {
                 e.Handled = true;
                 var text = InputBox.Text.Trim();
+
+                var options = ExamOption.Load();
+                var exam = options.FirstOrDefault(o => !string.IsNullOrEmpty(o.CodeMSG) && text.StartsWith(o.CodeMSG, StringComparison.OrdinalIgnoreCase));
+                if (exam != null)
+                {
+                    var name = text.Substring(exam.CodeMSG.Length).Trim();
+                    if (string.IsNullOrEmpty(name))
+                        _ = HotKeyService.ShowPatientDialogAsync(exam.Name);
+                    else
+                        _ = HotKeyService.DeclarePatientAsync(exam.Name, name);
+                    InputBox.Text = string.Empty;
+                    return;
+                }
+
                 if (string.Equals(text, "/getallroom", StringComparison.OrdinalIgnoreCase))
                 {
                     _ = ShowAllGroupsDialog();

--- a/Client/Services/HotKeyService.cs
+++ b/Client/Services/HotKeyService.cs
@@ -173,7 +173,7 @@ namespace Client.Services
             }, IntPtr.Zero);
             return foundTitle;
         }
-        private static async Task ShowPatientDialogAsync(string examName)
+        public static async Task ShowPatientDialogAsync(string examName, string? patientName = null)
         {
             var options = ExamOption.Load();
             var rooms = RoomList.Load();
@@ -213,22 +213,29 @@ namespace Client.Services
                 floorCombo.SelectedItem = examOpt.Floor;
             var commentBox = new TextBox { PlaceholderText = "Commentaire", Width = 600 };
 
-            // Extract patient name from active window title
-            var title = GetActiveWindowTitle();
-            Debug.WriteLine($"[HotKeyService] Active window title: {title}");
-
-            if (!TryExtractPatientFromTitle(title, out var patientTitle, out var lastName, out var firstName))
+            // Extract patient name either from parameter or active window title
+            if (string.IsNullOrWhiteSpace(patientName))
             {
-                var other = FindExamWindowTitle();
-                if (!string.IsNullOrEmpty(other))
-                {
-                    Debug.WriteLine($"[HotKeyService] Using window title: {other}");
-                    TryExtractPatientFromTitle(other, out patientTitle, out lastName, out firstName);
-                }
-            }
+                var title = GetActiveWindowTitle();
+                Debug.WriteLine($"[HotKeyService] Active window title: {title}");
 
-            if (!string.IsNullOrWhiteSpace(patientTitle) || !string.IsNullOrWhiteSpace(lastName) || !string.IsNullOrWhiteSpace(firstName))
-                nameBox.Text = $"{patientTitle} {lastName} {firstName}".Trim();
+                if (!TryExtractPatientFromTitle(title, out var patientTitle, out var lastName, out var firstName))
+                {
+                    var other = FindExamWindowTitle();
+                    if (!string.IsNullOrEmpty(other))
+                    {
+                        Debug.WriteLine($"[HotKeyService] Using window title: {other}");
+                        TryExtractPatientFromTitle(other, out patientTitle, out lastName, out firstName);
+                    }
+                }
+
+                if (!string.IsNullOrWhiteSpace(patientTitle) || !string.IsNullOrWhiteSpace(lastName) || !string.IsNullOrWhiteSpace(firstName))
+                    nameBox.Text = $"{patientTitle} {lastName} {firstName}".Trim();
+            }
+            else
+            {
+                nameBox.Text = patientName;
+            }
 
             // Layout
             AddLabeledControl(grid, 0, "Nom", nameBox);
@@ -274,6 +281,39 @@ namespace Client.Services
                 {
                     Debug.WriteLine($"[HotKeyService] Error declaring patient: {ex.Message}");
                 }
+            }
+        }
+
+        public static async Task DeclarePatientAsync(string examName, string patientName)
+        {
+            var options = ExamOption.Load();
+            var opt = options.FirstOrDefault(o => o.Name.Equals(examName, StringComparison.OrdinalIgnoreCase));
+
+            PatientStringHelper.ExtractInfoFromInput(patientName.Trim(),
+                out var title, out var lastName, out var firstName);
+
+            var patient = new Patient
+            {
+                Id = Guid.NewGuid().ToString(),
+                Colors = opt?.Color ?? string.Empty,
+                Title = title,
+                LastName = lastName,
+                FirstName = firstName,
+                Exams = examName,
+                Eye = "ODG",
+                Annotation = opt?.Annotation ?? string.Empty,
+                Position = opt?.Floor ?? string.Empty,
+                HoldTime = DateTime.Now,
+                Examinator = App.UserName,
+            };
+
+            try
+            {
+                await App.ChatService.DeclarePatient(patient);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[HotKeyService] Error declaring patient: {ex.Message}");
             }
         }
 


### PR DESCRIPTION
## Summary
- Declare patient automatically when chat input begins with an exam code and a name
- Add HotKeyService.DeclarePatientAsync to create patient objects directly from exam options

## Testing
- `~/.dotnet/dotnet build -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_688f3c9419c48324acb096c456627ee8