### PR TITLE
Expand connector detection for key combinations

### DIFF
--- a/Client/Models/ChatMessageModel.cs
+++ b/Client/Models/ChatMessageModel.cs
@@ -80,11 +80,30 @@ namespace Client.Models
 
         private static readonly Regex _urlRegex = new(@"https?://\S+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex _keyRegex = new(@"\[\[(?<key>[^\[\]]+)\]\]", RegexOptions.Compiled);
+        private static readonly Regex _combinationRegex = new(@"\{\{(?<combo>.*?)\}\}", RegexOptions.Compiled | RegexOptions.Singleline);
+        private static readonly HashSet<string> _knownKeyTokens = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "CTRL", "CONTROL", "ALT", "ALTGR", "ALTGRAPH", "SHIFT", "MAJ", "MAJUSCULE",
+            "CMD", "COMMAND", "COMMANDE", "WINDOWS", "WIN", "SUPER", "META", "OPTION",
+            "OPT", "FN", "MENU", "APPS", "APP", "ENTER", "ENTREE", "ENTRÉE", "RETURN",
+            "TAB", "TABULATION", "ESC", "ESCAPE", "ECHAP", "ÉCHAP", "SPACE", "SPACEBAR",
+            "ESPACE", "BACKSPACE", "SUPPR", "DELETE", "DEL", "INS", "INSERT", "HOME",
+            "END", "PGUP", "PAGEUP", "PGDN", "PAGEDOWN", "UP", "DOWN", "LEFT", "RIGHT",
+            "PAUSE", "BREAK", "PRINTSCREEN", "IMPR", "IMPRECRAN", "IMPRIMECRAN", "PRTSC",
+            "SCROLLLOCK", "SCRLK", "CAPSLOCK", "VERRMAJ", "NUMLOCK", "VERRNUM"
+        };
+        private static readonly HashSet<char> _punctuationKeyCharacters = new(new[]
+        {
+            '`', '~', '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '-', '_', '=', '+',
+            '[', ']', '{', '}', '\\', '|', ';', ':', '\'', '"', ',', '.', '<', '>', '/', '?'
+        });
+        private static readonly HashSet<char> _tokenTrimCharacters = new(new[] { '(', ')', '[', ']', '{', '}', '<', '>', '\'', '"', '`' });
 
         private enum SpecialSegmentType
         {
+            Key,
             Url,
-            Key
+            Combination
         }
 
         private sealed class SpecialSegment
@@ -93,6 +112,7 @@ namespace Client.Models
             public int Length { get; init; }
             public string Value { get; init; } = string.Empty;
             public SpecialSegmentType Type { get; init; }
+            public string Original { get; init; } = string.Empty;
         }
 
         public void FormatContent(object sender, RoutedEventArgs e)
@@ -133,6 +153,28 @@ namespace Client.Models
                 return;
 
             var segments = new List<SpecialSegment>();
+            var combinationRanges = new List<(int Start, int End)>();
+
+            foreach (Match match in _combinationRegex.Matches(text))
+            {
+                var combinationText = match.Groups["combo"].Value.Trim();
+                if (string.IsNullOrEmpty(combinationText))
+                    continue;
+
+                if (!_keyRegex.IsMatch(combinationText))
+                    continue;
+
+                segments.Add(new SpecialSegment
+                {
+                    Index = match.Index,
+                    Length = match.Length,
+                    Value = combinationText,
+                    Original = match.Value,
+                    Type = SpecialSegmentType.Combination
+                });
+
+                combinationRanges.Add((match.Index, match.Index + match.Length));
+            }
 
             foreach (Match match in _keyRegex.Matches(text))
             {
@@ -140,22 +182,30 @@ namespace Client.Models
                 if (string.IsNullOrEmpty(keyText))
                     continue;
 
+                if (IsInsideAnyRange(match.Index, match.Length, combinationRanges))
+                    continue;
+
                 segments.Add(new SpecialSegment
                 {
                     Index = match.Index,
                     Length = match.Length,
                     Value = keyText,
+                    Original = match.Value,
                     Type = SpecialSegmentType.Key
                 });
             }
 
             foreach (Match match in _urlRegex.Matches(text))
             {
+                if (IsInsideAnyRange(match.Index, match.Length, combinationRanges))
+                    continue;
+
                 segments.Add(new SpecialSegment
                 {
                     Index = match.Index,
                     Length = match.Length,
                     Value = match.Value,
+                    Original = match.Value,
                     Type = SpecialSegmentType.Url
                 });
             }
@@ -184,6 +234,9 @@ namespace Client.Models
                         break;
                     case SpecialSegmentType.Url:
                         AddUrlInline(container, segment.Value, foreground);
+                        break;
+                    case SpecialSegmentType.Combination:
+                        container.Add(CreateCombinationInline(segment.Value, segment.Original, fontSize, fontFamily, foreground));
                         break;
                 }
 
