### PR TITLE
Fix user staying offline after reconnect

### DIFF
--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -174,9 +174,11 @@ namespace ChatServeur
                 EnsureUsersLoaded();
                 Console.WriteLine($"[SERVER] RegisterUser : {username}");
 
-                var rooms = new List<string> { room };
+                var rooms = new List<string>();
                 if (AllUsers.TryGetValue(username, out var existing) && existing.Rooms.Any())
-                    rooms = new List<string>(existing.Rooms);
+                    rooms = existing.Rooms.Where(r => r != "Hors ligne").ToList();
+                if (!rooms.Contains(room))
+                    rooms.Add(room);
 
                 var user = new UserInfo
                 {


### PR DESCRIPTION
## Summary
- Clear offline placeholder from stored rooms when registering a user
- Add current room if missing so reconnecting user appears online

## Testing
- `dotnet build Serveur/Serveur.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6894c1ed23908324b2b092fe6570a205