### PR TITLE
Support multiple reminders with editable hours

### DIFF
--- a/Client/Models/ReminderConfig.cs
+++ b/Client/Models/ReminderConfig.cs
@@ -4,8 +4,7 @@ namespace Client.Models
 {
     public class ReminderConfig
     {
-        public string Message { get; set; } = string.Empty;
-        public List<string> Times { get; set; } = new();
+        public List<ReminderItem> Reminders { get; set; } = new();
         public bool IsEnabled { get; set; }
     }
 }

--- a/Client/Models/ReminderItem.cs
+++ b/Client/Models/ReminderItem.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Client.Models
+{
+    public class ReminderItem
+    {
+        public string Message { get; set; } = string.Empty;
+        public List<string> Times { get; set; } = new();
+    }
+}

--- a/Client/Pages/ReminderPage.xaml
+++ b/Client/Pages/ReminderPage.xaml
@@ -2,6 +2,7 @@
     x:Class="Client.Pages.ReminderPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:models="using:Client.Models"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
     <ScrollViewer>
         <StackPanel Padding="20" Spacing="20">
@@ -10,9 +11,38 @@
             <TextBox x:Name="MessageBox" Header="Message" AcceptsReturn="True" TextWrapping="Wrap"/>
             <StackPanel Orientation="Horizontal" Spacing="10">
                 <TimePicker x:Name="TimePicker"/>
-                <Button Content="Ajouter" Click="AddTime_Click"/>
+                <Button Content="Ajouter l'heure" Click="AddTime_Click"/>
             </StackPanel>
-            <ListView x:Name="TimesList" Height="100" DoubleTapped="TimesList_DoubleTapped"/>
+            <ListView x:Name="TimesList" Height="100">
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal" Spacing="10">
+                            <TextBlock Text="{Binding}" Width="60"/>
+                            <Button Content="Supprimer" Click="RemoveTime_Click" Tag="{Binding}"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+            <Button Content="Ajouter le rappel" Click="AddReminder_Click" HorizontalAlignment="Left"/>
+            <ListView x:Name="RemindersList" Height="200">
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="models:ReminderItem">
+                        <StackPanel Spacing="5">
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <TextBlock Text="{x:Bind Message}" FontWeight="Bold"/>
+                                <Button Content="Supprimer" Click="RemoveReminder_Click" Tag="{x:Bind}"/>
+                            </StackPanel>
+                            <ItemsControl ItemsSource="{x:Bind Times}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding}"/>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
             <ToggleSwitch x:Name="EnableSwitch" Header="Activer les rappels"/>
             <Button Content="Sauvegarder" Click="Save_Click" HorizontalAlignment="Left"/>
         </StackPanel>

--- a/Client/Pages/ReminderPage.xaml.cs
+++ b/Client/Pages/ReminderPage.xaml.cs
@@ -1,6 +1,5 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Input;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Client.Models;
@@ -10,11 +9,13 @@ namespace Client.Pages
     public sealed partial class ReminderPage : Page
     {
         public ObservableCollection<string> Times { get; } = new();
+        public ObservableCollection<ReminderItem> Reminders { get; } = new();
 
         public ReminderPage()
         {
             this.InitializeComponent();
             TimesList.ItemsSource = Times;
+            RemindersList.ItemsSource = Reminders;
             Loaded += ReminderPage_Loaded;
         }
 
@@ -23,10 +24,9 @@ namespace Client.Pages
             var cfg = await App.ChatService.GetReminderAsync();
             if (cfg != null)
             {
-                MessageBox.Text = cfg.Message;
-                Times.Clear();
-                foreach (var t in cfg.Times)
-                    Times.Add(t);
+                Reminders.Clear();
+                foreach (var r in cfg.Reminders)
+                    Reminders.Add(r);
                 EnableSwitch.IsOn = cfg.IsEnabled;
             }
         }
@@ -44,18 +44,37 @@ namespace Client.Pages
                 Times.Add(t);
         }
 
