### PR TITLE
Track patient modifications and expose history

### DIFF
--- a/Client/Models/PatientLog.cs
+++ b/Client/Models/PatientLog.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Client.Models
+{
+    public class PatientLog
+    {
+        public int Id { get; set; }
+        public string PatientId { get; set; } = string.Empty;
+        public string Username { get; set; } = string.Empty;
+        public string Action { get; set; } = string.Empty;
+        public string Details { get; set; } = string.Empty;
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -232,6 +232,7 @@
                 <Border.ContextFlyout>
                     <MenuFlyout>
                         <MenuFlyoutItem Text="{x:Bind ToggleExamLabel}" Tag="{x:Bind}" Click="TogglePatientTaken_Click" />
+                        <MenuFlyoutItem Text="Infos" Tag="{x:Bind}" Click="InfoPatient_Click" />
                         <MenuFlyoutItem Text="Modifier" Tag="{x:Bind}" Click="EditPatient_Click" />
                         <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
                         <MenuFlyoutSubItem Text="Modification temps" Visibility="{Binding TimeModificationVisibility, ElementName=PageRoot}">
@@ -282,6 +283,7 @@
                 <Border.ContextFlyout>
                     <MenuFlyout>
                         <MenuFlyoutItem Text="{x:Bind ToggleExamLabel}" Tag="{x:Bind}" Click="TogglePatientTaken_Click" />
+                        <MenuFlyoutItem Text="Infos" Tag="{x:Bind}" Click="InfoPatient_Click" />
                         <MenuFlyoutItem Text="Modifier" Tag="{x:Bind}" Click="EditPatient_Click" />
                     <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
                     

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -492,6 +492,14 @@ namespace Client.Pages
                 }
             }
         }
+        private async void InfoPatient_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as MenuFlyoutItem)?.Tag is Patient patient)
+            {
+                await HotKeyService.ShowPatientInfoDialogAsync(patient);
+            }
+        }
+
 
         private async void EditPatient_Click(object sender, RoutedEventArgs e)
         {

--- a/Client/Pages/HistoryPage.xaml
+++ b/Client/Pages/HistoryPage.xaml
@@ -11,6 +11,7 @@
                 <Border.ContextFlyout>
                     <MenuFlyout>
                         <MenuFlyoutItem Text="{x:Bind ToggleExamLabel}" Tag="{x:Bind}" Click="TogglePatientTaken_Click" />
+                        <MenuFlyoutItem Text="Infos" Tag="{x:Bind}" Click="InfoPatient_Click" />
                         <MenuFlyoutItem Text="Modifier" Tag="{x:Bind}" Click="EditPatient_Click" />
                         <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
                         <MenuFlyoutSubItem Text="Modification temps" Visibility="{Binding TimeModificationVisibility, ElementName=PageRoot}">
@@ -51,6 +52,7 @@
                 <Border.ContextFlyout>
                     <MenuFlyout>
                         <MenuFlyoutItem Text="{x:Bind ToggleExamLabel}" Tag="{x:Bind}" Click="TogglePatientTaken_Click" />
+                        <MenuFlyoutItem Text="Infos" Tag="{x:Bind}" Click="InfoPatient_Click" />
                         <MenuFlyoutItem Text="Modifier" Tag="{x:Bind}" Click="EditPatient_Click" />
                         <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
                     </MenuFlyout>
@@ -79,6 +81,7 @@
                 <Border.ContextFlyout>
                     <MenuFlyout>
                         <MenuFlyoutItem Text="Désarchiver" Tag="{x:Bind}" Click="UnarchivePatient_Click" />
+                        <MenuFlyoutItem Text="Infos" Tag="{x:Bind}" Click="InfoPatient_Click" />
                         <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
                     </MenuFlyout>
                 </Border.ContextFlyout>
@@ -113,6 +116,7 @@
                 <Border.ContextFlyout>
                     <MenuFlyout>
                         <MenuFlyoutItem Text="Désarchiver" Tag="{x:Bind}" Click="UnarchivePatient_Click" />
+                        <MenuFlyoutItem Text="Infos" Tag="{x:Bind}" Click="InfoPatient_Click" />
                         <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
                     </MenuFlyout>
                 </Border.ContextFlyout>

--- a/Client/Pages/HistoryPage.xaml.cs
+++ b/Client/Pages/HistoryPage.xaml.cs
@@ -127,6 +127,14 @@ namespace Client.Pages
             }
         }
 
