### PR TITLE
Fix down arrow icon for exam navigation

### DIFF
--- a/Client/Pages/ExamRoomPage.xaml
+++ b/Client/Pages/ExamRoomPage.xaml
@@ -69,10 +69,10 @@
                                 <StackPanel Grid.Column="5" Orientation="Horizontal" Spacing="5" HorizontalAlignment="Center">
                                     <Button Content="Dupliquer" Click="DuplicateExam_Click"/>
                                     <Button Click="MoveExamUp_Click" ToolTipService.ToolTip="Monter">
-                                        <SymbolIcon Symbol="Up"/>
+                                        <FontIcon FontFamily="Segoe UI Symbol" Glyph="↑" />
                                     </Button>
                                     <Button Click="MoveExamDown_Click" ToolTipService.ToolTip="Descendre">
-                                        <SymbolIcon Symbol="Down"/>
+                                        <FontIcon FontFamily="Segoe UI Symbol" Glyph="↓" />
                                     </Button>
                                     <Button Content="Supprimer" Click="DeleteExam_Click" />
                                 </StackPanel>


### PR DESCRIPTION
## Summary
- replace the invalid SymbolIcon with FontIcon glyphs for the exam ordering buttons
- update the up-arrow button to use the same glyph-based icon for visual consistency

## Testing
- dotnet build Client/Client.csproj *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ebbfbe1483249cc5678f6b6fec59