### PR TITLE
Fix crash when connecting with raw IP address

### DIFF
--- a/Client/Pages/ConnectionPage.xaml.cs
+++ b/Client/Pages/ConnectionPage.xaml.cs
@@ -13,7 +13,8 @@ namespace Client.Pages
         {
             this.InitializeComponent();
             var cfg = ConnectionConfig.Load();
-            ServerAddress = cfg.ServerAddress;
+            App.ChatService.ServerAddress = cfg.ServerAddress;
+            ServerAddress = App.ChatService.ServerAddress;
             DataContext = this;
         }
 
@@ -25,8 +26,8 @@ namespace Client.Pages
 
         private async void Save_Click(object sender, RoutedEventArgs e)
         {
-            ConnectionConfig.Save(new ConnectionConfig { ServerAddress = ServerAddress });
             App.ChatService.ServerAddress = ServerAddress;
+            ConnectionConfig.Save(new ConnectionConfig { ServerAddress = App.ChatService.ServerAddress });
             await App.ChatService.InitializeAsync();
         }
 

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -48,7 +48,12 @@ namespace Client.Services
         public bool IsHistoryLoaded => _historyLoaded;
         public IReadOnlyList<UserInfo> KnownUsers => _lastServerUserList;
 
-        public string ServerAddress { get; set; } = string.Empty;
+        private string _serverAddress = string.Empty;
+        public string ServerAddress
+        {
+            get => _serverAddress;
+            set => _serverAddress = NormalizeServerAddress(value);
+        }
 
         public SignalRService()
         {
@@ -70,6 +75,22 @@ namespace Client.Services
         {
             ContractResolver = new Newtonsoft.Json.Serialization.CamelCasePropertyNamesContractResolver()
         };
+
+        private static string NormalizeServerAddress(string address)
+        {
+            if (string.IsNullOrWhiteSpace(address))
+                return string.Empty;
+
+            address = address.Trim();
+
+            if (!address.StartsWith("http://", StringComparison.OrdinalIgnoreCase) &&
+                !address.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                address = "http://" + address;
+            }
+
+            return address.TrimEnd('/');
+        }
 
         private string ToServerAvatar(string avatar)
         {


### PR DESCRIPTION
## Summary
- Normalize server address in SignalR client to ensure a valid scheme is present
- Save sanitized server address from connection settings page

## Testing
- `dotnet build Serveur/Serveur.csproj`
- `dotnet test` *(fails: NETSDK1100 To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_6890ef1b602083249288a2d130c6119b