-        private void TimesList_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
+        private void RemoveTime_Click(object sender, RoutedEventArgs e)
         {
-            if (TimesList.SelectedItem is string t)
+            if (sender is Button btn && btn.Tag is string t)
                 Times.Remove(t);
+        }
+
+        private void AddReminder_Click(object sender, RoutedEventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(MessageBox.Text) || Times.Count == 0)
+                return;
+            var item = new ReminderItem
+            {
+                Message = MessageBox.Text,
+                Times = Times.ToList()
+            };
+            Reminders.Add(item);
+            MessageBox.Text = string.Empty;
+            Times.Clear();
+        }
+
+        private void RemoveReminder_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button btn && btn.Tag is ReminderItem item)
+                Reminders.Remove(item);
         }
 
         private async void Save_Click(object sender, RoutedEventArgs e)
         {
             var cfg = new ReminderConfig
             {
-                Message = MessageBox.Text,
-                Times = Times.ToList(),
+                Reminders = Reminders.ToList(),
                 IsEnabled = EnableSwitch.IsOn
             };
             await App.ChatService.SendReminderAsync(cfg);

--- a/Serveur/Models/ReminderConfig.cs
+++ b/Serveur/Models/ReminderConfig.cs
@@ -4,8 +4,7 @@ namespace ChatServeur
 {
     public class ReminderConfig
     {
-        public string Message { get; set; } = string.Empty;
-        public List<string> Times { get; set; } = new();
+        public List<ReminderItem> Reminders { get; set; } = new();
         public bool IsEnabled { get; set; }
     }
 }

--- a/Serveur/Models/ReminderItem.cs
+++ b/Serveur/Models/ReminderItem.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace ChatServeur
+{
+    public class ReminderItem
+    {
+        public string Message { get; set; } = string.Empty;
+        public List<string> Times { get; set; } = new();
+    }
+}

--- a/Serveur/ReminderService.cs
+++ b/Serveur/ReminderService.cs
@@ -58,36 +58,39 @@ namespace ChatServeur
                 return;
 
             var now = DateTime.Now;
-            foreach (var t in reminder.Times)
+            foreach (var item in reminder.Reminders)
             {
-                if (!TimeSpan.TryParse(t, out var span))
-                    continue;
-                var scheduled = now.Date.Add(span);
-                if (Math.Abs((scheduled - now).TotalMinutes) < 1)
+                foreach (var t in item.Times)
                 {
-                    var key = scheduled.ToString("yyyyMMddHHmm");
-                    if (_sent.Add(key))
+                    if (!TimeSpan.TryParse(t, out var span))
+                        continue;
+                    var scheduled = now.Date.Add(span);
+                    if (Math.Abs((scheduled - now).TotalMinutes) < 1)
                     {
-                        var message = new ChatMessage
+                        var key = $"{item.Message}-{scheduled:yyyyMMddHHmm}";
+                        if (_sent.Add(key))
                         {
-                            Sender = "Rappel",
-                            Destinataire = "A Tous",
-                            Room = string.Empty,
-                            Content = reminder.Message,
-                            Avatar = "/Assets/secretaria.png",
+                            var message = new ChatMessage
+                            {
+                                Sender = "Rappel",
+                                Destinataire = "A Tous",
+                                Room = string.Empty,
+                                Content = item.Message,
+                                Avatar = "/Assets/secretaria.png",
 
-                            Timestamp = now,
-                            IsDeleted = false
-                        };
-                        db.Messages.Add(message);
-                        await db.SaveChangesAsync();
-                        await _hub.Clients.All.SendAsync("ReceiveMessage", message.Id, message.Sender, message.Room, message.Destinataire, message.Content, message.Avatar, message.Timestamp);
+                                Timestamp = now,
+                                IsDeleted = false
+                            };
+                            db.Messages.Add(message);
+                            await db.SaveChangesAsync();
+                            await _hub.Clients.All.SendAsync("ReceiveMessage", message.Id, message.Sender, message.Room, message.Destinataire, message.Content, message.Avatar, message.Timestamp);
+                        }
                     }
                 }
             }
 
             var todayPrefix = now.ToString("yyyyMMdd");
-            _sent.RemoveWhere(k => !k.StartsWith(todayPrefix));
+            _sent.RemoveWhere(k => !k.Contains(todayPrefix));
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow managing a list of reminder items instead of a single message
- enable removing individual reminder times and entire reminders from the UI
- update reminder service to broadcast each configured reminder

## Testing
- `dotnet build WebApplication1.sln` *(fails: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*
- `dotnet build Serveur/Serveur.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6896372a80148324a1bc742fea3efdcc