+        private async void InfoPatient_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as MenuFlyoutItem)?.Tag is Patient patient)
+            {
+                await HotKeyService.ShowPatientInfoDialogAsync(patient);
+            }
+        }
+
         private async void EditPatient_Click(object sender, RoutedEventArgs e)
         {
             if ((sender as MenuFlyoutItem)?.Tag is Patient patient)

--- a/Client/Services/HotKeyService.cs
+++ b/Client/Services/HotKeyService.cs
@@ -2,6 +2,8 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Linq;
+using System.Collections.Generic;
+using System.Text;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.DataTransfer;
 using Microsoft.UI.Xaml;
@@ -364,6 +366,40 @@ namespace Client.Services
             }
         }
 
+        public static async Task ShowPatientInfoDialogAsync(Patient patient)
+        {
+            List<PatientLog> logs;
+            try
+            {
+                logs = await App.ChatService.GetPatientLogsAsync(patient.Id);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[HotKeyService] Error retrieving patient logs: {ex.Message}");
+                logs = new List<PatientLog>();
+            }
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"{patient.Title} {patient.LastName} {patient.FirstName}".Trim());
+            sb.AppendLine($"Examen : {patient.Exams}");
+            sb.AppendLine($"Œil : {patient.Eye}");
+            sb.AppendLine($"Salle : {patient.Position}");
+            sb.AppendLine();
+            foreach (var log in logs.OrderBy(l => l.Timestamp))
+                sb.AppendLine($"{log.Timestamp:dd/MM HH:mm} - {log.Username} - {log.Action} {log.Details}");
+
+            var dialog = new ContentDialog
+            {
+                Title = "Informations patient",
+                CloseButtonText = "Fermer",
+                Content = new ScrollViewer
+                {
+                    Content = new TextBlock { Text = sb.ToString(), TextWrapping = TextWrapping.Wrap }
+                },
+                XamlRoot = App.MainWindow.Content.XamlRoot,
+            };
+            await dialog.ShowAsync();
+        }
         public static async Task DeclarePatientAsync(string examName, string patientName)
         {
             var options = ExamOption.Load();

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -1109,6 +1109,25 @@ namespace Client.Services
                 }
             }
         }
+        public async Task<List<PatientLog>> GetPatientLogsAsync(string patientId)
+        {
+            if (Connection is null || Connection.State != HubConnectionState.Connected)
+            {
+                var connected = await TryReconnectAsync();
+                if (!connected) return new List<PatientLog>();
+            }
+
+            try
+            {
+                return await Connection.InvokeAsync<List<PatientLog>>("GetPatientLogs", patientId);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur récupération historique patient : {ex.Message}");
+                return new List<PatientLog>();
+            }
+        }
+
 
         public async Task<Dictionary<string, List<string>>> GetAllGroupsAsync()
         {

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -100,6 +100,25 @@ namespace ChatServeur
                     .Select(r => r.Trim()).ToList();
         }
 
