### PR TITLE
Force call dialog to remain on top

### DIFF
--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -623,6 +623,11 @@ namespace Client.Pages
 
         private async Task Service_OnCallReceived(string caller, string room)
         {
+            if (App.MainWindow is Window mainWindow)
+            {
+                WindowHelper.SetTopMost(mainWindow, true, true);
+            }
+
             var dialog = new ContentDialog
             {
                 Title = "Appel",
@@ -635,6 +640,11 @@ namespace Client.Pages
             };
 
             var result = await dialog.ShowAsync();
+
+            if (App.MainWindow is Window window)
+            {
+                WindowHelper.SetTopMost(window, false, false);
+            }
             string response = result switch
             {
                 ContentDialogResult.Primary => "je vient dans 0",


### PR DESCRIPTION
## Summary
- ensure incoming call dialog forces main window to topmost while awaiting response

## Testing
- `dotnet build Client/Client.csproj -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_6892347f07048324bdb22d166982604c