### PR TITLE
Add menu action to clear local backups with progress feedback

### DIFF
--- a/Client/MainWindow.xaml
+++ b/Client/MainWindow.xaml
@@ -86,6 +86,22 @@
                 <NavigationViewItem Content="Chat" Tag="ChatPage" Icon="LeaveChat" />
                 <NavigationViewItem Content="Historique" Tag="HistoryPage" Icon="People" />
             </NavigationView.MenuItems>
+            <NavigationView.PaneFooter>
+                <StackPanel Margin="12" Spacing="8">
+                    <Button x:Name="ClearBackupsButton"
+                            Content="Effacer les sauvegardes"
+                            HorizontalAlignment="Stretch"
+                            Click="ClearBackups_Click" />
+                    <ProgressBar x:Name="ClearBackupsProgress"
+                                 Visibility="Collapsed"
+                                 Height="4"
+                                 Minimum="0"
+                                 IsIndeterminate="True" />
+                    <TextBlock x:Name="ClearBackupsStatusText"
+                               TextWrapping="Wrap"
+                               Visibility="Collapsed" />
+                </StackPanel>
+            </NavigationView.PaneFooter>
             <Frame x:Name="contentFrame" Padding="-2" />
         </NavigationView>
     </Grid>

--- a/Client/MainWindow.xaml.cs
+++ b/Client/MainWindow.xaml.cs
@@ -3,6 +3,9 @@ using Microsoft.UI.Xaml.Controls;
 using System;
 using System.Linq;
 using System.IO;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.UI.Windowing;
 using WinRT.Interop;
 using Windows.UI;
@@ -17,6 +20,7 @@ namespace Client
     {
         public bool IsTopMost { get; private set; }
         private readonly AppWindow _appWindow;
+        private bool _isClearingBackups;
 
         public bool IsChatPageActive => contentFrame.CurrentSourcePageType == typeof(Pages.ChatPage);
 
@@ -112,11 +116,140 @@ namespace Client
             }
         }
 
+        private static string FormatBytes(long bytes)
+        {
+            string[] units = new[] { "octets", "Ko", "Mo", "Go", "To" };
+            double size = bytes;
+            var unitIndex = 0;
+            while (size >= 1024 && unitIndex < units.Length - 1)
+            {
+                size /= 1024;
+                unitIndex++;
+            }
+
+            return unitIndex == 0
+                ? $"{bytes} {units[unitIndex]}"
+                : $"{size:0.##} {units[unitIndex]}";
+        }
+
         public void ScrollMessagesToEnd()
         {
             if (contentFrame.Content is Pages.ChatPage chat)
             {
                 chat.ScrollToLastMessage();
+            }
+        }
+
+        private async void ClearBackups_Click(object sender, RoutedEventArgs e)
+        {
+            if (_isClearingBackups)
+                return;
+
+            _isClearingBackups = true;
+            ClearBackupsButton.IsEnabled = false;
+
+            ClearBackupsStatusText.Visibility = Visibility.Visible;
+            ClearBackupsStatusText.Text = "Analyse des sauvegardes...";
+            ClearBackupsProgress.Visibility = Visibility.Visible;
+            ClearBackupsProgress.IsIndeterminate = true;
+
+            try
+            {
+                var appFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat");
+                var backups = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                if (Directory.Exists(appFolder))
+                {
+                    var patterns = new[] { "*.bak", "*.bak*", "*.backup", "*.backup*" };
+                    foreach (var pattern in patterns)
+                    {
+                        try
+                        {
+                            foreach (var file in Directory.EnumerateFiles(appFolder, pattern, SearchOption.AllDirectories))
+                            {
+                                backups.Add(file);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.LogException($"Erreur lors de l'énumération des fichiers de sauvegarde ({pattern})", ex);
+                        }
+                    }
+                }
+
+                if (backups.Count == 0)
+                {
+                    ClearBackupsProgress.IsIndeterminate = false;
+                    ClearBackupsProgress.Visibility = Visibility.Collapsed;
+                    ClearBackupsStatusText.Text = "Aucune sauvegarde à supprimer.";
+                    return;
+                }
+
+                ClearBackupsProgress.IsIndeterminate = false;
+                ClearBackupsProgress.Minimum = 0;
+                ClearBackupsProgress.Maximum = backups.Count;
+                ClearBackupsProgress.Value = 0;
+
+                var dispatcher = DispatcherQueue;
+                int processed = 0;
+                int deleted = 0;
+                int failed = 0;
+                long freedBytes = 0;
+
+                await Task.Run(() =>
+                {
+                    foreach (var file in backups)
+                    {
+                        try
+                        {
+                            var info = new FileInfo(file);
+                            var length = info.Exists ? info.Length : 0;
+                            File.Delete(file);
+                            Interlocked.Add(ref freedBytes, length);
+                            Interlocked.Increment(ref deleted);
+                        }
+                        catch (Exception ex)
+                        {
+                            Interlocked.Increment(ref failed);
+                            Logger.LogException($"Erreur lors de la suppression de la sauvegarde '{file}'", ex);
+                        }
+
+                        var current = Interlocked.Increment(ref processed);
+                        dispatcher.TryEnqueue(() =>
+                        {
+                            ClearBackupsProgress.Value = current;
+                            ClearBackupsStatusText.Text = $"Suppression des sauvegardes... {current}/{backups.Count}";
+                        });
+                    }
+                });
+
+                ClearBackupsProgress.Visibility = Visibility.Collapsed;
+
+                var summary = $"Suppression terminée. {deleted} fichier(s) supprimé(s)";
+                if (freedBytes > 0)
+                {
+                    summary += $" ({FormatBytes(freedBytes)} libérés)";
+                }
+                summary += ".";
+
+                if (failed > 0)
+                {
+                    summary += $" {failed} fichier(s) n'ont pas pu être supprimés.";
+                }
+
+                ClearBackupsStatusText.Text = summary;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("Erreur inattendue lors du nettoyage des sauvegardes", ex);
+                ClearBackupsStatusText.Text = $"Erreur : {ex.Message}";
+            }
+            finally
+            {
+                ClearBackupsButton.IsEnabled = true;
+                ClearBackupsProgress.IsIndeterminate = false;
+                ClearBackupsProgress.Visibility = Visibility.Collapsed;
+                _isClearingBackups = false;
             }
         }
 


### PR DESCRIPTION
## Summary
- add a footer button in the navigation menu to trigger deletion of local backup files
- show progress and status updates while removing *.bak and *.backup files and log failures
- compute freed disk space and prevent concurrent cleanup requests during the operation

## Testing
- `dotnet build WebApplication1.sln` *(fails: dotnet CLI not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb97a33dc832492046b99d5076219