### PR TITLE
Handle startup failures when Patients table is missing

### DIFF
--- a/Serveur/Program.cs
+++ b/Serveur/Program.cs
@@ -46,6 +46,7 @@ using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<ChatDbContext>();
     db.Database.EnsureCreated();
+    EnsurePatientsTable(db);
     EnsureArchivedColumn(db);
     EnsureIsDeletedColumn(db);
     EnsurePatientLogsTable(db);
@@ -65,6 +66,11 @@ void EnsureArchivedColumn(ChatDbContext db)
     connection.Open();
     try
     {
+        if (!TableExists(connection, "Patients"))
+        {
+            return;
+        }
+
         using var cmd = connection.CreateCommand();
         cmd.CommandText = "PRAGMA table_info('Patients')";
         using var reader = cmd.ExecuteReader();
@@ -88,6 +94,56 @@ void EnsureArchivedColumn(ChatDbContext db)
     {
         connection.Close();
     }
+}
+
+void EnsurePatientsTable(ChatDbContext db)
+{
+    var connection = db.Database.GetDbConnection();
+    connection.Open();
+    try
+    {
+        if (TableExists(connection, "Patients"))
+        {
+            return;
+        }
+
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = @"CREATE TABLE Patients (
+            Id TEXT NOT NULL PRIMARY KEY,
+            Colors TEXT NOT NULL DEFAULT '',
+            Title TEXT NOT NULL DEFAULT '',
+            LastName TEXT NOT NULL DEFAULT '',
+            FirstName TEXT NOT NULL DEFAULT '',
+            Exams TEXT NOT NULL DEFAULT '',
+            Eye TEXT NOT NULL DEFAULT '',
+            Annotation TEXT NOT NULL DEFAULT '',
+            Position TEXT NOT NULL DEFAULT '',
+            HoldTime TEXT NOT NULL,
+            PickUpTime TEXT NULL,
+            TimeOrder TEXT NOT NULL,
+            Examinator TEXT NOT NULL DEFAULT '',
+            OperatorName TEXT NOT NULL DEFAULT '',
+            IsTaken INTEGER NOT NULL DEFAULT 0,
+            IsArchived INTEGER NOT NULL DEFAULT 0
+        )";
+        cmd.ExecuteNonQuery();
+    }
+    finally
+    {
+        connection.Close();
+    }
+}
+
+bool TableExists(System.Data.Common.DbConnection connection, string tableName)
+{
+    using var cmd = connection.CreateCommand();
+    cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name=$name";
+    var parameter = cmd.CreateParameter();
+    parameter.ParameterName = "$name";
+    parameter.Value = tableName;
+    cmd.Parameters.Add(parameter);
+    var result = cmd.ExecuteScalar();
+    return result != null;
 }
 
 void EnsureIsDeletedColumn(ChatDbContext db)


### PR DESCRIPTION
## Summary
- ensure the Patients table is created if it does not already exist
- guard the archived column migration so it only runs when the table exists

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d7f9c611f483248b65b5ee7995f1ab