### PR TITLE
Mark users offline when no rooms

### DIFF
--- a/Client/Models/UserInfo.cs
+++ b/Client/Models/UserInfo.cs
@@ -29,6 +29,7 @@ namespace Client.Models
                     _rooms.CollectionChanged += Rooms_CollectionChanged;
                     OnPropertyChanged(nameof(Rooms));
                     OnPropertyChanged(nameof(RoomsDisplay));
+                    IsOnline = _rooms.Count > 0;
                 }
             }
         }
@@ -61,10 +62,11 @@ namespace Client.Models
         /// <summary>
         /// Returns a comma separated list of rooms the user is connected to.
         /// </summary>
-        public string RoomsDisplay => Rooms.Count == 0 ? string.Empty : string.Join(", ", Rooms);
+        public string RoomsDisplay => Rooms.Count == 0 ? "Offline" : string.Join(", ", Rooms);
 
         private void Rooms_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
+            IsOnline = _rooms.Count > 0;
             OnPropertyChanged(nameof(RoomsDisplay));
         }
 

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -730,7 +730,13 @@ namespace Client.Services
                 if (File.Exists(path))
                 {
                     var json = await File.ReadAllTextAsync(path);
-                    return JsonConvert.DeserializeObject<List<UserInfo>>(json) ?? new();
+                    var users = JsonConvert.DeserializeObject<List<UserInfo>>(json) ?? new();
+                    foreach (var u in users)
+                    {
+                        if (u.Rooms.Count == 0)
+                            u.IsOnline = false;
+                    }
+                    return users;
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- Ensure users are flagged offline and show "Offline" text when they aren't in any rooms
- Reset online status for cached users who have no rooms on disk load

## Testing
- `~/.dotnet/dotnet test` *(fails: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_6894ce88e5c08324a775384074e0d56e