### PR TITLE
Handle disconnected SignalR when saving reminders

### DIFF
--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -853,7 +853,14 @@ namespace Client.Services
         public async Task SendReminderAsync(ReminderConfig config)
         {
             if (Connection is null || Connection.State != HubConnectionState.Connected)
-                throw new InvalidOperationException("Connexion SignalR non établie.");
+            {
+                var connected = await TryReconnectAsync();
+                if (!connected)
+                {
+                    Debug.WriteLine("Impossible d'envoyer le rappel : connexion SignalR non établie.");
+                    return;
+                }
+            }
 
             try
             {


### PR DESCRIPTION
## Summary
- Avoid crashing when saving reminders if SignalR connection isn't ready
- Log a message when reminder can't be sent due to missing connection

## Testing
- `dotnet build` *(fails: NETSDK1100 To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_68962e266ffc83249e81b3ea06b2fd25