### PR TITLE
Improve connector visuals and copy handling for keycaps

### DIFF
--- a/Client/Models/ChatMessageModel.cs
+++ b/Client/Models/ChatMessageModel.cs
@@ -245,29 +245,30 @@ namespace Client.Models
 
         private static Inline CreateConnectorInline(double fontSize, FontFamily? fontFamily, Brush? foreground)
         {
-
-            var run = new Run
+            var textBlock = new TextBlock
             {
                 Text = "+",
-                FontWeight = new FontWeight { Weight = 600 }
+                FontSize = fontSize > 0 ? fontSize : 14,
+                FontWeight = new FontWeight { Weight = 600 },
+                VerticalAlignment = VerticalAlignment.Center,
+                Padding = new Thickness(0),
+                Margin = new Thickness(0)
             };
-
-            if (fontSize > 0)
-            {
-                run.FontSize = fontSize;
-            }
 
             if (foreground != null)
             {
-                run.Foreground = foreground;
+                textBlock.Foreground = foreground;
             }
 
             if (fontFamily != null)
             {
-                run.FontFamily = fontFamily;
+                textBlock.FontFamily = fontFamily;
             }
 
-            return run;
+            return new InlineUIContainer
+            {
+                Child = textBlock
+            };
         }
 
         private static Run CreateTextRun(string text, double fontSize, FontFamily? fontFamily, Brush? foreground)

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -1024,20 +1024,60 @@ namespace Client.Pages
                 {
                     foreach (var inline in p.Inlines)
                     {
-                        switch (inline)
-                        {
-                            case Run run:
-                                sb.Append(run.Text);
-                                break;
-                            case LineBreak:
-                                sb.Append('\n');
-                                break;
-                        }
+                        AppendInlineText(sb, inline);
                     }
                     sb.Append('\n');
                 }
             }
             return sb.ToString();
+        }
+
+        private static void AppendInlineText(System.Text.StringBuilder sb, Inline inline)
+        {
+            switch (inline)
+            {
+                case Run run:
+                    sb.Append(run.Text);
+                    break;
+                case LineBreak:
+                    sb.Append('\n');
+                    break;
+                case InlineUIContainer container:
+                    sb.Append(ExtractTextFromElement(container.Child));
+                    break;
+            }
+        }
+
+        private static string ExtractTextFromElement(UIElement? element)
+        {
+            switch (element)
+            {
+                case TextBlock textBlock:
+                    return textBlock.Text;
+                case Border border:
+                    return ExtractTextFromElement(border.Child);
+                case Panel panel:
+                    {
+                        var sb = new System.Text.StringBuilder();
+                        foreach (var child in panel.Children)
+                        {
+                            if (child is UIElement uiElement)
+                            {
+                                sb.Append(ExtractTextFromElement(uiElement));
+                            }
+                        }
+                        return sb.ToString();
+                    }
+                case ContentControl contentControl:
+                    return contentControl.Content switch
+                    {
+                        string text => text,
+                        UIElement uiElement => ExtractTextFromElement(uiElement),
+                        _ => string.Empty
+                    };
+                default:
+                    return string.Empty;
+            }
         }
         private async void InputBox_Paste(object sender, TextControlPasteEventArgs e)
         {


### PR DESCRIPTION
## Summary
- render standalone plus connectors with an InlineUIContainer TextBlock so they share keycap styling cues without affecting layout
- update the copy helper to extract text from InlineUIContainer content so keycaps and connectors are preserved when copying

## Testing
- Not Run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d025fdc9d4832495b6cf8e81ce5b28