### PR TITLE
Improve keycap connector layout and copying

### DIFF
--- a/Client/Models/ChatMessageModel.cs
+++ b/Client/Models/ChatMessageModel.cs
@@ -245,29 +245,32 @@ namespace Client.Models
 
         private static Inline CreateConnectorInline(double fontSize, FontFamily? fontFamily, Brush? foreground)
         {
-
-            var run = new Run
+            var textBlock = new TextBlock
             {
                 Text = "+",
-                FontWeight = new FontWeight { Weight = 600 }
+                FontSize = fontSize > 0 ? fontSize : 14,
+                FontWeight = new FontWeight { Weight = 600 },
+                VerticalAlignment = VerticalAlignment.Center,
+                TextLineBounds = TextLineBounds.Tight,
+                Padding = new Thickness(0),
+                Margin = new Thickness(0, 1, 0, 1)
             };
-
-            if (fontSize > 0)
-            {
-                run.FontSize = fontSize;
-            }
 
             if (foreground != null)
             {
-                run.Foreground = foreground;
+                textBlock.Foreground = foreground;
             }
 
             if (fontFamily != null)
             {
-                run.FontFamily = fontFamily;
+                textBlock.FontFamily = fontFamily;
             }
 
-            return run;
+            return new InlineUIContainer
+            {
+                Child = textBlock,
+                BaselineAlignment = BaselineAlignment.Center
+            };
         }
 
         private static Run CreateTextRun(string text, double fontSize, FontFamily? fontFamily, Brush? foreground)
@@ -351,6 +354,18 @@ namespace Client.Models
                 Child = border
 
             };
+        }
+
+        public string GetPlainTextContent()
+        {
+            if (string.IsNullOrEmpty(Content))
+                return string.Empty;
+
+            return _keyRegex.Replace(Content, match =>
+            {
+                var keyText = match.Groups["key"].Value.Trim();
+                return keyText;
+            });
         }
 
         private void OnPropertyChanged(string propertyName) =>

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -923,7 +923,8 @@ namespace Client.Pages
             }
             else if (_currentMessageTarget?.DataContext is ChatMessageModel msg)
             {
-                text = $"{msg.Header}\n{msg.Content}\n{msg.TimeFormatted}";
+                var content = msg.GetPlainTextContent();
+                text = $"{msg.Header}\n{content}\n{msg.TimeFormatted}";
             }
 
             if (!string.IsNullOrEmpty(text))
@@ -1017,27 +1018,88 @@ namespace Client.Pages
 
         private static string GetRichText(RichTextBlock block)
         {
-            var sb = new System.Text.StringBuilder();
+            var sb = new StringBuilder();
             foreach (var b in block.Blocks)
             {
                 if (b is Paragraph p)
                 {
                     foreach (var inline in p.Inlines)
                     {
-                        switch (inline)
-                        {
-                            case Run run:
-                                sb.Append(run.Text);
-                                break;
-                            case LineBreak:
-                                sb.Append('\n');
-                                break;
-                        }
+                        AppendInlineText(sb, inline);
                     }
                     sb.Append('\n');
                 }
             }
             return sb.ToString();
+        }
+
+        private static void AppendInlineText(StringBuilder sb, Inline inline)
+        {
+            switch (inline)
+            {
+                case Run run:
+                    sb.Append(run.Text);
+                    break;
+                case LineBreak:
+                    sb.Append('\n');
+                    break;
+                case Span span:
+                    foreach (var child in span.Inlines)
+                    {
+                        AppendInlineText(sb, child);
+                    }
+                    break;
+                case InlineUIContainer container:
+                    sb.Append(ExtractTextFromElement(container.Child));
+                    break;
+            }
+        }
+
+        private static string ExtractTextFromElement(UIElement? element)
+        {
+            switch (element)
+            {
+                case TextBlock textBlock:
+                    if (!string.IsNullOrEmpty(textBlock.Text))
+                    {
+                        return textBlock.Text;
+                    }
+
+                    if (textBlock.Inlines != null && textBlock.Inlines.Count > 0)
+                    {
+                        var sb = new StringBuilder();
+                        foreach (var inline in textBlock.Inlines)
+                        {
+                            AppendInlineText(sb, inline);
+                        }
+                        return sb.ToString();
+                    }
+
+                    return string.Empty;
+                case Border border:
+                    return ExtractTextFromElement(border.Child);
+                case Panel panel:
+                    {
+                        var sb = new StringBuilder();
+                        foreach (var child in panel.Children)
+                        {
+                            if (child is UIElement uiElement)
+                            {
+                                sb.Append(ExtractTextFromElement(uiElement));
+                            }
+                        }
+                        return sb.ToString();
+                    }
+                case ContentControl contentControl:
+                    return contentControl.Content switch
+                    {
+                        string text => text,
+                        UIElement uiElement => ExtractTextFromElement(uiElement),
+                        _ => string.Empty
+                    };
+                default:
+                    return string.Empty;
+            }
         }
         private async void InputBox_Paste(object sender, TextControlPasteEventArgs e)
         {


### PR DESCRIPTION
## Summary
- center inline plus connectors by tightening text bounds and baseline alignment so they line up with keycaps
- expose a plain-text projection of message content and use it when copying chat messages so keycaps become regular characters
- walk nested spans and text elements when extracting rich text to capture inline UI containers such as keycaps and connectors

## Testing
- Not Run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d025fdc9d4832495b6cf8e81ce5b28