### PR TITLE
Improve server detection and reconnect handling

### DIFF
--- a/Client/Helpers/ConnectionConfig.cs
+++ b/Client/Helpers/ConnectionConfig.cs
@@ -6,7 +6,7 @@ namespace Client.Helpers
 {
     public class ConnectionConfig
     {
-        public string ServerAddress { get; set; } = "http://localhost:5000";
+        public string ServerAddress { get; set; } = string.Empty;
 
         public static string FilePath =>
             Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),

--- a/Client/Pages/ConnectionPage.xaml.cs
+++ b/Client/Pages/ConnectionPage.xaml.cs
@@ -37,13 +37,13 @@ namespace Client.Pages
             if (!string.IsNullOrEmpty(address))
             {
                 ServerAddress = address;
+                AddressBox.Text = ServerAddress;
             }
             else
             {
-                // fallback to localhost if nothing found
-                ServerAddress = "http://localhost:5000";
+                ServerAddress = string.Empty;
+                AddressBox.Text = "Serveur introuvable";
             }
-            AddressBox.Text = ServerAddress;
         }
     }
 }

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -48,7 +48,7 @@ namespace Client.Services
         public bool IsHistoryLoaded => _historyLoaded;
         public IReadOnlyList<UserInfo> KnownUsers => _lastServerUserList;
 
-        public string ServerAddress { get; set; } = "http://localhost:5000";
+        public string ServerAddress { get; set; } = string.Empty;
 
         public SignalRService()
         {
@@ -106,6 +106,23 @@ namespace Client.Services
                 return;
 
             _initialized = true;
+
+            if (string.IsNullOrWhiteSpace(ServerAddress) || ServerAddress.Contains("localhost"))
+            {
+                var detected = await NetworkScanner.FindServerAsync();
+                if (!string.IsNullOrEmpty(detected))
+                {
+                    ServerAddress = detected;
+                    ConnectionConfig.Save(new ConnectionConfig { ServerAddress = ServerAddress });
+                }
+                else if (ServerAddress.Contains("localhost"))
+                {
+                    ServerAddress = string.Empty;
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(ServerAddress))
+                return;
 
             var cachedUsers = await LoadUsersFromDiskAsync();
             foreach (var user in cachedUsers)
@@ -188,7 +205,6 @@ namespace Client.Services
 
             Connection = new HubConnectionBuilder()
                 .WithUrl($"{ServerAddress}/chatHub")
-                .WithAutomaticReconnect()
                 .Build();
 
             Connection.Closed += async (error) =>


### PR DESCRIPTION
## Summary
- auto-detect server address on startup to avoid localhost issues
- remove SignalR automatic reconnect to rely on custom timer
- show 'Serveur introuvable' when server search fails

## Testing
- `dotnet build WebApplication1.sln -c Release` *(fails: NETSDK1100 targeting Windows on Linux)*
- `dotnet build Serveur/Serveur.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_688f7df5bbb0832481fe01663d854b49