### PR TITLE
Ensure new clients sync shared configuration on connect

### DIFF
--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -173,6 +173,7 @@ namespace Client.Services
                 foreach (var u in finalList)
                     ConnectedUsers.Add(u);
                 UpdateSpecialUsers();
+                await SaveUsersToDiskAsync();
             }
 
             Messages.Clear();
@@ -200,6 +201,8 @@ namespace Client.Services
             Patients.Clear();
             foreach (var p in patients)
                 Patients.Add(p);
+
+            await SyncServerConfigurationAsync();
         }
 
         public async Task ConnectAsync(string username, string avatar, string room, string color)
@@ -485,6 +488,27 @@ namespace Client.Services
 
             _isConnecting = false;
 
+        }
+
+        private async Task SyncServerConfigurationAsync()
+        {
+            var examOptions = await GetExamOptionsAsync();
+            if (examOptions.Any())
+            {
+                var ordered = examOptions
+                    .OrderBy(o => o.Index)
+                    .ToList();
+                ExamOption.Save(new ObservableCollection<ExamOption>(ordered));
+                Dispatcher?.TryEnqueue(() => ExamOptionsUpdated?.Invoke(ordered));
+            }
+
+            var rooms = await GetRoomsAsync();
+            if (rooms.Any())
+            {
+                var roomList = rooms.ToList();
+                RoomList.Save(new ObservableCollection<string>(roomList));
+                Dispatcher?.TryEnqueue(() => RoomsUpdated?.Invoke(roomList));
+            }
         }
 
         public async Task SendMessage(string sender, string roomname, string destinataire, string message, string avatar, DateTime timemessage)


### PR DESCRIPTION
## Summary
- persist the retrieved user list when rebuilding the roster after connecting to the hub
- automatically download the latest exam options and rooms from the server as soon as the client connects
- notify listeners and save the synchronized configuration locally for subsequent sessions

## Testing
- dotnet build WebApplication1.sln *(fails: `dotnet` command not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0cda344a48324908328cd1e456470