@@ -218,7 +271,13 @@ namespace Client.Models
             container.Add(link);
         }
 
-        private static void AddPlainTextInline(InlineCollection container, string text, double fontSize, FontFamily? fontFamily, Brush? foreground)
+        private static void AddPlainTextInline(
+            InlineCollection container,
+            string text,
+            double fontSize,
+            FontFamily? fontFamily,
+            Brush? foreground,
+            bool allowTightConnectors = false)
         {
             if (string.IsNullOrEmpty(text))
                 return;
@@ -226,7 +285,10 @@ namespace Client.Models
             var current = 0;
             for (var i = 0; i < text.Length; i++)
             {
-                if (!IsStandalonePlus(text, i))
+                if (text[i] != '+')
+                    continue;
+
+                if (!ShouldTreatPlusAsConnector(text, i, allowTightConnectors))
                     continue;
 
                 if (i > current)
@@ -306,15 +368,167 @@ namespace Client.Models
 
         }
 
-        private static bool IsStandalonePlus(string text, int index)
+        private static bool ShouldTreatPlusAsConnector(string text, int index, bool allowTightConnectors)
         {
             if (text[index] != '+')
                 return false;
 
-            var isStartOrSpaceBefore = index == 0 || char.IsWhiteSpace(text[index - 1]);
-            var isEndOrSpaceAfter = index == text.Length - 1 || char.IsWhiteSpace(text[index + 1]);
+            if (allowTightConnectors)
+                return true;
 
-            return isStartOrSpaceBefore && isEndOrSpaceAfter;
+            if (IsWhitespaceSeparatedPlus(text, index))
+                return true;
+
+            var leftToken = ExtractKeyToken(text, index - 1, -1);
+            var rightToken = ExtractKeyToken(text, index + 1, 1);
+
+            if (string.IsNullOrEmpty(leftToken) || string.IsNullOrEmpty(rightToken))
+                return false;
+
+            var leftStrong = IsStrongKeyToken(leftToken);
+            var rightStrong = IsStrongKeyToken(rightToken);
+
+            if (!leftStrong && !rightStrong)
+                return false;
+
+            var leftIsKey = leftStrong || IsSingleKeyToken(leftToken);
+            var rightIsKey = rightStrong || IsSingleKeyToken(rightToken);
+
+            if (!leftIsKey || !rightIsKey)
+                return false;
+
+            if (!leftStrong && !rightStrong && IsDigitToken(leftToken) && IsDigitToken(rightToken))
+                return false;
+
+            return true;
+        }
+
+        private static bool IsWhitespaceSeparatedPlus(string text, int index)
+        {
+            var hasSpaceBefore = index == 0 || char.IsWhiteSpace(text[index - 1]);
+            var hasSpaceAfter = index >= text.Length - 1 || char.IsWhiteSpace(text[index + 1]);
+
+            return hasSpaceBefore && hasSpaceAfter;
+        }
+
+        private static string ExtractKeyToken(string text, int startIndex, int direction)
+        {
+            var i = startIndex;
+
+            while (i >= 0 && i < text.Length && char.IsWhiteSpace(text[i]))
+            {
+                i += direction;
+            }
+
+            if (i < 0 || i >= text.Length)
+                return string.Empty;
+
+            var tokenStart = i;
+            var tokenEnd = i;
+
+            if (direction < 0)
+            {
+                var j = i;
+                while (j >= 0 && !char.IsWhiteSpace(text[j]) && text[j] != '+')
+                {
+                    tokenStart = j;
+                    j--;
+                }
+
+                return text.Substring(tokenStart, tokenEnd - tokenStart + 1);
+            }
+            else
+            {
+                var j = i;
+                while (j < text.Length && !char.IsWhiteSpace(text[j]) && text[j] != '+')
+                {
+                    tokenEnd = j;
+                    j++;
+                }
+
+                return text.Substring(tokenStart, tokenEnd - tokenStart + 1);
+            }
+        }
+
+        private static bool IsStrongKeyToken(string token)
+        {
+            var trimmed = TrimToken(token);
+            if (string.IsNullOrEmpty(trimmed))
+                return false;
+
+            if (trimmed.StartsWith("[[", StringComparison.Ordinal) && trimmed.EndsWith("]]", StringComparison.Ordinal))
+                return true;
+
+            if (_knownKeyTokens.Contains(trimmed))
+                return true;
+
+            if (trimmed.Length >= 2 && (trimmed[0] == 'F' || trimmed[0] == 'f') && int.TryParse(trimmed[1..], out var functionNumber) && functionNumber >= 1 && functionNumber <= 24)
+                return true;
+
+            if (trimmed.Length > 6 && trimmed.StartsWith("NUMPAD", StringComparison.OrdinalIgnoreCase) && int.TryParse(trimmed[6..], out _))
+                return true;
+
+            if (trimmed.Length > 3 && trimmed.StartsWith("NUM", StringComparison.OrdinalIgnoreCase) && int.TryParse(trimmed[3..], out _))
+                return true;
+
+            return false;
+        }
+
+        private static bool IsSingleKeyToken(string token)
+        {
+            var trimmed = TrimToken(token);
+            if (string.IsNullOrEmpty(trimmed))
+                return false;
+
+            if (trimmed.StartsWith("[[", StringComparison.Ordinal) && trimmed.EndsWith("]]", StringComparison.Ordinal))
+                return true;
+
+            if (trimmed.Length == 1)
+            {
+                var ch = trimmed[0];
+                return char.IsLetterOrDigit(ch) || _punctuationKeyCharacters.Contains(ch);
+            }
+
+            return false;
+        }
+
+        private static bool IsDigitToken(string token)
+        {
+            var trimmed = TrimToken(token);
+            if (string.IsNullOrEmpty(trimmed))
+                return false;
+
+            foreach (var ch in trimmed)
+            {
+                if (!char.IsDigit(ch))
+                    return false;
+            }
+
+            return true;
+        }
+
+        private static string TrimToken(string token)
+        {
+            if (string.IsNullOrEmpty(token))
+                return string.Empty;
+
+            var trimmed = token.Trim();
+            var start = 0;
+            var end = trimmed.Length;
+
+            while (start < end && _tokenTrimCharacters.Contains(trimmed[start]))
+            {
+                start++;
+            }
+
+            while (end > start && _tokenTrimCharacters.Contains(trimmed[end - 1]))
+            {
+                end--;
+            }
+
+            return start == 0 && end == trimmed.Length
+                ? trimmed
+                : trimmed.Substring(start, end - start);
         }
 
         private static Inline CreateKeyInline(string keyText, double fontSize, FontFamily? fontFamily, Brush? foreground)
@@ -363,16 +577,93 @@ namespace Client.Models
             };
         }
 
