### PR TITLE
Add day and room title support for reminders

### DIFF
--- a/Client/Models/ReminderItem.cs
+++ b/Client/Models/ReminderItem.cs
@@ -1,10 +1,13 @@
+using System;
 using System.Collections.Generic;
 
 namespace Client.Models
 {
     public class ReminderItem
     {
+        public string Title { get; set; } = string.Empty;
         public string Message { get; set; } = string.Empty;
+        public List<DayOfWeek> Days { get; set; } = new();
         public List<string> Times { get; set; } = new();
     }
 }

--- a/Client/Pages/ReminderPage.xaml
+++ b/Client/Pages/ReminderPage.xaml
@@ -8,7 +8,17 @@
         <StackPanel Padding="20" Spacing="20">
             <Button Content="\u2190 Retour" Click="Back_Click" HorizontalAlignment="Left"/>
             <TextBlock Text="Rappels" FontSize="24" FontWeight="Bold"/>
+            <TextBox x:Name="TitleBox" Header="Titre"/>
             <RichEditBox x:Name="MessageBox" Header="Message"/>
+            <StackPanel x:Name="DaysPanel" Orientation="Horizontal" Spacing="10">
+                <CheckBox Content="Lun" Tag="Monday" Checked="Day_Checked" Unchecked="Day_Unchecked"/>
+                <CheckBox Content="Mar" Tag="Tuesday" Checked="Day_Checked" Unchecked="Day_Unchecked"/>
+                <CheckBox Content="Mer" Tag="Wednesday" Checked="Day_Checked" Unchecked="Day_Unchecked"/>
+                <CheckBox Content="Jeu" Tag="Thursday" Checked="Day_Checked" Unchecked="Day_Unchecked"/>
+                <CheckBox Content="Ven" Tag="Friday" Checked="Day_Checked" Unchecked="Day_Unchecked"/>
+                <CheckBox Content="Sam" Tag="Saturday" Checked="Day_Checked" Unchecked="Day_Unchecked"/>
+                <CheckBox Content="Dim" Tag="Sunday" Checked="Day_Checked" Unchecked="Day_Unchecked"/>
+            </StackPanel>
             <StackPanel Orientation="Horizontal" Spacing="10">
                 <TimePicker x:Name="TimePicker"/>
                 <Button Content="Ajouter l'heure" Click="AddTime_Click"/>
@@ -29,10 +39,18 @@
                     <DataTemplate x:DataType="models:ReminderItem">
                         <StackPanel Spacing="5">
                             <StackPanel Orientation="Horizontal" Spacing="10">
-                                <TextBlock Text="{x:Bind Message}" FontWeight="Bold" TextWrapping="Wrap"/>
+                                <TextBlock Text="{x:Bind Title}" FontWeight="Bold" TextWrapping="Wrap"/>
                                 <Button Content="Modifier" Click="EditReminder_Click" Tag="{x:Bind}"/>
                                 <Button Content="Supprimer" Click="RemoveReminder_Click" Tag="{x:Bind}"/>
                             </StackPanel>
+                            <TextBlock Text="{x:Bind Message}" TextWrapping="Wrap"/>
+                            <ItemsControl ItemsSource="{x:Bind Days}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding}"/>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
                             <ItemsControl ItemsSource="{x:Bind Times}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>

--- a/Client/Pages/ReminderPage.xaml.cs
+++ b/Client/Pages/ReminderPage.xaml.cs
@@ -1,5 +1,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Client.Models;
@@ -11,6 +12,7 @@ namespace Client.Pages
     public sealed partial class ReminderPage : Page
     {
         public ObservableCollection<string> Times { get; } = new();
+        public ObservableCollection<DayOfWeek> Days { get; } = new();
         public ObservableCollection<ReminderItem> Reminders { get; } = new();
         private ReminderItem? _editing;
 
@@ -47,6 +49,23 @@ namespace Client.Pages
                 Times.Add(t);
         }
 