+        private string GetUsername()
+        {
+            return ConnectedUsers.TryGetValue(Context.ConnectionId, out var user)
+                ? user.Username
+                : "Unknown";
+        }
+
+        private void AddPatientLog(string patientId, string action, string details)
+        {
+            _db.PatientLogs.Add(new PatientLog
+            {
+                PatientId = patientId,
+                Username = GetUsername(),
+                Action = action,
+                Details = details,
+                Timestamp = DateTime.Now
+            });
+        }
+
         public override Task OnConnectedAsync()
         {
             return base.OnConnectedAsync();
@@ -684,6 +703,7 @@ namespace ChatServeur
         {
             patient.IsArchived = false;
             _db.Patients.Add(patient);
+            AddPatientLog(patient.Id, "Create", "Patient créé");
             await _db.SaveChangesAsync();
             await Clients.All.SendAsync("NewPatient", patient);
         }
@@ -694,6 +714,7 @@ namespace ChatServeur
             if (patient != null)
             {
                 _db.Patients.Remove(patient);
+                AddPatientLog(patient.Id, "Delete", "Patient supprimé");
                 await _db.SaveChangesAsync();
                 await Clients.All.SendAsync("PatientRemoved", id);
             }
@@ -704,8 +725,10 @@ namespace ChatServeur
             var patient = await _db.Patients.FindAsync(id);
             if (patient != null)
             {
+                var oldValue = patient.IsTaken;
                 patient.IsTaken = isTaken;
                 patient.PickUpTime = isTaken ? DateTime.Now : null;
+                AddPatientLog(patient.Id, "IsTaken", $"IsTaken: {oldValue} -> {isTaken}");
                 _db.Patients.Update(patient);
                 await _db.SaveChangesAsync();
                 await Clients.All.SendAsync("PatientUpdated", patient);
@@ -717,7 +740,9 @@ namespace ChatServeur
             var patient = await _db.Patients.FindAsync(id);
             if (patient != null)
             {
+                var oldTime = patient.HoldTime;
                 patient.HoldTime = newTime;
+                AddPatientLog(patient.Id, "HoldTime", $"HoldTime: {oldTime:HH:mm} -> {newTime:HH:mm}");
                 _db.Patients.Update(patient);
                 await _db.SaveChangesAsync();
                 await Clients.All.SendAsync("PatientUpdated", patient);
@@ -729,18 +754,23 @@ namespace ChatServeur
             var patient = await _db.Patients.FindAsync(updated.Id);
             if (patient != null)
             {
-                patient.Title = updated.Title;
-                patient.LastName = updated.LastName;
-                patient.FirstName = updated.FirstName;
-                patient.Exams = updated.Exams;
-                patient.Eye = updated.Eye;
-                patient.Annotation = updated.Annotation;
-                patient.Position = updated.Position;
-                patient.Colors = updated.Colors;
-                patient.HoldTime = updated.HoldTime;
-                _db.Patients.Update(patient);
-                await _db.SaveChangesAsync();
-                await Clients.All.SendAsync("PatientUpdated", patient);
+                var changes = new List<string>();
+                if (patient.Title != updated.Title) { changes.Add($"Titre: {patient.Title} -> {updated.Title}"); patient.Title = updated.Title; }
+                if (patient.LastName != updated.LastName) { changes.Add($"Nom: {patient.LastName} -> {updated.LastName}"); patient.LastName = updated.LastName; }
+                if (patient.FirstName != updated.FirstName) { changes.Add($"Prénom: {patient.FirstName} -> {updated.FirstName}"); patient.FirstName = updated.FirstName; }
+                if (patient.Exams != updated.Exams) { changes.Add($"Examen: {patient.Exams} -> {updated.Exams}"); patient.Exams = updated.Exams; }
+                if (patient.Eye != updated.Eye) { changes.Add($"Œil: {patient.Eye} -> {updated.Eye}"); patient.Eye = updated.Eye; }
+                if (patient.Annotation != updated.Annotation) { changes.Add($"Commentaire: {patient.Annotation} -> {updated.Annotation}"); patient.Annotation = updated.Annotation; }
+                if (patient.Position != updated.Position) { changes.Add($"Salle: {patient.Position} -> {updated.Position}"); patient.Position = updated.Position; }
+                if (patient.Colors != updated.Colors) { changes.Add("Couleurs modifiées"); patient.Colors = updated.Colors; }
+                if (patient.HoldTime != updated.HoldTime) { changes.Add($"Heure: {patient.HoldTime:HH:mm} -> {updated.HoldTime:HH:mm}"); patient.HoldTime = updated.HoldTime; }
+                if (changes.Count > 0)
+                {
+                    _db.Patients.Update(patient);
+                    AddPatientLog(patient.Id, "Update", string.Join(", ", changes));
+                    await _db.SaveChangesAsync();
+                    await Clients.All.SendAsync("PatientUpdated", patient);
+                }
             }
         }
 
@@ -767,7 +797,10 @@ namespace ChatServeur
             if (patients.Any())
             {
                 foreach (var p in patients)
+                {
                     p.IsArchived = true;
+                    AddPatientLog(p.Id, "Archive", "Archivé");
+                }
                 _db.Patients.UpdateRange(patients);
                 await _db.SaveChangesAsync();
                 foreach (var p in patients)
@@ -781,7 +814,10 @@ namespace ChatServeur
             if (patients.Any())
             {
                 foreach (var p in patients)
+                {
                     p.IsArchived = false;
+                    AddPatientLog(p.Id, "UnarchiveAll", "Désarchivé");
+                }
                 _db.Patients.UpdateRange(patients);
                 await _db.SaveChangesAsync();
                 foreach (var p in patients)
@@ -795,10 +831,19 @@ namespace ChatServeur
             if (patient != null)
             {
                 patient.IsArchived = false;
+                AddPatientLog(patient.Id, "Unarchive", "Désarchivé");
                 _db.Patients.Update(patient);
                 await _db.SaveChangesAsync();
                 await Clients.All.SendAsync("PatientUpdated", patient);
             }
+        }
+
+        public async Task<List<PatientLog>> GetPatientLogs(string patientId)
+        {
+            return await _db.PatientLogs
+                .Where(l => l.PatientId == patientId)
+                .OrderBy(l => l.Timestamp)
+                .ToListAsync();
         }
 
         public Task<Dictionary<string, List<string>>> GetAllGroupMembers()

--- a/Serveur/Models/ChatDbContext.cs
+++ b/Serveur/Models/ChatDbContext.cs
@@ -12,6 +12,7 @@ namespace ChatServeur
         public DbSet<GroupMembership> GroupMemberships => Set<GroupMembership>();
         public DbSet<SecureGroup> SecureGroups => Set<SecureGroup>();
         public DbSet<ServerConfig> ServerConfigs => Set<ServerConfig>();
+        public DbSet<PatientLog> PatientLogs => Set<PatientLog>();
         public DbSet<Patient> Patients => Set<Patient>();
         public DbSet<UserSetting> UserSettings => Set<UserSetting>();
         public DbSet<KnownUser> KnownUsers => Set<KnownUser>();

--- a/Serveur/Models/PatientLog.cs
+++ b/Serveur/Models/PatientLog.cs
@@ -1,0 +1,13 @@
+using System;
+namespace ChatServeur
+{
+    public class PatientLog
+    {
+        public int Id { get; set; }
+        public string PatientId { get; set; } = string.Empty;
+        public string Username { get; set; } = string.Empty;
+        public string Action { get; set; } = string.Empty;
+        public string Details { get; set; } = string.Empty;
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/Serveur/Program.cs
+++ b/Serveur/Program.cs
@@ -38,6 +38,7 @@ using (var scope = app.Services.CreateScope())
     db.Database.EnsureCreated();
     EnsureArchivedColumn(db);
     EnsureIsDeletedColumn(db);
+    EnsurePatientLogsTable(db);
     EnsureUserSettingsTable(db);
     CleanupKnownUsers(db);
     if (!db.ServerConfigs.Any())
@@ -121,6 +122,27 @@ void EnsureUserSettingsTable(ChatDbContext db)
         if (result == null)
         {
             cmd.CommandText = "CREATE TABLE UserSettings (Id INTEGER PRIMARY KEY AUTOINCREMENT, Username TEXT NOT NULL UNIQUE, SettingsJson TEXT NOT NULL)";
+            cmd.ExecuteNonQuery();
+        }
+    }
+    finally
+    {
+        connection.Close();
+    }
+}
+
+void EnsurePatientLogsTable(ChatDbContext db)
+{
+    var connection = db.Database.GetDbConnection();
+    connection.Open();
+    try
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name='PatientLogs'";
+        var result = cmd.ExecuteScalar();
+        if (result == null)
+        {
+            cmd.CommandText = "CREATE TABLE PatientLogs (Id INTEGER PRIMARY KEY AUTOINCREMENT, PatientId TEXT NOT NULL, Username TEXT NOT NULL, Action TEXT NOT NULL, Details TEXT NOT NULL, Timestamp TEXT NOT NULL)";
             cmd.ExecuteNonQuery();
         }
     }


### PR DESCRIPTION
## Summary
- log patient changes and actor via new `PatientLog` entity
- expose patient history and add "Infos" menu to view it client-side
- server initializes history table

## Testing
- `dotnet build Serveur/Serveur.csproj`
- `dotnet build Client/Client.csproj` *(fails: NETSDK1100 to build Windows project on this OS)*

------
https://chatgpt.com/codex/tasks/task_e_6894438916408324b4637025bedb5530