### PR TITLE
feat: add configurable reminder system

### DIFF
--- a/Client/Helpers/MachineConfig.cs
+++ b/Client/Helpers/MachineConfig.cs
@@ -15,6 +15,11 @@ namespace Client.Helpers
         /// </summary>
         public bool ShowTimeModification { get; set; }
 
+        /// <summary>
+        /// Show the reminder page in settings.
+        /// </summary>
+        public bool ShowReminderPage { get; set; }
+
         public static string FilePath =>
             Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                 "EyeChat", "machine.json");

--- a/Client/Models/ReminderConfig.cs
+++ b/Client/Models/ReminderConfig.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Client.Models
+{
+    public class ReminderConfig
+    {
+        public string Message { get; set; } = string.Empty;
+        public List<string> Times { get; set; } = new();
+        public bool IsEnabled { get; set; }
+    }
+}

--- a/Client/Pages/ReminderPage.xaml
+++ b/Client/Pages/ReminderPage.xaml
@@ -1,0 +1,20 @@
+<Page
+    x:Class="Client.Pages.ReminderPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <ScrollViewer>
+        <StackPanel Padding="20" Spacing="20">
+            <Button Content="\u2190 Retour" Click="Back_Click" HorizontalAlignment="Left"/>
+            <TextBlock Text="Rappels" FontSize="24" FontWeight="Bold"/>
+            <TextBox x:Name="MessageBox" Header="Message" AcceptsReturn="True" TextWrapping="Wrap"/>
+            <StackPanel Orientation="Horizontal" Spacing="10">
+                <TimePicker x:Name="TimePicker"/>
+                <Button Content="Ajouter" Click="AddTime_Click"/>
+            </StackPanel>
+            <ListView x:Name="TimesList" Height="100" DoubleTapped="TimesList_DoubleTapped"/>
+            <ToggleSwitch x:Name="EnableSwitch" Header="Activer les rappels"/>
+            <Button Content="Sauvegarder" Click="Save_Click" HorizontalAlignment="Left"/>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/Client/Pages/ReminderPage.xaml.cs
+++ b/Client/Pages/ReminderPage.xaml.cs
@@ -1,0 +1,64 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Client.Models;
+
+namespace Client.Pages
+{
+    public sealed partial class ReminderPage : Page
+    {
+        public ObservableCollection<string> Times { get; } = new();
+
+        public ReminderPage()
+        {
+            this.InitializeComponent();
+            TimesList.ItemsSource = Times;
+            Loaded += ReminderPage_Loaded;
+        }
+
+        private async void ReminderPage_Loaded(object sender, RoutedEventArgs e)
+        {
+            var cfg = await App.ChatService.GetReminderAsync();
+            if (cfg != null)
+            {
+                MessageBox.Text = cfg.Message;
+                Times.Clear();
+                foreach (var t in cfg.Times)
+                    Times.Add(t);
+                EnableSwitch.IsOn = cfg.IsEnabled;
+            }
+        }
+
+        private void Back_Click(object sender, RoutedEventArgs e)
+        {
+            if (Frame.CanGoBack)
+                Frame.GoBack();
+        }
+
+        private void AddTime_Click(object sender, RoutedEventArgs e)
+        {
+            var t = TimePicker.Time.ToString("hh\\:mm");
+            if (!Times.Contains(t))
+                Times.Add(t);
+        }
+
+        private void TimesList_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
+        {
+            if (TimesList.SelectedItem is string t)
+                Times.Remove(t);
+        }
+
+        private async void Save_Click(object sender, RoutedEventArgs e)
+        {
+            var cfg = new ReminderConfig
+            {
+                Message = MessageBox.Text,
+                Times = Times.ToList(),
+                IsEnabled = EnableSwitch.IsOn
+            };
+            await App.ChatService.SendReminderAsync(cfg);
+        }
+    }
+}

--- a/Client/Pages/SettingsPage.xaml
+++ b/Client/Pages/SettingsPage.xaml
@@ -55,6 +55,15 @@
                     </StackPanel>
                 </Button>
             </Grid>
