### PR TITLE
Enable editing reminders and improve scheduling accuracy

### DIFF
--- a/Client/Pages/ReminderPage.xaml
+++ b/Client/Pages/ReminderPage.xaml
@@ -8,7 +8,7 @@
         <StackPanel Padding="20" Spacing="20">
             <Button Content="\u2190 Retour" Click="Back_Click" HorizontalAlignment="Left"/>
             <TextBlock Text="Rappels" FontSize="24" FontWeight="Bold"/>
-            <TextBox x:Name="MessageBox" Header="Message" AcceptsReturn="True" TextWrapping="Wrap"/>
+            <RichEditBox x:Name="MessageBox" Header="Message"/>
             <StackPanel Orientation="Horizontal" Spacing="10">
                 <TimePicker x:Name="TimePicker"/>
                 <Button Content="Ajouter l'heure" Click="AddTime_Click"/>
@@ -23,13 +23,14 @@
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>
-            <Button Content="Ajouter le rappel" Click="AddReminder_Click" HorizontalAlignment="Left"/>
+            <Button x:Name="AddReminderButton" Content="Ajouter le rappel" Click="AddReminder_Click" HorizontalAlignment="Left"/>
             <ListView x:Name="RemindersList" Height="200">
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="models:ReminderItem">
                         <StackPanel Spacing="5">
                             <StackPanel Orientation="Horizontal" Spacing="10">
-                                <TextBlock Text="{x:Bind Message}" FontWeight="Bold"/>
+                                <TextBlock Text="{x:Bind Message}" FontWeight="Bold" TextWrapping="Wrap"/>
+                                <Button Content="Modifier" Click="EditReminder_Click" Tag="{x:Bind}"/>
                                 <Button Content="Supprimer" Click="RemoveReminder_Click" Tag="{x:Bind}"/>
                             </StackPanel>
                             <ItemsControl ItemsSource="{x:Bind Times}">

--- a/Client/Pages/ReminderPage.xaml.cs
+++ b/Client/Pages/ReminderPage.xaml.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Xaml.Controls;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Client.Models;
+using Windows.UI.Text;
 
 namespace Client.Pages
 {
@@ -10,6 +11,7 @@ namespace Client.Pages
     {
         public ObservableCollection<string> Times { get; } = new();
         public ObservableCollection<ReminderItem> Reminders { get; } = new();
+        private ReminderItem? _editing;
 
         public ReminderPage()
         {
@@ -52,16 +54,45 @@ namespace Client.Pages
 
         private void AddReminder_Click(object sender, RoutedEventArgs e)
         {
-            if (string.IsNullOrWhiteSpace(MessageBox.Text) || Times.Count == 0)
+            MessageBox.Document.GetText(TextGetOptions.None, out var txt);
+            var message = txt.Trim();
+            if (string.IsNullOrWhiteSpace(message) || Times.Count == 0)
                 return;
-            var item = new ReminderItem
+
+            if (_editing != null)
             {
-                Message = MessageBox.Text,
-                Times = Times.ToList()
-            };
-            Reminders.Add(item);
-            MessageBox.Text = string.Empty;
+                _editing.Message = message;
+                _editing.Times = Times.ToList();
+                Reminders.Add(_editing);
+                _editing = null;
+                AddReminderButton.Content = "Ajouter le rappel";
+            }
+            else
+            {
+                var item = new ReminderItem
+                {
+                    Message = message,
+                    Times = Times.ToList()
+                };
+                Reminders.Add(item);
+            }
+
+            MessageBox.Document.SetText(TextSetOptions.None, string.Empty);
             Times.Clear();
+        }
+
+        private void EditReminder_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button btn && btn.Tag is ReminderItem item)
+            {
+                MessageBox.Document.SetText(TextSetOptions.None, item.Message);
+                Times.Clear();
+                foreach (var t in item.Times)
+                    Times.Add(t);
+                Reminders.Remove(item);
+                _editing = item;
+                AddReminderButton.Content = "Mettre à jour le rappel";
+            }
         }
 
         private void RemoveReminder_Click(object sender, RoutedEventArgs e)

--- a/Serveur/ReminderService.cs
+++ b/Serveur/ReminderService.cs
@@ -33,7 +33,10 @@ namespace ChatServeur
                 {
                     _logger.LogError(ex, "Erreur service rappels");
                 }
-                await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
+
+                var now = DateTime.Now;
+                var delay = TimeSpan.FromMinutes(1) - TimeSpan.FromSeconds(now.Second) - TimeSpan.FromMilliseconds(now.Millisecond);
+                await Task.Delay(delay, stoppingToken);
             }
         }
 


### PR DESCRIPTION
## Summary
- Use a RichEditBox for reminder messages and add ability to edit existing reminders
- Align reminder service checks to the start of each minute for more precise sending

## Testing
- `dotnet build Serveur/Serveur.csproj`
- `dotnet build Client/Client.csproj -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68964637db408324856c63ff65a540a1