+        private void Day_Checked(object sender, RoutedEventArgs e)
+        {
+            if (sender is CheckBox cb && Enum.TryParse<DayOfWeek>(cb.Tag?.ToString(), out var day))
+            {
+                if (!Days.Contains(day))
+                    Days.Add(day);
+            }
+        }
+
+        private void Day_Unchecked(object sender, RoutedEventArgs e)
+        {
+            if (sender is CheckBox cb && Enum.TryParse<DayOfWeek>(cb.Tag?.ToString(), out var day))
+            {
+                Days.Remove(day);
+            }
+        }
+
         private void RemoveTime_Click(object sender, RoutedEventArgs e)
         {
             if (sender is Button btn && btn.Tag is string t)
@@ -55,15 +74,18 @@ namespace Client.Pages
 
         private void AddReminder_Click(object sender, RoutedEventArgs e)
         {
+            var title = TitleBox.Text.Trim();
             MessageBox.Document.GetText(TextGetOptions.None, out var txt);
             var message = txt.Trim();
-            if (string.IsNullOrWhiteSpace(message) || Times.Count == 0)
+            if (string.IsNullOrWhiteSpace(title) || string.IsNullOrWhiteSpace(message) || Times.Count == 0 || Days.Count == 0)
                 return;
 
             if (_editing != null)
             {
+                _editing.Title = title;
                 _editing.Message = message;
                 _editing.Times = Times.ToList();
+                _editing.Days = Days.ToList();
                 Reminders.Add(_editing);
                 _editing = null;
                 AddReminderButton.Content = "Ajouter le rappel";
@@ -72,24 +94,39 @@ namespace Client.Pages
             {
                 var item = new ReminderItem
                 {
+                    Title = title,
                     Message = message,
+                    Days = Days.ToList(),
                     Times = Times.ToList()
                 };
                 Reminders.Add(item);
             }
 
+            TitleBox.Text = string.Empty;
             MessageBox.Document.SetText(TextSetOptions.None, string.Empty);
             Times.Clear();
+            Days.Clear();
+            foreach (var cb in DaysPanel.Children.OfType<CheckBox>())
+                cb.IsChecked = false;
         }
 
         private void EditReminder_Click(object sender, RoutedEventArgs e)
         {
             if (sender is Button btn && btn.Tag is ReminderItem item)
             {
+                TitleBox.Text = item.Title;
                 MessageBox.Document.SetText(TextSetOptions.None, item.Message);
                 Times.Clear();
                 foreach (var t in item.Times)
                     Times.Add(t);
+                Days.Clear();
+                foreach (var cb in DaysPanel.Children.OfType<CheckBox>())
+                {
+                    if (Enum.TryParse<DayOfWeek>(cb.Tag?.ToString(), out var day))
+                        cb.IsChecked = item.Days.Contains(day);
+                }
+                foreach (var d in item.Days)
+                    Days.Add(d);
                 Reminders.Remove(item);
                 _editing = item;
                 AddReminderButton.Content = "Mettre à jour le rappel";

--- a/Serveur/Models/ReminderItem.cs
+++ b/Serveur/Models/ReminderItem.cs
@@ -1,10 +1,13 @@
+using System;
 using System.Collections.Generic;
 
 namespace ChatServeur
 {
     public class ReminderItem
     {
+        public string Title { get; set; } = string.Empty;
         public string Message { get; set; } = string.Empty;
+        public List<DayOfWeek> Days { get; set; } = new();
         public List<string> Times { get; set; } = new();
     }
 }

--- a/Serveur/ReminderService.cs
+++ b/Serveur/ReminderService.cs
@@ -63,6 +63,8 @@ namespace ChatServeur
             var now = DateTime.Now;
             foreach (var item in reminder.Reminders)
             {
+                if (item.Days != null && item.Days.Count > 0 && !item.Days.Contains(now.DayOfWeek))
+                    continue;
                 foreach (var t in item.Times)
                 {
                     if (!TimeSpan.TryParse(t, out var span))
@@ -70,14 +72,14 @@ namespace ChatServeur
                     var scheduled = now.Date.Add(span);
                     if (Math.Abs((scheduled - now).TotalMinutes) < 1)
                     {
-                        var key = $"{item.Message}-{scheduled:yyyyMMddHHmm}";
+                        var key = $"{item.Title}-{item.Message}-{scheduled:yyyyMMddHHmm}";
                         if (_sent.Add(key))
                         {
                             var message = new ChatMessage
                             {
                                 Sender = "Rappel",
                                 Destinataire = "A Tous",
-                                Room = string.Empty,
+                                Room = item.Title ?? string.Empty,
                                 Content = item.Message,
                                 Avatar = "/Assets/secretaria.png",
 


### PR DESCRIPTION
## Summary
- allow reminders to include a title, broadcast days, and multiple times
- send reminders to a titled room only on selected days
- expand client UI for entering titles, days and times per reminder

## Testing
- `dotnet build` *(fails: NETSDK1100 To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*
- `dotnet build Serveur/Serveur.csproj`
- `dotnet build Client/Client.csproj -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_6899c6482094832490c596bf60363be2