+            <Grid x:Name="ReminderGrid" Visibility="Collapsed">
+                <Border CornerRadius="8" Margin="2,2,0,0" />
+                <Button x:Name="ReminderButton" CornerRadius="8" Padding="20" Width="300" Height="120" Click="Reminder_Click">
+                    <StackPanel Spacing="5">
+                        <TextBlock Text="Rappels" FontSize="18" FontWeight="Bold" HorizontalAlignment="Center" />
+                        <TextBlock Text="Automatiques" HorizontalAlignment="Center" />
+                    </StackPanel>
+                </Button>
+            </Grid>
         </StackPanel>
         
     </StackPanel>

--- a/Client/Pages/SettingsPage.xaml.cs
+++ b/Client/Pages/SettingsPage.xaml.cs
@@ -1,5 +1,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Client.Helpers;
 
 namespace Client.Pages
 {
@@ -8,6 +9,8 @@ namespace Client.Pages
         public SettingsPage()
         {
             this.InitializeComponent();
+            var cfg = MachineConfig.Load();
+            ReminderGrid.Visibility = cfg.ShowReminderPage ? Visibility.Visible : Visibility.Collapsed;
         }
 
         private void Appearance_Click(object sender, RoutedEventArgs e)
@@ -33,6 +36,11 @@ namespace Client.Pages
         private void Connection_Click(object sender, RoutedEventArgs e)
         {
             Frame.Navigate(typeof(ConnectionPage));
+        }
+
+        private void Reminder_Click(object sender, RoutedEventArgs e)
+        {
+            Frame.Navigate(typeof(ReminderPage));
         }
     }
 }

--- a/Client/Pages/SystemPage.xaml
+++ b/Client/Pages/SystemPage.xaml
@@ -12,6 +12,7 @@
                                         <TextBlock Text="Nom de la salle"/>
                                         <TextBox x:Name="RoomBox" Text="{x:Bind RoomName, Mode=TwoWay}"/>
                                         <ToggleSwitch x:Name="TimeModSwitch" Header="Afficher la modification du temps" IsOn="{x:Bind ShowTimeModification, Mode=TwoWay}"/>
+                                        <ToggleSwitch x:Name="ReminderPageSwitch" Header="Afficher la page de rappel" IsOn="{x:Bind ShowReminderPage, Mode=TwoWay}"/>
                                         <TextBlock Text="Utilisateur par défaut"/>
                                         <ComboBox ItemsSource="{x:Bind Users}" SelectedItem="{x:Bind DefaultUser, Mode=TwoWay}"/>
                                         <ToggleSwitch Header="Se connecter avec le dernier utilisateur" IsOn="{x:Bind ConnectLastUser, Mode=TwoWay}"/>

--- a/Client/Pages/SystemPage.xaml.cs
+++ b/Client/Pages/SystemPage.xaml.cs
@@ -12,6 +12,7 @@ namespace Client.Pages
     {
         public string RoomName { get; set; } = string.Empty;
         public bool ShowTimeModification { get; set; }
+        public bool ShowReminderPage { get; set; }
         public List<string> Users { get; set; } = new();
         public string DefaultUser { get; set; } = string.Empty;
         public bool ConnectLastUser { get; set; }
@@ -22,6 +23,7 @@ namespace Client.Pages
             this.InitializeComponent();
             var cfg = MachineConfig.Load();
             ShowTimeModification = cfg.ShowTimeModification;
+            ShowReminderPage = cfg.ShowReminderPage;
             RoomName = cfg.RoomName;
             DefaultUser = cfg.DefaultUser;
             ConnectLastUser = cfg.ConnectLastUser;
@@ -49,6 +51,7 @@ namespace Client.Pages
             var cfg = MachineConfig.Load();
             cfg.RoomName = RoomName;
             cfg.ShowTimeModification = ShowTimeModification;
+            cfg.ShowReminderPage = ShowReminderPage;
             cfg.DefaultUser = DefaultUser;
             cfg.ConnectLastUser = ConnectLastUser;
             MachineConfig.Save(cfg);

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -849,6 +849,40 @@ namespace Client.Services
                 Debug.WriteLine($"Erreur envoi salles silencieux : {ex.Message}");
             }
         }
