### PR TITLE
Add context menu action to put patient on hold

### DIFF
--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -232,6 +232,7 @@
                 <Border.ContextFlyout>
                     <MenuFlyout>
                         <MenuFlyoutItem Text="{x:Bind ToggleExamLabel}" Tag="{x:Bind}" Click="TogglePatientTaken_Click" />
+                        <MenuFlyoutItem Text="Mettre en attente" Tag="{x:Bind}" Click="SetPatientOnHold_Click" />
                         <MenuFlyoutItem Text="Infos" Tag="{x:Bind}" Click="InfoPatient_Click" />
                         <MenuFlyoutItem Text="Modifier" Tag="{x:Bind}" Click="EditPatient_Click" />
                         <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
@@ -283,9 +284,10 @@
                 <Border.ContextFlyout>
                     <MenuFlyout>
                         <MenuFlyoutItem Text="{x:Bind ToggleExamLabel}" Tag="{x:Bind}" Click="TogglePatientTaken_Click" />
+                        <MenuFlyoutItem Text="Mettre en attente" Tag="{x:Bind}" Click="SetPatientOnHold_Click" />
                         <MenuFlyoutItem Text="Infos" Tag="{x:Bind}" Click="InfoPatient_Click" />
                         <MenuFlyoutItem Text="Modifier" Tag="{x:Bind}" Click="EditPatient_Click" />
-                    <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
+                        <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
                     
                 </MenuFlyout>
                 </Border.ContextFlyout>

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -839,6 +839,25 @@ namespace Client.Pages
             }
         }
 
+        private async void SetPatientOnHold_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as MenuFlyoutItem)?.Tag is not Patient patient)
+                return;
+
+            var oldExam = patient.Exams?.Trim() ?? string.Empty;
+            if (string.Equals(oldExam, "AT", StringComparison.OrdinalIgnoreCase))
+                return;
+
+            patient.Exams = "AT";
+            if (!string.IsNullOrWhiteSpace(oldExam))
+            {
+                patient.Annotation = $"{oldExam} FAIT";
+            }
+
+            UpdatePatientViews();
+            await _service.UpdatePatientAsync(patient);
+        }
+
         private async void MovePatientFirst_Click(object sender, RoutedEventArgs e)
         {
             if ((sender as MenuFlyoutItem)?.Tag is Patient patient)


### PR DESCRIPTION
## Summary
- add a "Mettre en attente" option to the patient context menu for both waiting and taken templates
- update the handler to switch the exam to AT and store the previous exam followed by "FAIT" in the comment before syncing with the server

## Testing
- not run (dotnet CLI is not available in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0e5cb99288324944f68b564ba97a0