### PR TITLE
feat: allow editing patients

### DIFF
--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -232,6 +232,7 @@
                 <Border.ContextFlyout>
                     <MenuFlyout>
                         <MenuFlyoutItem Text="{x:Bind ToggleExamLabel}" Tag="{x:Bind}" Click="TogglePatientTaken_Click" />
+                        <MenuFlyoutItem Text="Modifier" Tag="{x:Bind}" Click="EditPatient_Click" />
                         <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
                         <MenuFlyoutSubItem Text="Modification temps" Visibility="{Binding TimeModificationVisibility, ElementName=PageRoot}">
                         <MenuFlyoutItem Text="Mettre en premier" Tag="{x:Bind}" Click="MovePatientFirst_Click" />
@@ -278,6 +279,7 @@
                 <Border.ContextFlyout>
                     <MenuFlyout>
                         <MenuFlyoutItem Text="{x:Bind ToggleExamLabel}" Tag="{x:Bind}" Click="TogglePatientTaken_Click" />
+                        <MenuFlyoutItem Text="Modifier" Tag="{x:Bind}" Click="EditPatient_Click" />
                     <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
                     
                 </MenuFlyout>

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -493,6 +493,15 @@ namespace Client.Pages
             }
         }
 
+        private async void EditPatient_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as MenuFlyoutItem)?.Tag is Patient patient)
+            {
+                await HotKeyService.ShowEditPatientDialogAsync(patient);
+                UpdatePatientViews();
+            }
+        }
+
         private async void TogglePatientTaken_Click(object sender, RoutedEventArgs e)
         {
             if ((sender as MenuFlyoutItem)?.Tag is Patient patient)

--- a/Client/Pages/HistoryPage.xaml
+++ b/Client/Pages/HistoryPage.xaml
@@ -11,6 +11,7 @@
                 <Border.ContextFlyout>
                     <MenuFlyout>
                         <MenuFlyoutItem Text="{x:Bind ToggleExamLabel}" Tag="{x:Bind}" Click="TogglePatientTaken_Click" />
+                        <MenuFlyoutItem Text="Modifier" Tag="{x:Bind}" Click="EditPatient_Click" />
                         <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
                         <MenuFlyoutSubItem Text="Modification temps" Visibility="{Binding TimeModificationVisibility, ElementName=PageRoot}">
                             <MenuFlyoutItem Text="Mettre en premier" Tag="{x:Bind}" Click="MovePatientFirst_Click" />
@@ -45,6 +46,7 @@
                 <Border.ContextFlyout>
                     <MenuFlyout>
                         <MenuFlyoutItem Text="{x:Bind ToggleExamLabel}" Tag="{x:Bind}" Click="TogglePatientTaken_Click" />
+                        <MenuFlyoutItem Text="Modifier" Tag="{x:Bind}" Click="EditPatient_Click" />
                         <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
                     </MenuFlyout>
                 </Border.ContextFlyout>

--- a/Client/Pages/HistoryPage.xaml.cs
+++ b/Client/Pages/HistoryPage.xaml.cs
@@ -127,6 +127,15 @@ namespace Client.Pages
             }
         }
 
+        private async void EditPatient_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as MenuFlyoutItem)?.Tag is Patient patient)
+            {
+                await HotKeyService.ShowEditPatientDialogAsync(patient);
+                BuildRooms();
+            }
+        }
+
         private async void DeletePatient_Click(object sender, RoutedEventArgs e)
         {
             if ((sender as MenuFlyoutItem)?.Tag is Patient patient)

--- a/Client/Services/HotKeyService.cs
+++ b/Client/Services/HotKeyService.cs
@@ -284,6 +284,86 @@ namespace Client.Services
             }
         }
 
