### PR TITLE
Fix user room status updating

### DIFF
--- a/Client/Models/UserInfo.cs
+++ b/Client/Models/UserInfo.cs
@@ -1,17 +1,57 @@
-using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
 
 namespace Client.Models
 {
-    public class UserInfo
+    public class UserInfo : INotifyPropertyChanged
     {
         public string ConnectionId { get; set; } = string.Empty;
         public string Username { get; set; } = string.Empty;
         public string Avatar { get; set; } = string.Empty;
-        public List<string> Rooms { get; set; } = new();
+        private ObservableCollection<string> _rooms = new();
+
+        public UserInfo()
+        {
+            _rooms.CollectionChanged += Rooms_CollectionChanged;
+        }
+
+        public ObservableCollection<string> Rooms
+        {
+            get => _rooms;
+            set
+            {
+                if (_rooms != value)
+                {
+                    if (_rooms != null)
+                        _rooms.CollectionChanged -= Rooms_CollectionChanged;
+                    _rooms = value ?? new ObservableCollection<string>();
+                    _rooms.CollectionChanged += Rooms_CollectionChanged;
+                    OnPropertyChanged(nameof(Rooms));
+                    OnPropertyChanged(nameof(RoomsDisplay));
+                }
+            }
+        }
+
         public string ColorUserName { get; set; } = string.Empty;
         public string DisplayName { get; set; } = string.Empty;
-        public bool IsOnline { get; set; }
+
+        private bool _isOnline;
+        public bool IsOnline
+        {
+            get => _isOnline;
+            set
+            {
+                if (_isOnline != value)
+                {
+                    _isOnline = value;
+                    OnPropertyChanged(nameof(IsOnline));
+                }
+            }
+        }
+
         public string Note { get; set; } = string.Empty;
+
         /// <summary>
         /// Convenience property returning <see cref="DisplayName"/> if set or
         /// <see cref="Username"/> otherwise.
@@ -22,6 +62,16 @@ namespace Client.Models
         /// Returns a comma separated list of rooms the user is connected to.
         /// </summary>
         public string RoomsDisplay => Rooms.Count == 0 ? string.Empty : string.Join(", ", Rooms);
+
+        private void Rooms_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            OnPropertyChanged(nameof(RoomsDisplay));
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        private void OnPropertyChanged(string propertyName)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
     }
 }

--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -412,7 +412,7 @@
                             <Image Source="{x:Bind Avatar}" Width="40" Height="40"/>
                             <StackPanel>
                                 <TextBlock Text="{x:Bind Username}" Foreground="{x:Bind ColorUserName}" FontWeight="Bold"/>
-                                <TextBlock Text="{x:Bind RoomsDisplay, FallbackValue='Offline'}"/>
+                                <TextBlock Text="{x:Bind RoomsDisplay, Mode=OneWay, FallbackValue='Offline'}"/>
                             </StackPanel>
                         </StackPanel>
                     </DataTemplate>

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -1241,7 +1241,7 @@ namespace Client.Services
                             ConnectionId = string.Empty,
                             Username = name,
                             Avatar = visibleToAll ? "ms-appx:///Assets/secretaria.png" : "ms-appx:///Assets/earth.png",
-                            Rooms = new List<string>(),
+                            Rooms = new ObservableCollection<string>(),
                             DisplayName = name,
                             ColorUserName = visibleToAll ? "Blue" : "Green",
                             IsOnline = true,


### PR DESCRIPTION
## Summary
- ensure UserInfo notifies UI of room/status changes via INotifyPropertyChanged
- create users with observable room lists and bind room display in OneWay mode

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe exited with code 126)*

------
https://chatgpt.com/codex/tasks/task_e_689497bca9988324a84e76ba2c0b64cf