### PR TITLE
Add keycap formatting for sample F5 instruction

### DIFF
--- a/Client/Models/ChatMessageModel.cs
+++ b/Client/Models/ChatMessageModel.cs
@@ -2,10 +2,13 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml;
 using System;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Windows.System;
 using Microsoft.UI.Xaml.Media;
 using System.ComponentModel;
+using Windows.UI;
+using Windows.UI.Text;
 
 namespace Client.Models
 {
@@ -75,6 +78,21 @@ namespace Client.Models
         public string IrcHeader => $"[{IrcTimestamp}] <{Sender} ({Room})> <{Destinataire}> : {Content}";
 
         private static readonly Regex _urlRegex = new(@"https?://\S+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex _keyRegex = new(@"\[\[(?<key>[^\[\]]+)\]\]", RegexOptions.Compiled);
+
+        private enum SpecialSegmentType
+        {
+            Url,
+            Key
+        }
+
+        private sealed class SpecialSegment
+        {
+            public int Index { get; init; }
+            public int Length { get; init; }
+            public string Value { get; init; } = string.Empty;
+            public SpecialSegmentType Type { get; init; }
+        }
 
         public void FormatContent(object sender, RoutedEventArgs e)
         {
@@ -83,16 +101,26 @@ namespace Client.Models
 
             InlineCollection? container = null;
             Brush? foreground = null;
+            double fontSize = block.FontSize;
+            FontFamily? fontFamily = block.FontFamily;
 
             if (block.FindName("ContentParagraph") is Paragraph paragraph)
             {
                 container = paragraph.Inlines;
                 foreground = paragraph.Foreground;
+                if (paragraph.FontSize > 0)
+                    fontSize = paragraph.FontSize;
+                if (paragraph.FontFamily != null)
+                    fontFamily = paragraph.FontFamily;
             }
             else if (block.FindName("ContentSpan") is Span span)
             {
                 container = span.Inlines;
                 foreground = span.Foreground;
+                if (span.FontSize > 0)
+                    fontSize = span.FontSize;
+                if (span.FontFamily != null)
+                    fontFamily = span.FontFamily;
             }
             if (container is null)
                 return;
@@ -100,33 +128,135 @@ namespace Client.Models
             container.Clear();
 
             var text = Content;
-            var last = 0;
+            if (string.IsNullOrEmpty(text))
+                return;
+
+            var segments = new List<SpecialSegment>();
+
+            foreach (Match match in _keyRegex.Matches(text))
+            {
+                var keyText = match.Groups["key"].Value.Trim();
+                if (string.IsNullOrEmpty(keyText))
+                    continue;
+
+                segments.Add(new SpecialSegment
+                {
+                    Index = match.Index,
+                    Length = match.Length,
+                    Value = keyText,
+                    Type = SpecialSegmentType.Key
+                });
+            }
+
             foreach (Match match in _urlRegex.Matches(text))
             {
-                if (match.Index > last)
-                    container.Add(new Run { Text = text.Substring(last, match.Index - last) });
-
-                var url = match.Value;
-                if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+                segments.Add(new SpecialSegment
                 {
-                    container.Add(new Run { Text = url });
-                }
-                else
-                {
-                    var link = new Hyperlink
-                    {
-                        NavigateUri = uri,
-                        Foreground = foreground
-                    };
-                    link.Inlines.Add(new Run { Text = url });
-                    link.Click += async (_, _) => await Launcher.LaunchUriAsync(uri);
-                    container.Add(link);
-                }
-
-                last = match.Index + match.Length;
+                    Index = match.Index,
+                    Length = match.Length,
+                    Value = match.Value,
+                    Type = SpecialSegmentType.Url
+                });
             }
-            if (last < text.Length)
-                container.Add(new Run { Text = text[last..] });
+
+            segments.Sort((a, b) => a.Index.CompareTo(b.Index));
+
+            var currentIndex = 0;
+            foreach (var segment in segments)
+            {
+                if (segment.Index < currentIndex)
+                    continue;
+
+                if (segment.Index > currentIndex)
+                {
+                    container.Add(new Run
+                    {
+                        Text = text.Substring(currentIndex, segment.Index - currentIndex)
+                    });
+                }
+
+                switch (segment.Type)
+                {
+                    case SpecialSegmentType.Key:
+                        container.Add(CreateKeyInline(segment.Value, fontSize, fontFamily, foreground));
+                        break;
+                    case SpecialSegmentType.Url:
+                        AddUrlInline(container, segment.Value, foreground);
+                        break;
+                }
+
+                currentIndex = segment.Index + segment.Length;
+            }
+
+            if (currentIndex < text.Length)
+            {
+                container.Add(new Run { Text = text[currentIndex..] });
+            }
+        }
+
+        private static void AddUrlInline(InlineCollection container, string url, Brush? foreground)
+        {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            {
+                container.Add(new Run { Text = url });
+                return;
+            }
+
+            var link = new Hyperlink
+            {
+                NavigateUri = uri,
+                Foreground = foreground
+            };
+            link.Inlines.Add(new Run { Text = url });
+            link.Click += async (_, _) => await Launcher.LaunchUriAsync(uri);
+            container.Add(link);
+        }
+
+        private static Inline CreateKeyInline(string keyText, double fontSize, FontFamily? fontFamily, Brush? foreground)
+        {
+            var baseColor = Colors.Gray;
+            if (foreground is SolidColorBrush solid)
+            {
+                baseColor = solid.Color;
+            }
+
+            var backgroundColor = Color.FromArgb(40, baseColor.R, baseColor.G, baseColor.B);
+            var borderColor = Color.FromArgb(120, baseColor.R, baseColor.G, baseColor.B);
+
+            var textBlock = new TextBlock
+            {
+                Text = keyText,
+                FontSize = fontSize > 0 ? fontSize : 14,
+                FontWeight = FontWeights.SemiBold,
+                VerticalAlignment = VerticalAlignment.Center
+            };
+
+            if (foreground != null)
+            {
+                textBlock.Foreground = foreground;
+            }
+
+            if (fontFamily != null)
+            {
+                textBlock.FontFamily = fontFamily;
+            }
+
+            var border = new Border
+            {
+                Background = new SolidColorBrush(backgroundColor),
+                BorderBrush = new SolidColorBrush(borderColor),
+                BorderThickness = new Thickness(1),
+                CornerRadius = new CornerRadius(4),
+                Padding = new Thickness(6, 2, 6, 2),
+                Margin = new Thickness(2, 0, 2, 0),
+                Child = textBlock
+            };
+
+            return new InlineUIContainer
+            {
+                Child = border,
+                BaselineAlignment = BaselineAlignment.Center
+            };
         }
 
         private void OnPropertyChanged(string propertyName) =>

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -329,6 +329,7 @@ namespace ChatServeur
             {
                 (username, userRoom, "A Tous", "Bonjour à tous, ceci est un message de démonstration.", userAvatar),
                 (username, userRoom, "A Tous", "Utilisez l'icône « + » pour ajouter un patient au planning.", userAvatar),
+                (username, userRoom, "A Tous", "Pour mettre votre en-tête, appuyez sur la touche [[F5]].", userAvatar),
                 ("Secrétariat", "Secrétariat", "A Tous", "Pensez à prévenir l'équipe lorsqu'un examen est terminé.", secretariatAvatar),
                 (username, userRoom, "A Tous", "Sélectionnez un destinataire pour envoyer un message privé.", userAvatar),
                 ("Secrétariat", "Secrétariat", "A Tous", "Tapez /clearallmessageday pour remettre le fil à zéro.", secretariatAvatar)


### PR DESCRIPTION
## Summary
- add a demo message explaining how to insert the header using the F5 key token
- enhance chat message rendering to convert [[KEY]] markers into styled keycaps while preserving link handling

## Testing
- `dotnet build WebApplication1.sln` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfebb83d1c8324b2d81559ff8e2229