### PR TITLE
Reorganize shortcut layout on user settings page

### DIFF
--- a/Client/Pages/UserSettingsPage.xaml
+++ b/Client/Pages/UserSettingsPage.xaml
@@ -110,88 +110,94 @@
                 <StackPanel Spacing="10">
                     <TextBlock Text="Raccourcis patient" FontSize="18" FontWeight="Bold"/>
                     <StackPanel Orientation="Horizontal" Spacing="10">
-                        <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
-                            <StackPanel Spacing="10">
-                                <TextBlock Text="Ctrl F9" FontWeight="Bold" HorizontalAlignment="Center"/>
-                                <ComboBox Width="150"
-                                          ItemsSource="{x:Bind ExamOptions}"
-                                          DisplayMemberPath="Name"
-                                          SelectedValuePath="Name"
-                                          SelectedValue="{x:Bind ViewModelSettings.CtrlF9Exam, Mode=TwoWay}"/>
-                            </StackPanel>
-                        </Border>
-                        <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
-                            <StackPanel Spacing="10">
-                                <TextBlock Text="Maj F9" FontWeight="Bold" HorizontalAlignment="Center"/>
-                                <ComboBox Width="150"
-                                          ItemsSource="{x:Bind ExamOptions}"
-                                          DisplayMemberPath="Name"
-                                          SelectedValuePath="Name"
-                                          SelectedValue="{x:Bind ViewModelSettings.ShiftF9Exam, Mode=TwoWay}"/>
-                            </StackPanel>
-                        </Border>
-                        <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
-                            <StackPanel Spacing="10">
-                                <TextBlock Text="Ctrl F10" FontWeight="Bold" HorizontalAlignment="Center"/>
-                                <ComboBox Width="150"
-                                          ItemsSource="{x:Bind ExamOptions}"
-                                          DisplayMemberPath="Name"
-                                          SelectedValuePath="Name"
-                                          SelectedValue="{x:Bind ViewModelSettings.CtrlF10Exam, Mode=TwoWay}"/>
-                            </StackPanel>
-                        </Border>
-                        <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
-                            <StackPanel Spacing="10">
-                                <TextBlock Text="Maj F10" FontWeight="Bold" HorizontalAlignment="Center"/>
-                                <ComboBox Width="150"
-                                          ItemsSource="{x:Bind ExamOptions}"
-                                          DisplayMemberPath="Name"
-                                          SelectedValuePath="Name"
-                                          SelectedValue="{x:Bind ViewModelSettings.ShiftF10Exam, Mode=TwoWay}"/>
-                            </StackPanel>
-                        </Border>
-                    </StackPanel>
-                    <StackPanel Orientation="Horizontal" Spacing="10">
-                        <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
-                            <StackPanel Spacing="10">
-                                <TextBlock Text="Ctrl F11" FontWeight="Bold" HorizontalAlignment="Center"/>
-                                <ComboBox Width="150"
-                                          ItemsSource="{x:Bind ExamOptions}"
-                                          DisplayMemberPath="Name"
-                                          SelectedValuePath="Name"
-                                          SelectedValue="{x:Bind ViewModelSettings.CtrlF11Exam, Mode=TwoWay}"/>
-                            </StackPanel>
-                        </Border>
-                        <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
-                            <StackPanel Spacing="10">
-                                <TextBlock Text="Maj F11" FontWeight="Bold" HorizontalAlignment="Center"/>
-                                <ComboBox Width="150"
-                                          ItemsSource="{x:Bind ExamOptions}"
-                                          DisplayMemberPath="Name"
-                                          SelectedValuePath="Name"
-                                          SelectedValue="{x:Bind ViewModelSettings.ShiftF11Exam, Mode=TwoWay}"/>
-                            </StackPanel>
-                        </Border>
-                        <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
-                            <StackPanel Spacing="10">
-                                <TextBlock Text="Ctrl F12" FontWeight="Bold" HorizontalAlignment="Center"/>
-                                <ComboBox Width="150"
-                                          ItemsSource="{x:Bind ExamOptions}"
-                                          DisplayMemberPath="Name"
-                                          SelectedValuePath="Name"
-                                          SelectedValue="{x:Bind ViewModelSettings.CtrlF12Exam, Mode=TwoWay}"/>
-                            </StackPanel>
-                        </Border>
-                        <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
-                            <StackPanel Spacing="10">
-                                <TextBlock Text="Maj F12" FontWeight="Bold" HorizontalAlignment="Center"/>
-                                <ComboBox Width="150"
-                                          ItemsSource="{x:Bind ExamOptions}"
-                                          DisplayMemberPath="Name"
-                                          SelectedValuePath="Name"
-                                          SelectedValue="{x:Bind ViewModelSettings.ShiftF12Exam, Mode=TwoWay}"/>
-                            </StackPanel>
-                        </Border>
+                        <StackPanel Spacing="10">
+                            <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
+                                <StackPanel Spacing="10">
+                                    <TextBlock Text="Maj F9" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <ComboBox Width="150"
+                                              ItemsSource="{x:Bind ExamOptions}"
+                                              DisplayMemberPath="Name"
+                                              SelectedValuePath="Name"
+                                              SelectedValue="{x:Bind ViewModelSettings.ShiftF9Exam, Mode=TwoWay}"/>
+                                </StackPanel>
+                            </Border>
+                            <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
+                                <StackPanel Spacing="10">
+                                    <TextBlock Text="Ctrl F9" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <ComboBox Width="150"
+                                              ItemsSource="{x:Bind ExamOptions}"
+                                              DisplayMemberPath="Name"
+                                              SelectedValuePath="Name"
+                                              SelectedValue="{x:Bind ViewModelSettings.CtrlF9Exam, Mode=TwoWay}"/>
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
+                        <StackPanel Spacing="10">
+                            <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
+                                <StackPanel Spacing="10">
+                                    <TextBlock Text="Maj F10" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <ComboBox Width="150"
+                                              ItemsSource="{x:Bind ExamOptions}"
+                                              DisplayMemberPath="Name"
+                                              SelectedValuePath="Name"
+                                              SelectedValue="{x:Bind ViewModelSettings.ShiftF10Exam, Mode=TwoWay}"/>
+                                </StackPanel>
+                            </Border>
+                            <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
+                                <StackPanel Spacing="10">
+                                    <TextBlock Text="Ctrl F10" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <ComboBox Width="150"
+                                              ItemsSource="{x:Bind ExamOptions}"
+                                              DisplayMemberPath="Name"
+                                              SelectedValuePath="Name"
+                                              SelectedValue="{x:Bind ViewModelSettings.CtrlF10Exam, Mode=TwoWay}"/>
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
+                        <StackPanel Spacing="10">
+                            <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
+                                <StackPanel Spacing="10">
+                                    <TextBlock Text="Maj F11" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <ComboBox Width="150"
+                                              ItemsSource="{x:Bind ExamOptions}"
+                                              DisplayMemberPath="Name"
+                                              SelectedValuePath="Name"
+                                              SelectedValue="{x:Bind ViewModelSettings.ShiftF11Exam, Mode=TwoWay}"/>
+                                </StackPanel>
+                            </Border>
+                            <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
+                                <StackPanel Spacing="10">
+                                    <TextBlock Text="Ctrl F11" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <ComboBox Width="150"
+                                              ItemsSource="{x:Bind ExamOptions}"
+                                              DisplayMemberPath="Name"
+                                              SelectedValuePath="Name"
+                                              SelectedValue="{x:Bind ViewModelSettings.CtrlF11Exam, Mode=TwoWay}"/>
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
+                        <StackPanel Spacing="10">
+                            <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
+                                <StackPanel Spacing="10">
+                                    <TextBlock Text="Maj F12" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <ComboBox Width="150"
+                                              ItemsSource="{x:Bind ExamOptions}"
+                                              DisplayMemberPath="Name"
+                                              SelectedValuePath="Name"
+                                              SelectedValue="{x:Bind ViewModelSettings.ShiftF12Exam, Mode=TwoWay}"/>
+                                </StackPanel>
+                            </Border>
+                            <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
+                                <StackPanel Spacing="10">
+                                    <TextBlock Text="Ctrl F12" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                    <ComboBox Width="150"
+                                              ItemsSource="{x:Bind ExamOptions}"
+                                              DisplayMemberPath="Name"
+                                              SelectedValuePath="Name"
+                                              SelectedValue="{x:Bind ViewModelSettings.CtrlF12Exam, Mode=TwoWay}"/>
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
                     </StackPanel>
                 </StackPanel>
             </Border>


### PR DESCRIPTION
## Summary
- group patient shortcut bindings in vertical columns so Shift keys appear above Ctrl keys on UserSettingsPage

## Testing
- `dotnet build` *(fails: XamlCompiler.exe exec format error on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_6897a638d9288324bdfa21ed908d8f3a