### PR TITLE
feat: add call request workflow

### DIFF
--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -211,8 +211,8 @@
         </Style>
 
         <!-- Menu contextuel des utilisateurs -->
-        <MenuFlyout x:Key="UserContextMenu">
-            <MenuFlyoutItem Text="Message"/>
+        <MenuFlyout x:Key="UserContextMenu" Opened="UserContextMenu_Opened">
+            <MenuFlyoutItem Text="Tu peut venir" Click="CallUser_Click"/>
             <MenuFlyoutItem Text="Monter" Click="MoveUserUp_Click"/>
             <MenuFlyoutItem Text="Descendre" Click="MoveUserDown_Click"/>
         </MenuFlyout>

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -61,6 +61,7 @@ namespace Client.Pages
             _service.OnPatientRemoved += Service_OnPatientRemoved;
             _service.OnPatientUpdated += Service_OnPatientUpdated;
             _service.ReconnectCountdownChanged += Service_ReconnectCountdownChanged;
+            _service.OnCallReceived += Service_OnCallReceived;
             Loaded += ChatPage_Loaded;
             Unloaded += ChatPage_Unloaded;
         }
@@ -71,6 +72,7 @@ namespace Client.Pages
             _service.OnPatientRemoved -= Service_OnPatientRemoved;
             _service.OnPatientUpdated -= Service_OnPatientUpdated;
             _service.ReconnectCountdownChanged -= Service_ReconnectCountdownChanged;
+            _service.OnCallReceived -= Service_OnCallReceived;
             ViewModel.ViewModel.SettingsViewModel.DisplayStyleChanged -= ApplyChatStyle;
             ViewModel.ViewModel.SettingsViewModel.BubbleColorModeChanged -= ApplyBubbleColorMode;
             Patients.CollectionChanged -= Patients_CollectionChanged;
@@ -619,6 +621,31 @@ namespace Client.Pages
             });
         }
 
+        private async void Service_OnCallReceived(string caller, string room)
+        {
+            var dialog = new ContentDialog
+            {
+                Title = "Appel",
+                Content = $"{caller} vous a appelé dans la pièce {room}",
+                PrimaryButtonText = "0",
+                SecondaryButtonText = "5",
+                CloseButtonText = "AT",
+                DefaultButton = ContentDialogButton.Primary,
+                XamlRoot = this.XamlRoot
+            };
+
+            var result = await dialog.ShowAsync();
+            string response = result switch
+            {
+                ContentDialogResult.Primary => "je vient dans 0",
+                ContentDialogResult.Secondary => "je vient dans 5",
+                _ => "met en attente"
+            };
+
+            var avatar = AppSettings.Get("Avatar", "ms-appx:///Assets/earth.png");
+            await _service.SendMessage(App.UserName, _service.RoomName, "A Tous", response, avatar, DateTime.Now);
+        }
+
         private IEnumerable<Patient> GetPatientsForRoom(string room)
         {
             IEnumerable<Patient> query = room == "Toutes"
@@ -634,6 +661,19 @@ namespace Client.Pages
         {
             if (sender is MenuFlyout menu)
                 _currentMessageTarget = menu.Target as FrameworkElement;
+        }
+
+        private void UserContextMenu_Opened(object sender, object e)
+        {
+            if (sender is MenuFlyout menu && menu.Items.Count > 0)
+            {
+                if (menu.Items[0] is MenuFlyoutItem item && menu.Target?.DataContext is UserInfo user)
+                {
+                    item.Visibility = (user.Username == "A Tous" || user.Username == "Secrétariat")
+                        ? Visibility.Collapsed
+                        : Visibility.Visible;
+                }
+            }
         }
 
         private void CopySelection_Click(object sender, RoutedEventArgs e)
@@ -843,6 +883,17 @@ namespace Client.Pages
                 MessagesList.ItemTemplateSelector = null;
                 MessagesList.ItemTemplateSelector = selector;
                 MessagesList.UpdateLayout();
+            }
+        }
+
+        private async void CallUser_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as FrameworkElement)?.DataContext is UserInfo user)
+            {
+                var avatar = AppSettings.Get("Avatar", "ms-appx:///Assets/earth.png");
+                var content = $"{App.UserName} a appelé {user.Username}";
+                await _service.SendMessage(App.UserName, _service.RoomName, "A Tous", content, avatar, DateTime.Now);
+                await _service.CallUser(App.UserName, _service.RoomName, user.Username);
             }
         }
 

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -59,6 +59,7 @@ namespace Client.Services
         }
 
         public event Action<ChatMessageModel>? OnMessageReceived;
+        public event Action<string, string>? OnCallReceived;
         public event Action<Patient>? OnNewPatient;
         public event Action<string>? OnPatientRemoved;
         public event Action<Patient>? OnPatientUpdated;
@@ -317,6 +318,11 @@ namespace Client.Services
                 });
             });
 
+            Connection.On<string, string>("ReceiveCall", (caller, room) =>
+            {
+                Dispatcher?.TryEnqueue(() => OnCallReceived?.Invoke(caller, room));
+            });
+
             Connection.On<int>("MessageDeleted", id =>
             {
                 Dispatcher?.TryEnqueue(async () =>
@@ -438,6 +444,13 @@ namespace Client.Services
                 throw new InvalidOperationException("Connexion SignalR non établie.");
             await Connection.InvokeAsync("SendMessage", sender, roomname, destinataire, message, ToServerAvatar(avatar), timemessage);
 
+        }
+
+        public async Task CallUser(string sender, string roomname, string destinataire)
+        {
+            if (Connection is null || Connection.State != HubConnectionState.Connected)
+                throw new InvalidOperationException("Connexion SignalR non établie.");
+            await Connection.InvokeAsync("CallUser", sender, roomname, destinataire);
         }
 
         public async Task<Result<List<ChatMessageModel>>> LoadTodayMessagesAsync(string username)

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -268,7 +268,15 @@ namespace ChatServeur
                 await Clients.Group(destinataire).SendAsync("ReceiveMessage", message.Id, sender, room, destinataire, content, avatar, timestamp);
                 await Clients.Caller.SendAsync("ReceiveMessage", message.Id, sender, room, destinataire, content, avatar, timestamp);
             }
-            Console.WriteLine($"[SERVER] Message sent from {sender} to {destinataire} in room {room}: {content}");  
+            Console.WriteLine($"[SERVER] Message sent from {sender} to {destinataire} in room {room}: {content}");
+        }
+
+        public async Task CallUser(string caller, string room, string destinataire)
+        {
+            if (_userToConnectionId.TryGetValue(destinataire, out var targetConnectionIds))
+            {
+                await Clients.Clients(targetConnectionIds).SendAsync("ReceiveCall", caller, room);
+            }
         }
 
         public async Task JoinRoom(string roomName)


### PR DESCRIPTION
## Summary
- replace user context menu Message with Tu peut venir
- broadcast call request and response messages through SignalR
- show dialog for called user with quick reply buttons

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*
- `dotnet build Serveur/Serveur.csproj`


------
https://chatgpt.com/codex/tasks/task_e_688f7461cd808324ae24134aad438e1d