### PR TITLE
Display eye and annotation on patient label

### DIFF
--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -263,9 +263,12 @@
                        Text="{x:Bind Examinator}" Foreground="{x:Bind ForegroundColor}"
                        HorizontalAlignment="Right"/>
 
-                    <!-- Deuxième ligne : examens et heure -->
-                    <TextBlock Grid.Row="1" Grid.Column="0"
-                       Text="{x:Bind Exams}" FontWeight="Bold" Foreground="{x:Bind ForegroundColor}"/>
+                    <!-- Deuxième ligne : examens, œil, annotation et heure -->
+                    <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" Spacing="4">
+                        <TextBlock Text="{x:Bind Exams}" FontWeight="Bold" Foreground="{x:Bind ForegroundColor}"/>
+                        <TextBlock Text="{x:Bind Eye}" Foreground="{x:Bind ForegroundColor}"/>
+                        <TextBlock Text="{x:Bind Annotation}" Foreground="{x:Bind ForegroundColor}"/>
+                    </StackPanel>
                     <TextBlock Grid.Row="1" Grid.Column="1"
                        Text="{x:Bind HoldTimeFormatted}" Foreground="{x:Bind ForegroundColor}"
                        FontWeight="Bold" HorizontalAlignment="Right"/>

--- a/Client/Pages/HistoryPage.xaml
+++ b/Client/Pages/HistoryPage.xaml
@@ -35,7 +35,12 @@
                         <TextBlock Text="{x:Bind FirstName}" Foreground="{x:Bind ForegroundColor}"/>
                     </StackPanel>
                     <TextBlock Grid.Row="0" Grid.Column="1" Text="{x:Bind Examinator}" Foreground="{x:Bind ForegroundColor}" HorizontalAlignment="Right"/>
-                    <TextBlock Grid.Row="1" Grid.Column="0" Text="{x:Bind Exams}" FontWeight="Bold" Foreground="{x:Bind ForegroundColor}"/>
+                    <!-- Deuxième ligne : examens, œil, annotation et heure -->
+                    <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" Spacing="4">
+                        <TextBlock Text="{x:Bind Exams}" FontWeight="Bold" Foreground="{x:Bind ForegroundColor}"/>
+                        <TextBlock Text="{x:Bind Eye}" Foreground="{x:Bind ForegroundColor}"/>
+                        <TextBlock Text="{x:Bind Annotation}" Foreground="{x:Bind ForegroundColor}"/>
+                    </StackPanel>
                     <TextBlock Grid.Row="1" Grid.Column="1" Text="{x:Bind HoldTimeFormatted}" Foreground="{x:Bind ForegroundColor}" FontWeight="Bold" HorizontalAlignment="Right"/>
                 </Grid>
             </Border>
@@ -92,7 +97,12 @@
                         <TextBlock Text="{x:Bind FirstName}" Foreground="{x:Bind ForegroundColor}"/>
                     </StackPanel>
                     <TextBlock Grid.Row="0" Grid.Column="1" Text="{x:Bind Examinator}" Foreground="{x:Bind ForegroundColor}" HorizontalAlignment="Right"/>
-                    <TextBlock Grid.Row="1" Grid.Column="0" Text="{x:Bind Exams}" FontWeight="Bold" Foreground="{x:Bind ForegroundColor}"/>
+                    <!-- Deuxième ligne : examens, œil, annotation et heure -->
+                    <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" Spacing="4">
+                        <TextBlock Text="{x:Bind Exams}" FontWeight="Bold" Foreground="{x:Bind ForegroundColor}"/>
+                        <TextBlock Text="{x:Bind Eye}" Foreground="{x:Bind ForegroundColor}"/>
+                        <TextBlock Text="{x:Bind Annotation}" Foreground="{x:Bind ForegroundColor}"/>
+                    </StackPanel>
                     <TextBlock Grid.Row="1" Grid.Column="1" Text="{x:Bind HoldTimeFormatted}" Foreground="{x:Bind ForegroundColor}" FontWeight="Bold" HorizontalAlignment="Right"/>
                 </Grid>
             </Border>


### PR DESCRIPTION
## Summary
- show eye and annotation beside exam on patient labels
- mirror the same info on history and archived patient views

## Testing
- `dotnet build` *(fails: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*
- `dotnet build Serveur/Serveur.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68938a8984048324977d9fe0ac71750f