### PR TITLE
Handle async call notification correctly

### DIFF
--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -621,7 +621,7 @@ namespace Client.Pages
             });
         }
 
-        private async void Service_OnCallReceived(string caller, string room)
+        private async Task Service_OnCallReceived(string caller, string room)
         {
             var dialog = new ContentDialog
             {

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -64,7 +64,7 @@ namespace Client.Services
         }
 
         public event Action<ChatMessageModel>? OnMessageReceived;
-        public event Action<string, string>? OnCallReceived;
+        public event Func<string, string, Task>? OnCallReceived;
         public event Action<Patient>? OnNewPatient;
         public event Action<string>? OnPatientRemoved;
         public event Action<Patient>? OnPatientUpdated;
@@ -357,7 +357,11 @@ namespace Client.Services
 
             Connection.On<string, string>("ReceiveCall", (caller, room) =>
             {
-                Dispatcher?.TryEnqueue(() => OnCallReceived?.Invoke(caller, room));
+                Dispatcher?.TryEnqueue(async () =>
+                {
+                    if (OnCallReceived != null)
+                        await OnCallReceived(caller, room);
+                });
             });
 
             Connection.On<int>("MessageDeleted", id =>


### PR DESCRIPTION
## Summary
- Make call notification event async to allow awaiting handlers
- Await call dialog and message send in ChatPage

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(no tests found)*
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_6891dc7619988324bc653dac175e5c54