### PR TITLE
Ensure chat window restores on calls and auto-selects incoming sender

### DIFF
--- a/Client/Helpers/WindowHelper.cs
+++ b/Client/Helpers/WindowHelper.cs
@@ -10,6 +10,7 @@ namespace Client.Helpers
         private const uint SWP_NOSIZE = 0x0001;
         private const uint SWP_NOMOVE = 0x0002;
         private const uint SWP_NOACTIVATE = 0x0010;
+        private const int SW_RESTORE = 9;
         private static readonly IntPtr HWND_TOPMOST = new(-1);
         private static readonly IntPtr HWND_NOTOPMOST = new(-2);
 
@@ -20,12 +21,33 @@ namespace Client.Helpers
         [DllImport("user32.dll")]
         private static extern IntPtr GetForegroundWindow();
 
+        [DllImport("user32.dll")]
+        private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool IsIconic(IntPtr hWnd);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool SetForegroundWindow(IntPtr hWnd);
+
         public static void SetTopMost(Window window, bool topMost, bool activate)
         {
             var hwnd = WindowNative.GetWindowHandle(window);
+            if (activate && IsIconic(hwnd))
+            {
+                ShowWindow(hwnd, SW_RESTORE);
+            }
+
             uint flags = SWP_NOMOVE | SWP_NOSIZE | (activate ? 0u : SWP_NOACTIVATE);
             SetWindowPos(hwnd, topMost ? HWND_TOPMOST : HWND_NOTOPMOST,
                 0, 0, 0, 0, flags);
+
+            if (activate)
+            {
+                SetForegroundWindow(hwnd);
+            }
         }
 
         public static bool IsForeground(Window window)

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -193,10 +193,37 @@ namespace Client.Pages
                 if (!existing)
                 {
                     Messages.Add(chat);
+                    AutoSelectConversationForIncomingMessage(chat);
                     ScrollToLastMessage();
                     await _service.SaveTodayMessagesToDiskAsync();
                 }
             });
+        }
+
+        private void AutoSelectConversationForIncomingMessage(ChatMessageModel message)
+        {
+            if (UsersList == null)
+                return;
+
+            var me = App.UserName;
+            if (message.Sender == me)
+                return;
+
+            UserInfo? target = null;
+
+            if (message.Destinataire == "A Tous")
+            {
+                target = ConnectedUsers.FirstOrDefault(u => u.Username == "A Tous");
+            }
+            else if (message.Destinataire == me)
+            {
+                target = ConnectedUsers.FirstOrDefault(u => u.Username == message.Sender);
+            }
+
+            if (target != null && !Equals(UsersList.SelectedItem, target))
+            {
+                UsersList.SelectedItem = target;
+            }
         }
 
         private void Messages_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
## Summary
- restore minimized windows before toggling top-most and push the window to the foreground
- auto-select the relevant conversation when a new message for you or everyone arrives

## Testing
- dotnet build *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8cade9258832494bae6dcd05e9dda