+        private static Inline CreateCombinationInline(string combinationText, string originalText, double fontSize, FontFamily? fontFamily, Brush? foreground)
+        {
+            if (string.IsNullOrEmpty(combinationText))
+            {
+                return new Run { Text = originalText };
+            }
+
+            var span = new Span();
+            var matches = _keyRegex.Matches(combinationText);
+
+            if (matches.Count == 0)
+            {
+                return new Run { Text = originalText };
+            }
+
+            var currentIndex = 0;
+            foreach (Match match in matches)
+            {
+                if (match.Index > currentIndex)
+                {
+                    AddPlainTextInline(
+                        span.Inlines,
+                        combinationText.Substring(currentIndex, match.Index - currentIndex),
+                        fontSize,
+                        fontFamily,
+                        foreground,
+                        allowTightConnectors: true);
+                }
+
+                var keyText = match.Groups["key"].Value.Trim();
+                if (!string.IsNullOrEmpty(keyText))
+                {
+                    span.Inlines.Add(CreateKeyInline(keyText, fontSize, fontFamily, foreground));
+                }
+
+                currentIndex = match.Index + match.Length;
+            }
+
+            if (currentIndex < combinationText.Length)
+            {
+                AddPlainTextInline(
+                    span.Inlines,
+                    combinationText.Substring(currentIndex),
+                    fontSize,
+                    fontFamily,
+                    foreground,
+                    allowTightConnectors: true);
+            }
+
+            if (span.Inlines.Count == 0)
+            {
+                return new Run { Text = originalText };
+            }
+
+            return span;
+        }
+
         public string GetPlainTextContent()
         {
             if (string.IsNullOrEmpty(Content))
                 return string.Empty;
 
-            return _keyRegex.Replace(Content, match =>
+            string ReplaceKey(Match match) => match.Groups["key"].Value.Trim();
+
+            var withoutCombinations = _combinationRegex.Replace(Content, match =>
             {
-                var keyText = match.Groups["key"].Value.Trim();
-                return keyText;
+                var combinationText = match.Groups["combo"].Value;
+                if (!_keyRegex.IsMatch(combinationText))
+                    return match.Value;
+
+                return _keyRegex.Replace(combinationText, ReplaceKey);
             });
+
+            return _keyRegex.Replace(withoutCombinations, ReplaceKey);
+        }
+
+        private static bool IsInsideAnyRange(int index, int length, List<(int Start, int End)> ranges)
+        {
+            foreach (var (start, end) in ranges)
+            {
+                if (index >= start && index + length <= end)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private void OnPropertyChanged(string propertyName) =>


### PR DESCRIPTION
## Summary
- add key token and punctuation lookups so tight key separators are detected even without surrounding whitespace
- replace the standalone plus check with a token-aware analyzer to cover combinations like Ctrl+F5 and `{{[[Ctrl]]+[[F5]]}}`

## Testing
- dotnet build WebApplication1.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d2cd62a8dc83249b90560b61ee07ae