### PR TITLE
feat: add default user selection

### DIFF
--- a/Client/Pages/SystemPage.xaml
+++ b/Client/Pages/SystemPage.xaml
@@ -8,13 +8,16 @@
 			<Button Content="← Retour" Click="Back_Click" HorizontalAlignment="Left"/>
 			<TextBlock Text="Système" FontSize="24" FontWeight="Bold"/>
 			<Border CornerRadius="8" Padding="20">
-				<StackPanel Spacing="10">
-					<TextBlock Text="Nom de la salle"/>
-					<TextBox x:Name="RoomBox" Text="{x:Bind RoomName, Mode=TwoWay}"/>
-					<ToggleSwitch x:Name="TimeModSwitch" Header="Afficher la modification du temps" IsOn="{x:Bind ShowTimeModification, Mode=TwoWay}"/>
-					<Button Content="Sauvegarder" Click="Save_Click" HorizontalAlignment="Left"/>
-				</StackPanel>
-			</Border>
-		</StackPanel>
-	</ScrollViewer>
+                                <StackPanel Spacing="10">
+                                        <TextBlock Text="Nom de la salle"/>
+                                        <TextBox x:Name="RoomBox" Text="{x:Bind RoomName, Mode=TwoWay}"/>
+                                        <ToggleSwitch x:Name="TimeModSwitch" Header="Afficher la modification du temps" IsOn="{x:Bind ShowTimeModification, Mode=TwoWay}"/>
+                                        <TextBlock Text="Utilisateur par défaut"/>
+                                        <ComboBox ItemsSource="{x:Bind Users}" SelectedItem="{x:Bind DefaultUser, Mode=TwoWay}"/>
+                                        <ToggleSwitch Header="Se connecter avec le dernier utilisateur" IsOn="{x:Bind ConnectLastUser, Mode=TwoWay}"/>
+                                        <Button Content="Sauvegarder" Click="Save_Click" HorizontalAlignment="Left"/>
+                                </StackPanel>
+                        </Border>
+                </StackPanel>
+        </ScrollViewer>
 </Page>

--- a/Client/Pages/SystemPage.xaml.cs
+++ b/Client/Pages/SystemPage.xaml.cs
@@ -1,5 +1,9 @@
 ﻿using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using Client.Helpers;
 
 namespace Client.Pages
@@ -8,6 +12,9 @@ namespace Client.Pages
     {
         public string RoomName { get; set; } = string.Empty;
         public bool ShowTimeModification { get; set; }
+        public List<string> Users { get; set; } = new();
+        public string DefaultUser { get; set; } = string.Empty;
+        public bool ConnectLastUser { get; set; }
 
         public SystemPage()
         {
@@ -16,6 +23,18 @@ namespace Client.Pages
             var cfg = MachineConfig.Load();
             ShowTimeModification = cfg.ShowTimeModification;
             RoomName = cfg.RoomName;
+            DefaultUser = cfg.DefaultUser;
+            ConnectLastUser = cfg.ConnectLastUser;
+
+            var folder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat");
+            if (Directory.Exists(folder))
+            {
+                var files = Directory.GetFiles(folder, "*_settings.json");
+                Users = files.Select(f => Path.GetFileName(f).Replace("_settings.json", "")).ToList();
+            }
+            if (!Users.Contains(DefaultUser) && !string.IsNullOrWhiteSpace(DefaultUser))
+                Users.Add(DefaultUser);
+
             DataContext = this;
         }
 
@@ -30,6 +49,8 @@ namespace Client.Pages
             var cfg = MachineConfig.Load();
             cfg.RoomName = RoomName;
             cfg.ShowTimeModification = ShowTimeModification;
+            cfg.DefaultUser = DefaultUser;
+            cfg.ConnectLastUser = ConnectLastUser;
             MachineConfig.Save(cfg);
             App.ChatService.RoomName = RoomName;
             await App.ChatService.UpdateRoomNameAsync(RoomName);


### PR DESCRIPTION
## Summary
- allow selecting a default user and toggling reconnect to last user from system settings
- persist the new settings in MachineConfig

## Testing
- `~/.dotnet/dotnet build Client/Client.csproj -p:EnableWindowsTargeting=true` (fails: XamlCompiler.exe exec format error)
- `~/.dotnet/dotnet build Serveur/Serveur.csproj`

------
https://chatgpt.com/codex/tasks/task_e_689586e71ee483248592ed0b004f5017