### PR TITLE
Add duplication and reordering controls for exams

### DIFF
--- a/Client/Pages/ExamRoomPage.xaml
+++ b/Client/Pages/ExamRoomPage.xaml
@@ -22,14 +22,14 @@
                     <ColumnDefinition Width="150" />
                     <ColumnDefinition Width="200" />
                     <ColumnDefinition Width="200" />
-                    <ColumnDefinition Width="80" />
+                    <ColumnDefinition Width="220" />
                 </Grid.ColumnDefinitions>
                 <TextBlock Text="Nom" Grid.Column="0" TextAlignment="Center"/>
                 <TextBlock Text="Couleur" Grid.Column="1" TextAlignment="Center"/>
                 <TextBlock Text="Code clavier" Grid.Column="2" TextAlignment="Center"/>
                 <TextBlock Text="Annotation" Grid.Column="3" TextAlignment="Center"/>
                 <TextBlock Text="Salle" Grid.Column="4" TextAlignment="Center"/>
-                <TextBlock Text="" Grid.Column="5" />
+                <TextBlock Text="Actions" Grid.Column="5" TextAlignment="Center"/>
             </Grid>
 
             <ListView x:Name="OptionsList" ItemsSource="{x:Bind Options}" SelectionMode="None">
@@ -43,7 +43,7 @@
                                     <ColumnDefinition Width="150" />
                                     <ColumnDefinition Width="200" />
                                     <ColumnDefinition Width="200" />
-                                    <ColumnDefinition Width="100" />
+                                    <ColumnDefinition Width="220" />
                                 </Grid.ColumnDefinitions>
                                 <TextBox Text="{x:Bind Name, Mode=TwoWay}" Grid.Column="0"/>
                                 <Grid Grid.Column="1">
@@ -66,7 +66,16 @@
                                 <ComboBox Grid.Column="4" Width="200"
                                           ItemsSource="{Binding Rooms, ElementName=PageRoot}"
                                           SelectedItem="{x:Bind Floor, Mode=TwoWay}"/>
-                                <Button Grid.Column="5" Content="Supprimer" Click="DeleteExam_Click" />
+                                <StackPanel Grid.Column="5" Orientation="Horizontal" Spacing="5" HorizontalAlignment="Center">
+                                    <Button Content="Dupliquer" Click="DuplicateExam_Click"/>
+                                    <Button Click="MoveExamUp_Click" ToolTipService.ToolTip="Monter">
+                                        <SymbolIcon Symbol="Up"/>
+                                    </Button>
+                                    <Button Click="MoveExamDown_Click" ToolTipService.ToolTip="Descendre">
+                                        <SymbolIcon Symbol="Down"/>
+                                    </Button>
+                                    <Button Content="Supprimer" Click="DeleteExam_Click" />
+                                </StackPanel>
                             </Grid>
                         </Border>
                     </DataTemplate>

--- a/Client/Pages/ExamRoomPage.xaml.cs
+++ b/Client/Pages/ExamRoomPage.xaml.cs
@@ -13,6 +13,7 @@ using System.IO;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using Client.Helpers;
+using System.Text.RegularExpressions;
 
 namespace Client.Pages
 {
@@ -47,6 +48,76 @@ namespace Client.Pages
             if (sender is Button btn && btn.DataContext is ExamOption opt)
             {
                 Options.Remove(opt);
+            }
+        }
+
+        private void DuplicateExam_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button btn && btn.DataContext is ExamOption opt)
+            {
+                var duplicate = new ExamOption
+                {
+                    Color = opt.Color,
+                    Name = GenerateDuplicateName(opt.Name),
+                    CodeMSG = opt.CodeMSG,
+                    Annotation = opt.Annotation,
+                    Floor = opt.Floor
+                };
+
+                var index = Options.IndexOf(opt);
+                if (index >= 0)
+                {
+                    Options.Insert(index + 1, duplicate);
+                }
+                else
+                {
+                    Options.Add(duplicate);
+                }
+            }
+        }
+
+        private string GenerateDuplicateName(string originalName)
+        {
+            var baseName = originalName.Trim();
+            var match = Regex.Match(baseName, @"^(.*)\s\((\d+)\)$");
+            if (match.Success)
+            {
+                baseName = match.Groups[1].Value;
+            }
+
+            var counter = 1;
+            string candidate;
+            do
+            {
+                candidate = $"{baseName} ({counter})";
+                counter++;
+            }
+            while (Options.Any(o => string.Equals(o.Name, candidate, StringComparison.OrdinalIgnoreCase)));
+
+            return candidate;
+        }
+
+        private void MoveExamUp_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button btn && btn.DataContext is ExamOption opt)
+            {
+                var index = Options.IndexOf(opt);
+                if (index > 0)
+                {
+                    Options.Move(index, index - 1);
+                }
+            }
+        }
+
+        private void MoveExamDown_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button btn && btn.DataContext is ExamOption opt)
+            {
+                var index = Options.IndexOf(opt);
+                if (index >= 0 && index < Options.Count - 1)
+                {
+                    Options.Move(index, index + 1);
+                }
             }
         }
         private void Add_Click(object sender, RoutedEventArgs e)
@@ -138,11 +209,32 @@ namespace Client.Pages
 
         private void Options_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
+            if (e.Action == NotifyCollectionChangedAction.Reset)
+            {
+                foreach (var option in Options)
+                    option.PropertyChanged += Option_PropertyChanged;
+            }
+            else
+            {
+                if (e.OldItems != null)
+                {
+                    foreach (ExamOption item in e.OldItems)
+                        item.PropertyChanged -= Option_PropertyChanged;
+                }
+
+                if (e.NewItems != null)
+                {
+                    foreach (ExamOption item in e.NewItems)
+                        item.PropertyChanged += Option_PropertyChanged;
+                }
+            }
+
             if (_syncing) return;
             int index = 1;
             foreach (var opt in Options)
                 opt.Index = index++;
 
+            _hasChanges = true;
             ExamOption.Save(Options);
         }
 


### PR DESCRIPTION
## Summary
- add action buttons to duplicate, reorder, and delete exams directly from the list
- generate unique names for duplicated exams while preserving other settings
- keep option change tracking up to date when items are added, removed, or reordered

## Testing
- Not run (dotnet CLI not available in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0eaa7f47c8324bed2572e2a09eba1