+
+        public async Task SendReminderAsync(ReminderConfig config)
+        {
+            if (Connection is null || Connection.State != HubConnectionState.Connected)
+                throw new InvalidOperationException("Connexion SignalR non établie.");
+
+            try
+            {
+                await Connection.InvokeAsync("SaveReminder", config);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur envoi rappel : {ex.Message}");
+            }
+        }
+
+        public async Task<ReminderConfig?> GetReminderAsync()
+        {
+            if (Connection is null || Connection.State != HubConnectionState.Connected)
+            {
+                var connected = await TryReconnectAsync();
+                if (!connected) return null;
+            }
+
+            try
+            {
+                return await Connection.InvokeAsync<ReminderConfig>("GetReminder");
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur récupération rappel : {ex.Message}");
+                return null;
+            }
+        }
         public async Task<List<ExamOption>> GetExamOptionsAsync()
         {
             if (Connection is null || Connection.State != HubConnectionState.Connected)

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -701,6 +701,34 @@ namespace ChatServeur
             }
         }
 
+        public async Task SaveReminder(ReminderConfig config)
+        {
+            var json = JsonSerializer.Serialize(config);
+            var cfg = await _db.ServerConfigs.SingleOrDefaultAsync();
+            if (cfg == null)
+            {
+                cfg = new ServerConfig();
+                _db.ServerConfigs.Add(cfg);
+            }
+            cfg.ReminderJson = json;
+            await _db.SaveChangesAsync();
+        }
+
+        public async Task<ReminderConfig?> GetReminder()
+        {
+            var cfg = await _db.ServerConfigs.SingleOrDefaultAsync();
+            if (cfg == null || string.IsNullOrEmpty(cfg.ReminderJson))
+                return new ReminderConfig();
+            try
+            {
+                return JsonSerializer.Deserialize<ReminderConfig>(cfg.ReminderJson) ?? new ReminderConfig();
+            }
+            catch
+            {
+                return new ReminderConfig();
+            }
+        }
+
         public async Task DeclarePatient(Patient patient)
         {
             patient.IsArchived = false;

--- a/Serveur/Models/ReminderConfig.cs
+++ b/Serveur/Models/ReminderConfig.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace ChatServeur
+{
+    public class ReminderConfig
+    {
+        public string Message { get; set; } = string.Empty;
+        public List<string> Times { get; set; } = new();
+        public bool IsEnabled { get; set; }
+    }
+}

--- a/Serveur/Models/ServerConfig.cs
+++ b/Serveur/Models/ServerConfig.cs
@@ -5,5 +5,6 @@ namespace ChatServeur
         public int Id { get; set; }
         public string ExamOptionsJson { get; set; } = string.Empty;
         public string RoomsJson { get; set; } = string.Empty;
+        public string ReminderJson { get; set; } = string.Empty;
     }
 }

--- a/Serveur/Program.cs
+++ b/Serveur/Program.cs
@@ -16,6 +16,7 @@ builder.Services.AddSignalR(o =>
 {
     o.MaximumReceiveMessageSize = 2 * 1024 * 1024;
 });
+builder.Services.AddHostedService<ReminderService>();
 builder.WebHost.UseUrls("http://0.0.0.0:5000");
 
 var app = builder.Build();
@@ -40,6 +41,7 @@ using (var scope = app.Services.CreateScope())
     EnsureIsDeletedColumn(db);
     EnsurePatientLogsTable(db);
     EnsureUserSettingsTable(db);
