### PR TITLE
Add centralized logging for unhandled exceptions

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -25,6 +25,10 @@ namespace Client
         {
             this.InitializeComponent();
 
+            this.UnhandledException += App_UnhandledException;
+            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+            TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
+
             AppSettings.SettingsChanged += async () =>
             {
                 try
@@ -328,5 +332,60 @@ namespace Client
         }
 
         private Window? m_window;
+
+        private void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
+        {
+            if (e.Exception is Exception ex)
+            {
+                Logger.LogException("Unhandled UI exception", ex);
+            }
+            else
+            {
+                Logger.Log("Unhandled UI exception without an Exception instance.");
+            }
+
+            e.Handled = true;
+
+            if (MainWindow is MainWindow window && window.Content is FrameworkElement root)
+            {
+                window.DispatcherQueue.TryEnqueue(async () =>
+                {
+                    try
+                    {
+                        var dialog = new ContentDialog
+                        {
+                            Title = "Erreur inattendue",
+                            Content = "Une erreur est survenue. Un journal a été enregistré dans les données locales.",
+                            CloseButtonText = "Fermer",
+                            XamlRoot = root.XamlRoot
+                        };
+
+                        await dialog.ShowAsync();
+                    }
+                    catch
+                    {
+                        // Ignore dialog errors – the dispatcher may not be available during shutdown.
+                    }
+                });
+            }
+        }
+
+        private void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            if (e.ExceptionObject is Exception ex)
+            {
+                Logger.LogException("AppDomain unhandled exception", ex);
+            }
+            else
+            {
+                Logger.Log($"AppDomain unhandled exception object: {e.ExceptionObject}");
+            }
+        }
+
+        private void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+        {
+            Logger.LogException("Unobserved task exception", e.Exception);
+            e.SetObserved();
+        }
     }
 }

--- a/Client/Helpers/Logger.cs
+++ b/Client/Helpers/Logger.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace Client.Helpers
+{
+    public static class Logger
+    {
+        private static readonly object _sync = new();
+        private static readonly string _logPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "EyeChat",
+            "app.log");
+
+        public static void Log(string message)
+        {
+            try
+            {
+                var line = $"[{DateTime.Now:O}] {message}{Environment.NewLine}";
+                lock (_sync)
+                {
+                    var directory = Path.GetDirectoryName(_logPath);
+                    if (!string.IsNullOrEmpty(directory))
+                    {
+                        Directory.CreateDirectory(directory);
+                    }
+
+                    File.AppendAllText(_logPath, line, Encoding.UTF8);
+                }
+            }
+            catch
+            {
+                // Ignore logging failures – the goal is to avoid crashing the app when we cannot log.
+            }
+        }
+
+        public static void LogException(string context, Exception exception)
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine(context);
+            builder.AppendLine(exception.ToString());
+            Log(builder.ToString());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a lightweight logger helper that writes diagnostic information to the local EyeChat data folder
- register UI, AppDomain, and TaskScheduler unhandled exception hooks to capture crashes and notify the user with a dialog

## Testing
- Not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d804eb381c8324a82171b2d2bc09f6