### PR TITLE
Synchroniser les paramètres utilisateurs

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.IO;
 using Client.Pages;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR.Client;
 
 namespace Client
 {
@@ -23,6 +24,21 @@ namespace Client
         public App()
         {
             this.InitializeComponent();
+
+            AppSettings.SettingsChanged += async () =>
+            {
+                try
+                {
+                    if (ChatService.Connection != null && ChatService.Connection.State == HubConnectionState.Connected)
+                    {
+                        await ChatService.SaveUserSettingsAsync(UserName, AppSettings.Export());
+                    }
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"❌ Sync settings error: {ex.Message}");
+                }
+            };
         }
 
         protected async override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
@@ -128,10 +144,11 @@ namespace Client
                 ChatService.RoomName = machine.RoomName;
                 await ChatService.InitializeAsync();
                 await SyncUserSettingsAsync(root);
+                await DownloadMissingUserSettingsAsync();
             }
         }
 
-        private static void ApplySavedAppearance(FrameworkElement root)
+        public static void ApplySavedAppearance(FrameworkElement root)
         {
             var theme = AppSettings.Get("AppTheme", "Dark");
             if (Enum.TryParse<ApplicationTheme>(theme, out var appTheme))
@@ -242,6 +259,28 @@ namespace Client
             }
         }
 
+        private async Task DownloadMissingUserSettingsAsync()
+        {
+            try
+            {
+                var appFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat");
+                Directory.CreateDirectory(appFolder);
+                var localUsers = Directory.GetFiles(appFolder, "*_settings.json")
+                    .Select(f => Path.GetFileNameWithoutExtension(f).Replace("_settings", ""))
+                    .ToList();
+                var missing = await ChatService.GetMissingUserSettingsAsync(localUsers);
+                foreach (var kvp in missing)
+                {
+                    var path = Path.Combine(appFolder, $"{kvp.Key}_settings.json");
+                    File.WriteAllText(path, kvp.Value);
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"❌ Sync missing settings error: {ex.Message}");
+            }
+        }
+
         public async Task ChangeUserAsync(string username)
         {
             if (MainWindow?.Content is not FrameworkElement root)
@@ -267,6 +306,7 @@ namespace Client
 
             await ChatService.InitializeAsync();
             await SyncUserSettingsAsync(root);
+            await DownloadMissingUserSettingsAsync();
 
             if (MainWindow is MainWindow mw)
             {

--- a/Client/Helpers/AppSettings.cs
+++ b/Client/Helpers/AppSettings.cs
@@ -11,6 +11,8 @@ namespace Client.Helpers
     {
         private static Dictionary<string, JsonElement> _settings = new();
 
+        public static event Action? SettingsChanged;
+
         private static string FilePath =>
               Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                 "EyeChat",
@@ -91,6 +93,7 @@ namespace Client.Helpers
         {
             _settings[key] = JsonDocument.Parse($"\"{value}\"").RootElement;
             Save();
+            SettingsChanged?.Invoke();
         }
 
         public static void SetObject<T>(string key, T value)
@@ -98,6 +101,7 @@ namespace Client.Helpers
             var json = JsonSerializer.Serialize(value);
             _settings[key] = JsonDocument.Parse(json).RootElement;
             Save();
+            SettingsChanged?.Invoke();
         }
 
         public static string Export()

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -901,20 +901,9 @@ namespace Client.Pages
             _ignoreOrderChange = false;
         }
 
-        private async void SaveUserOrder()
+        private void SaveUserOrder()
         {
             AppSettings.UserOrder = ConnectedUsers.Select(u => u.Username).ToList();
-
-            if (_service.Connection != null &&
-                _service.Connection.State == HubConnectionState.Connected)
-            {
-                try
-                {
-                    await _service.SaveUserSettingsAsync(App.UserName,
-                        AppSettings.Export());
-                }
-                catch { }
-            }
         }
     }
 

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Threading;
 using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
 using Windows.ApplicationModel.Chat;
 using Microsoft.VisualBasic;
 using Newtonsoft.Json;
@@ -377,10 +378,35 @@ namespace Client.Services
                 RoomsUpdated?.Invoke(rooms);
             });
 
+            Connection.On<string, string>("UserSettingsUpdated", (username, json) =>
+            {
+                Dispatcher?.TryEnqueue(() =>
+                {
+                    try
+                    {
+                        var appFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat");
+                        Directory.CreateDirectory(appFolder);
+                        var path = Path.Combine(appFolder, $"{username}_settings.json");
+                        File.WriteAllText(path, json);
+
+                        if (username == App.UserName)
+                        {
+                            AppSettings.Import(json);
+                            if (App.MainWindow?.Content is FrameworkElement root)
+                                App.ApplySavedAppearance(root);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"Erreur MAJ paramètres : {ex.Message}");
+                    }
+                });
+            });
+
             try
             {
                 await Connection.StartAsync();
-                await Connection.InvokeAsync("RegisterUser", username, ToServerAvatar(avatar), room, color); 
+                await Connection.InvokeAsync("RegisterUser", username, ToServerAvatar(avatar), room, color);
                 StopReconnectTimer();
             }
             catch (Exception ex)
@@ -837,6 +863,25 @@ namespace Client.Services
             {
                 Debug.WriteLine($"Erreur récupération paramètres : {ex.Message}");
                 return string.Empty;
+            }
+        }
+
+        public async Task<Dictionary<string, string>> GetMissingUserSettingsAsync(IEnumerable<string> knownUsers)
+        {
+            if (Connection is null || Connection.State != HubConnectionState.Connected)
+            {
+                var connected = await TryReconnectAsync();
+                if (!connected) return new Dictionary<string, string>();
+            }
+
+            try
+            {
+                return await Connection.InvokeAsync<Dictionary<string, string>>("GetMissingUserSettings", knownUsers);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur récupération paramètres manquants : {ex.Message}");
+                return new Dictionary<string, string>();
             }
         }
 

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -518,12 +518,21 @@ namespace ChatServeur
 
             setting.SettingsJson = json;
             await _db.SaveChangesAsync();
+
+            await Clients.Others.SendAsync("UserSettingsUpdated", username, json);
         }
 
         public async Task<string?> GetUserSettings(string username)
         {
             var setting = await _db.UserSettings.FirstOrDefaultAsync(s => s.Username == username);
             return setting?.SettingsJson;
+        }
+
+        public async Task<Dictionary<string, string>> GetMissingUserSettings(IEnumerable<string> knownUsers)
+        {
+            return await _db.UserSettings
+                .Where(s => !knownUsers.Contains(s.Username))
+                .ToDictionaryAsync(s => s.Username, s => s.SettingsJson);
         }
 
         public Task<List<UserInfo>> GetAllUsers()


### PR DESCRIPTION
## Summary
- Diffuser les paramètres utilisateur sauvegardés et exposer les paramètres manquants côté serveur
- Mettre à jour/recevoir automatiquement les fichiers `{user}_settings.json` côté client
- Propager les modifications locales de paramètres vers le serveur et les autres clients

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(échoue: XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_688f6fb0113c8324ab980ce9dc550bef