### PR TITLE
Affichage des jours en français

### DIFF
--- a/Client/Helpers/DayOfWeekToFrenchConverter.cs
+++ b/Client/Helpers/DayOfWeekToFrenchConverter.cs
@@ -1,0 +1,45 @@
+using Microsoft.UI.Xaml.Data;
+using System;
+
+namespace Client.Helpers
+{
+    public class DayOfWeekToFrenchConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            if (value is DayOfWeek day)
+            {
+                return day switch
+                {
+                    DayOfWeek.Monday => "Lundi",
+                    DayOfWeek.Tuesday => "Mardi",
+                    DayOfWeek.Wednesday => "Mercredi",
+                    DayOfWeek.Thursday => "Jeudi",
+                    DayOfWeek.Friday => "Vendredi",
+                    DayOfWeek.Saturday => "Samedi",
+                    DayOfWeek.Sunday => "Dimanche",
+                    _ => string.Empty
+                };
+            }
+            return string.Empty;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            if (value is string s)
+            {
+                switch (s.ToLower())
+                {
+                    case "lundi": return DayOfWeek.Monday;
+                    case "mardi": return DayOfWeek.Tuesday;
+                    case "mercredi": return DayOfWeek.Wednesday;
+                    case "jeudi": return DayOfWeek.Thursday;
+                    case "vendredi": return DayOfWeek.Friday;
+                    case "samedi": return DayOfWeek.Saturday;
+                    case "dimanche": return DayOfWeek.Sunday;
+                }
+            }
+            return DayOfWeek.Monday;
+        }
+    }
+}

--- a/Client/Pages/ReminderPage.xaml
+++ b/Client/Pages/ReminderPage.xaml
@@ -3,7 +3,11 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:models="using:Client.Models"
+    xmlns:helpers="using:Client.Helpers"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Page.Resources>
+        <helpers:DayOfWeekToFrenchConverter x:Key="DayOfWeekToFrenchConverter" />
+    </Page.Resources>
     <ScrollViewer>
         <StackPanel Padding="20" Spacing="20">
             <Button Content="\u2190 Retour" Click="Back_Click" HorizontalAlignment="Left"/>
@@ -47,7 +51,7 @@
                             <ItemsControl ItemsSource="{x:Bind Days}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
-                                        <TextBlock Text="{Binding}"/>
+                                        <TextBlock Text="{Binding Converter={StaticResource DayOfWeekToFrenchConverter}}"/>
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>


### PR DESCRIPTION
## Summary
- ajoute un convertisseur pour afficher les jours des rappels en français
- utilise le convertisseur dans `ReminderPage`

## Testing
- `dotnet build WebApplication1.sln` *(échoue : To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*
- `dotnet build Serveur/Serveur.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689a2bfd2e488324b9e5f8b1602a22f0