+        public static async Task ShowEditPatientDialogAsync(Patient patient)
+        {
+            var options = ExamOption.Load();
+            var rooms = RoomList.Load();
+
+            var dialog = new ContentDialog
+            {
+                Title = "Modifier un patient",
+                PrimaryButtonText = "Valider",
+                CloseButtonText = "Annuler",
+                XamlRoot = App.MainWindow.Content.XamlRoot,
+            };
+
+            var grid = new Grid { ColumnSpacing = 10, RowSpacing = 4 };
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            for (int i = 0; i < 5; i++)
+                grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+            var nameBox = new TextBox { Width = 600, Text = $"{patient.Title} {patient.LastName} {patient.FirstName}".Trim() };
+            var examCombo = new ComboBox
+            {
+                ItemsSource = options,
+                DisplayMemberPath = "Name",
+                SelectedValuePath = "Name",
+                SelectedValue = patient.Exams,
+                Width = 600
+            };
+            var eyeCombo = new ComboBox { Width = 600 };
+            eyeCombo.Items.Add(new ComboBoxItem { Content = "ODG" });
+            eyeCombo.Items.Add(new ComboBoxItem { Content = "OD" });
+            eyeCombo.Items.Add(new ComboBoxItem { Content = "OG" });
+            eyeCombo.SelectedItem = eyeCombo.Items
+                .OfType<ComboBoxItem>()
+                .FirstOrDefault(i => (string)i.Content == patient.Eye) ?? eyeCombo.Items[0];
+
+            var floorCombo = new ComboBox { Width = 600, ItemsSource = rooms, SelectedItem = patient.Position };
+            var timePicker = new TimePicker { Width = 600, Time = patient.HoldTime.TimeOfDay };
+            var commentBox = new TextBox { Width = 600, Text = patient.Annotation };
+
+            AddLabeledControl(grid, 0, "Nom", nameBox);
+            AddLabeledControl(grid, 1, "Examen", examCombo);
+            AddLabeledControl(grid, 2, "Heure", timePicker);
+            AddLabeledControl(grid, 3, "Salle", floorCombo);
+            AddLabeledControl(grid, 4, "Commentaire", commentBox);
+
+            dialog.Content = grid;
+
+            var result = await dialog.ShowAsync();
+            if (result == ContentDialogResult.Primary)
+            {
+                var inputName = nameBox.Text.Trim();
+                PatientStringHelper.ExtractInfoFromInput(inputName,
+                    out var titleBox, out var lastNameBox, out var firstNameBox);
+
+                var selectedExam = examCombo.SelectedValue as string ?? string.Empty;
+                var opt = options.FirstOrDefault(o => o.Name == selectedExam);
+
+                patient.Title = titleBox;
+                patient.LastName = lastNameBox;
+                patient.FirstName = firstNameBox;
+                patient.Exams = selectedExam;
+                patient.Eye = (eyeCombo.SelectedItem as ComboBoxItem)?.Content as string ?? string.Empty;
+                patient.Annotation = string.IsNullOrWhiteSpace(commentBox.Text) ? opt?.Annotation ?? string.Empty : commentBox.Text.Trim();
+                patient.Position = floorCombo.SelectedItem as string ?? string.Empty;
+                patient.Colors = opt?.Color ?? string.Empty;
+                var date = patient.HoldTime.Date;
+                patient.HoldTime = date + timePicker.Time;
+
+                try
+                {
+                    await App.ChatService.UpdatePatientAsync(patient);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[HotKeyService] Error updating patient: {ex.Message}");
+                }
+            }
+        }
+
         public static async Task DeclarePatientAsync(string examName, string patientName)
         {
             var options = ExamOption.Load();

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -669,6 +669,12 @@ namespace Client.Services
                 await Connection.InvokeAsync("UpdatePatientHoldTime", id, newTime);
         }
 
+        public async Task UpdatePatientAsync(Patient patient)
+        {
+            if (Connection != null && Connection.State == HubConnectionState.Connected)
+                await Connection.InvokeAsync("UpdatePatient", patient);
+        }
+
         public async Task DeleteMessageAsync(int id)
         {
             if (Connection != null && Connection.State == HubConnectionState.Connected)

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -724,6 +724,26 @@ namespace ChatServeur
             }
         }
 
+        public async Task UpdatePatient(Patient updated)
+        {
+            var patient = await _db.Patients.FindAsync(updated.Id);
+            if (patient != null)
+            {
+                patient.Title = updated.Title;
+                patient.LastName = updated.LastName;
+                patient.FirstName = updated.FirstName;
+                patient.Exams = updated.Exams;
+                patient.Eye = updated.Eye;
+                patient.Annotation = updated.Annotation;
+                patient.Position = updated.Position;
+                patient.Colors = updated.Colors;
+                patient.HoldTime = updated.HoldTime;
+                _db.Patients.Update(patient);
+                await _db.SaveChangesAsync();
+                await Clients.All.SendAsync("PatientUpdated", patient);
+            }
+        }
+
         public async Task<List<Patient>> GetPatients()
         {
             var today = DateTime.Today;


### PR DESCRIPTION
## Summary
- add context menu entry to edit patients
- implement dialog to update patient name, exam, time and room
- propagate patient updates through SignalR and server hub

## Testing
- `/root/.dotnet/dotnet build -p:EnableWindowsTargeting=true` *(fails: XamlCompiler exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_689244dff2f08324a04b88aa1f061645