+    EnsureReminderColumn(db);
     CleanupKnownUsers(db);
     if (!db.ServerConfigs.Any())
     {
@@ -122,6 +124,37 @@ void EnsureUserSettingsTable(ChatDbContext db)
         if (result == null)
         {
             cmd.CommandText = "CREATE TABLE UserSettings (Id INTEGER PRIMARY KEY AUTOINCREMENT, Username TEXT NOT NULL UNIQUE, SettingsJson TEXT NOT NULL)";
+            cmd.ExecuteNonQuery();
+        }
+    }
+    finally
+    {
+        connection.Close();
+    }
+}
+
+void EnsureReminderColumn(ChatDbContext db)
+{
+    var connection = db.Database.GetDbConnection();
+    connection.Open();
+    try
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "PRAGMA table_info('ServerConfigs')";
+        using var reader = cmd.ExecuteReader();
+        bool exists = false;
+        while (reader.Read())
+        {
+            if (string.Equals(reader.GetString(1), "ReminderJson", StringComparison.OrdinalIgnoreCase))
+            {
+                exists = true;
+                break;
+            }
+        }
+        reader.Close();
+        if (!exists)
+        {
+            cmd.CommandText = "ALTER TABLE ServerConfigs ADD COLUMN ReminderJson TEXT NOT NULL DEFAULT ''";
             cmd.ExecuteNonQuery();
         }
     }

--- a/Serveur/ReminderService.cs
+++ b/Serveur/ReminderService.cs
@@ -1,0 +1,92 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using System.Text.Json;
+
+namespace ChatServeur
+{
+    public class ReminderService : BackgroundService
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly IHubContext<ChatHub> _hub;
+        private readonly ILogger<ReminderService> _logger;
+        private readonly HashSet<string> _sent = new();
+
+        public ReminderService(IServiceScopeFactory scopeFactory, IHubContext<ChatHub> hub, ILogger<ReminderService> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _hub = hub;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await CheckRemindersAsync();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Erreur service rappels");
+                }
+                await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
+            }
+        }
+
+        private async Task CheckRemindersAsync()
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ChatDbContext>();
+            var config = await db.ServerConfigs.SingleOrDefaultAsync();
+            if (config == null || string.IsNullOrEmpty(config.ReminderJson))
+                return;
+
+            ReminderConfig? reminder;
+            try
+            {
+                reminder = JsonSerializer.Deserialize<ReminderConfig>(config.ReminderJson);
+            }
+            catch
+            {
+                return;
+            }
+            if (reminder == null || !reminder.IsEnabled)
+                return;
+
+            var now = DateTime.Now;
+            foreach (var t in reminder.Times)
+            {
+                if (!TimeSpan.TryParse(t, out var span))
+                    continue;
+                var scheduled = now.Date.Add(span);
+                if (Math.Abs((scheduled - now).TotalMinutes) < 1)
+                {
+                    var key = scheduled.ToString("yyyyMMddHHmm");
+                    if (_sent.Add(key))
+                    {
+                        var message = new ChatMessage
+                        {
+                            Sender = "Rappel",
+                            Destinataire = "A Tous",
+                            Room = string.Empty,
+                            Content = reminder.Message,
+                            Avatar = string.Empty,
+                            Timestamp = now,
+                            IsDeleted = false
+                        };
+                        db.Messages.Add(message);
+                        await db.SaveChangesAsync();
+                        await _hub.Clients.All.SendAsync("ReceiveMessage", message.Id, message.Sender, message.Room, message.Destinataire, message.Content, message.Avatar, message.Timestamp);
+                    }
+                }
+            }
+
+            var todayPrefix = now.ToString("yyyyMMdd");
+            _sent.RemoveWhere(k => !k.StartsWith(todayPrefix));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add optional reminder page toggle in system settings
- implement reminder page UI for message and schedule
- broadcast scheduled reminders from server via background service

## Testing
- `dotnet build Serveur/Serveur.csproj`
- `dotnet build WebApplication1.sln -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*


------
https://chatgpt.com/codex/tasks/task_e_6895d2852f9c83249afcb270e47c5d93