### PR TITLE
Improve reminder item layout

### DIFF
--- a/Client/Pages/ReminderPage.xaml
+++ b/Client/Pages/ReminderPage.xaml
@@ -42,26 +42,54 @@
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="models:ReminderItem">
                         <StackPanel Spacing="5">
-                            <StackPanel Orientation="Horizontal" Spacing="10">
-                                <TextBlock Text="{x:Bind Title}" FontWeight="Bold" TextWrapping="Wrap"/>
-                                <Button Content="Modifier" Click="EditReminder_Click" Tag="{x:Bind}"/>
-                                <Button Content="Supprimer" Click="RemoveReminder_Click" Tag="{x:Bind}"/>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" FontWeight="Bold" TextWrapping="Wrap">
+                                    <Run Text="Titre : "/>
+                                    <Run Text="{x:Bind Title}"/>
+                                </TextBlock>
+                                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10">
+                                    <Button Content="Modifier" Click="EditReminder_Click" Tag="{x:Bind}"/>
+                                    <Button Content="Supprimer" Click="RemoveReminder_Click" Tag="{x:Bind}"/>
+                                </StackPanel>
+                            </Grid>
+                            <TextBlock TextWrapping="Wrap">
+                                <Run Text="Message : "/>
+                                <Run Text="{x:Bind Message}"/>
+                            </TextBlock>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Jours : "/>
+                                <ItemsControl ItemsSource="{x:Bind Days}">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <StackPanel Orientation="Horizontal"/>
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding Converter={StaticResource DayOfWeekToFrenchConverter}}" Margin="0,0,5,0"/>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
                             </StackPanel>
-                            <TextBlock Text="{x:Bind Message}" TextWrapping="Wrap"/>
-                            <ItemsControl ItemsSource="{x:Bind Days}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <TextBlock Text="{Binding Converter={StaticResource DayOfWeekToFrenchConverter}}"/>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-                            <ItemsControl ItemsSource="{x:Bind Times}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <TextBlock Text="{Binding}"/>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Heures : "/>
+                                <ItemsControl ItemsSource="{x:Bind Times}">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <StackPanel Orientation="Horizontal"/>
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding}" Margin="0,0,5,0"/>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
                         </StackPanel>
                     </DataTemplate>
                 </ListView.ItemTemplate>


### PR DESCRIPTION
## Summary
- adjust reminder list layout to show title with action buttons and labeled message, days and times

## Testing
- `~/.dotnet/dotnet build WebApplication1.sln -p:EnableWindowsTargeting=true` *(fails: XamlCompiler.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_689a2de2946083248549465b40250afb