### PR TITLE
Amélioration de l’affichage des utilisateurs

### DIFF
--- a/Client/Models/UserInfo.cs
+++ b/Client/Models/UserInfo.cs
@@ -61,8 +61,12 @@ namespace Client.Models
 
         /// <summary>
         /// Returns a comma separated list of rooms the user is connected to.
+        /// "A Tous" and "Secrétariat" never display the "Offline" label.
         /// </summary>
-        public string RoomsDisplay => Rooms.Count == 0 ? "Offline" : string.Join(", ", Rooms);
+        public string RoomsDisplay
+            => Username == "A Tous" || Username == "Secrétariat"
+                ? string.Join(", ", Rooms)
+                : Rooms.Count == 0 ? "Offline" : string.Join(", ", Rooms);
 
         private void Rooms_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -153,6 +153,7 @@ namespace Client.Services
                 user.Avatar = ToClientAvatar(user.Avatar);
                 ConnectedUsers.Add(user);
             }
+            UpdateSpecialUsers();
 
             var color = AppSettings.Get("ColorUserName", "Black");
             var avatar = AppSettings.Get("Avatar", "ms-appx:///Assets/earth.png");
@@ -171,6 +172,7 @@ namespace Client.Services
                 ConnectedUsers.Clear();
                 foreach (var u in finalList)
                     ConnectedUsers.Add(u);
+                UpdateSpecialUsers();
             }
 
             Messages.Clear();
@@ -253,6 +255,7 @@ namespace Client.Services
                     u.IsOnline = false;
                     u.Rooms.Clear();
                 }
+                UpdateSpecialUsers();
                 await SaveUsersToDiskAsync();
                 await Task.Delay(3000);
                 if (EnableReconnect)
@@ -274,6 +277,7 @@ namespace Client.Services
                     {
                         ConnectedUsers.Add(user);
                     }
+                    UpdateSpecialUsers();
                     Debug.WriteLine($"✅ User connecté : {user.Username}");
                     await SaveUsersToDiskAsync();
                 });
@@ -303,6 +307,7 @@ namespace Client.Services
                         ConnectedUsers.Add(user);
                         Debug.WriteLine($"✅ User list ajoutée : {user.Username} ({string.Join(", ", user.Rooms)})");
                     }
+                    UpdateSpecialUsers();
 
                     foreach (var msg in Messages.OfType<ChatMessageModel>())
                     {
@@ -1226,6 +1231,31 @@ namespace Client.Services
             return true;
         }
 
+        private void UpdateSpecialUsers()
+        {
+            var realUsers = ConnectedUsers.Where(u =>
+                u.Username != "A Tous" &&
+                u.Username != "Secrétariat" &&
+                (!string.IsNullOrEmpty(u.ConnectionId) || !u.IsOnline)).ToList();
+
+            int totalKnown = realUsers.Count;
+            int totalOnline = realUsers.Count(u => u.IsOnline);
+
+            var allUser = ConnectedUsers.FirstOrDefault(u => u.Username == "A Tous");
+            if (allUser != null)
+            {
+                allUser.Rooms.Clear();
+                allUser.Rooms.Add($"{totalOnline}/{totalKnown}");
+            }
+
+            var secretariat = ConnectedUsers.FirstOrDefault(u => u.Username == "Secrétariat");
+            if (secretariat != null)
+            {
+                secretariat.Rooms.Clear();
+                secretariat.Rooms.Add(string.Empty);
+            }
+        }
+
         private async Task<List<UserInfo>> BuildUserListWithGroupsAsync(IEnumerable<UserInfo> baseList)
         {
             var result = baseList.ToList();
@@ -1291,6 +1321,7 @@ namespace Client.Services
                 ConnectedUsers.Clear();
                 foreach (var u in finalList)
                     ConnectedUsers.Add(u);
+                UpdateSpecialUsers();
 
                 foreach (var msg in Messages.OfType<ChatMessageModel>())
                 {


### PR DESCRIPTION
## Summary
- Masquer le libellé "Offline" pour les entrées "A Tous" et "Secrétariat"
- Afficher le nombre d’utilisateurs connectés/parmi les connus sous "A Tous"
- Mise à jour dynamique de ces informations lors des changements de la liste d’utilisateurs

## Testing
- `dotnet build` *(échec : projet client Windows nécessite des outils spécifiques)*
- `dotnet build Serveur/Serveur.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6894d95f70b4832491d19b2c46e86a07