### PR TITLE
Ensure chat window and call prompts appear in foreground

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -194,7 +194,7 @@ namespace Client
                 mw.DispatcherQueue.TryEnqueue(() =>
                 {
                     mw.ShowChatPage();
-                    mw.SetTopMost(true, false);
+                    mw.BringToForeground();
                     mw.ScrollMessagesToEnd();
                 });
             }

--- a/Client/MainWindow.xaml.cs
+++ b/Client/MainWindow.xaml.cs
@@ -99,6 +99,19 @@ namespace Client
             IsTopMost = topMost;
         }
 
+        public void BringToForeground()
+        {
+            if (IsTopMost)
+            {
+                SetTopMost(true, true);
+            }
+            else
+            {
+                SetTopMost(true, true);
+                SetTopMost(false, false);
+            }
+        }
+
         public void ScrollMessagesToEnd()
         {
             if (contentFrame.Content is Pages.ChatPage chat)

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -846,9 +846,15 @@ namespace Client.Pages
 
         private async Task Service_OnCallReceived(string caller, string room)
         {
-            if (App.MainWindow is Window mainWindow)
+            bool resetTopMost = false;
+            if (App.MainWindow is MainWindow mainWindow)
             {
-                WindowHelper.SetTopMost(mainWindow, true, true);
+                mainWindow.BringToForeground();
+            }
+            else if (App.MainWindow is Window genericWindow)
+            {
+                WindowHelper.SetTopMost(genericWindow, true, true);
+                resetTopMost = true;
             }
 
             var dialog = new ContentDialog
@@ -864,7 +870,7 @@ namespace Client.Pages
 
             var result = await dialog.ShowAsync();
 
-            if (App.MainWindow is Window window)
+            if (resetTopMost && App.MainWindow is Window window)
             {
                 WindowHelper.SetTopMost(window, false, false);
             }


### PR DESCRIPTION
## Summary
- add a MainWindow helper that temporarily toggles the top-most state to bring the window to the foreground
- use the new helper when incoming chat messages arrive so the conversation is surfaced immediately
- reuse the foreground helper for the “Tu peut venir” call prompt while preserving any existing top-most preference

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d80fd1fcc08324b2ad647070738135