### PR TITLE
Add local exam export/import and final annotation column

### DIFF
--- a/Client/Models/ExamOption.cs
+++ b/Client/Models/ExamOption.cs
@@ -13,6 +13,7 @@ namespace Client.Models
         private string _color = string.Empty;
         private string _codeMSG = string.Empty;
         private string _annotation = string.Empty;
+        private string _endAnnotation = string.Empty;
         private string _floor = string.Empty;
 
         public int Index
@@ -82,6 +83,19 @@ namespace Client.Models
                 {
                     _annotation = value;
                     OnPropertyChanged(nameof(Annotation));
+                }
+            }
+        }
+
+        public string EndAnnotation
+        {
+            get => _endAnnotation;
+            set
+            {
+                if (_endAnnotation != value)
+                {
+                    _endAnnotation = value;
+                    OnPropertyChanged(nameof(EndAnnotation));
                 }
             }
         }

--- a/Client/Pages/ExamRoomPage.xaml
+++ b/Client/Pages/ExamRoomPage.xaml
@@ -22,14 +22,16 @@
                     <ColumnDefinition Width="150" />
                     <ColumnDefinition Width="200" />
                     <ColumnDefinition Width="200" />
-                    <ColumnDefinition Width="220" />
+                    <ColumnDefinition Width="200" />
+                    <ColumnDefinition Width="280" />
                 </Grid.ColumnDefinitions>
                 <TextBlock Text="Nom" Grid.Column="0" TextAlignment="Center"/>
                 <TextBlock Text="Couleur" Grid.Column="1" TextAlignment="Center"/>
                 <TextBlock Text="Code clavier" Grid.Column="2" TextAlignment="Center"/>
                 <TextBlock Text="Annotation" Grid.Column="3" TextAlignment="Center"/>
-                <TextBlock Text="Salle" Grid.Column="4" TextAlignment="Center"/>
-                <TextBlock Text="Actions" Grid.Column="5" TextAlignment="Center"/>
+                <TextBlock Text="Annotation de fin" Grid.Column="4" TextAlignment="Center"/>
+                <TextBlock Text="Salle" Grid.Column="5" TextAlignment="Center"/>
+                <TextBlock Text="Actions" Grid.Column="6" TextAlignment="Center"/>
             </Grid>
 
             <ListView x:Name="OptionsList" ItemsSource="{x:Bind Options}" SelectionMode="None">
@@ -43,7 +45,8 @@
                                     <ColumnDefinition Width="150" />
                                     <ColumnDefinition Width="200" />
                                     <ColumnDefinition Width="200" />
-                                    <ColumnDefinition Width="220" />
+                                    <ColumnDefinition Width="200" />
+                                    <ColumnDefinition Width="280" />
                                 </Grid.ColumnDefinitions>
                                 <TextBox Text="{x:Bind Name, Mode=TwoWay}" Grid.Column="0"/>
                                 <Grid Grid.Column="1">
@@ -63,10 +66,11 @@
 
                                 <TextBox Text="{x:Bind CodeMSG, Mode=TwoWay}" Grid.Column="2"/>
                                 <TextBox Text="{x:Bind Annotation, Mode=TwoWay}" Grid.Column="3"/>
-                                <ComboBox Grid.Column="4" Width="200"
+                                <TextBox Text="{x:Bind EndAnnotation, Mode=TwoWay}" Grid.Column="4"/>
+                                <ComboBox Grid.Column="5" Width="200"
                                           ItemsSource="{Binding Rooms, ElementName=PageRoot}"
                                           SelectedItem="{x:Bind Floor, Mode=TwoWay}"/>
-                                <StackPanel Grid.Column="5" Orientation="Horizontal" Spacing="5" HorizontalAlignment="Center">
+                                <StackPanel Grid.Column="6" Orientation="Horizontal" Spacing="5" HorizontalAlignment="Center">
                                     <Button Content="Dupliquer" Click="DuplicateExam_Click"/>
                                     <Button Click="MoveExamUp_Click" ToolTipService.ToolTip="Monter">
                                         <FontIcon FontFamily="Segoe UI Symbol" Glyph="↑" />
@@ -101,6 +105,10 @@
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>
+            <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,10,0,0">
+                <Button Content="Exporter" Click="Export_Click" />
+                <Button Content="Importer" Click="Import_Click" />
+            </StackPanel>
             <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,10,0,0">
                 <Button Content="Charger depuis serveur" Click="LoadServer_Click" />
                 <Button Content="Envoyer au serveur" Click="SendServer_Click" />

--- a/Client/Pages/ExamRoomPage.xaml.cs
+++ b/Client/Pages/ExamRoomPage.xaml.cs
@@ -14,6 +14,10 @@ using Newtonsoft.Json;
 using System.Collections.Generic;
 using Client.Helpers;
 using System.Text.RegularExpressions;
+using Windows.Storage;
+using Windows.Storage.Pickers;
+using Windows.Storage.Provider;
+using WinRT.Interop;
 
 namespace Client.Pages
 {
@@ -61,6 +65,7 @@ namespace Client.Pages
                     Name = GenerateDuplicateName(opt.Name),
                     CodeMSG = opt.CodeMSG,
                     Annotation = opt.Annotation,
+                    EndAnnotation = opt.EndAnnotation,
                     Floor = opt.Floor
                 };
 
@@ -129,6 +134,7 @@ namespace Client.Pages
                 Name = "Nouvel examen",
                 CodeMSG = "examen",
                 Annotation = string.Empty,
+                EndAnnotation = string.Empty,
                 Floor = "tes"
 
 
@@ -166,6 +172,102 @@ namespace Client.Pages
         private async void SendServer_Click(object sender, RoutedEventArgs e)
         {
             await SendConfigToServerAsync();
+        }
+
+        private async void Export_Click(object sender, RoutedEventArgs e)
+        {
+            var picker = new FileSavePicker();
+            picker.FileTypeChoices.Add("Configuration EyeChat", new List<string> { ".eyechatconfig" });
+            picker.SuggestedFileName = $"EyeChatConfig_{DateTime.Now:yyyyMMdd_HHmm}";
+            var hwnd = WindowNative.GetWindowHandle(App.MainWindow);
+            InitializeWithWindow.Initialize(picker, hwnd);
+
+            var file = await picker.PickSaveFileAsync();
+            if (file == null)
+                return;
+
+            try
+            {
+                var configuration = new ExamRoomConfiguration
+                {
+                    Exams = Options.ToList(),
+                    Rooms = Rooms.ToList()
+                };
+
+                var json = JsonConvert.SerializeObject(configuration, Formatting.Indented);
+                CachedFileManager.DeferUpdates(file);
+                await FileIO.WriteTextAsync(file, json);
+                await CachedFileManager.CompleteUpdatesAsync(file);
+            }
+            catch (Exception ex)
+            {
+                await ShowMessageAsync("Erreur d'export", $"Impossible d'enregistrer la configuration : {ex.Message}");
+            }
+        }
+
+        private async void Import_Click(object sender, RoutedEventArgs e)
+        {
+            var picker = new FileOpenPicker();
+            picker.FileTypeFilter.Add(".eyechatconfig");
+            var hwnd = WindowNative.GetWindowHandle(App.MainWindow);
+            InitializeWithWindow.Initialize(picker, hwnd);
+
+            var file = await picker.PickSingleFileAsync();
+            if (file == null)
+                return;
+
+            try
+            {
+                var json = await FileIO.ReadTextAsync(file);
+                var configuration = JsonConvert.DeserializeObject<ExamRoomConfiguration>(json);
+                if (configuration == null)
+                {
+                    await ShowMessageAsync("Import invalide", "Le fichier sélectionné est vide ou invalide.");
+                    return;
+                }
+
+                _syncing = true;
+
+                BackupFile(ExamOption.FilePath);
+                Options.CollectionChanged -= Options_CollectionChanged;
+                foreach (var option in Options)
+                    option.PropertyChanged -= Option_PropertyChanged;
+                Options.Clear();
+                if (configuration.Exams != null)
+                {
+                    foreach (var opt in configuration.Exams.OrderBy(o => o.Index))
+                    {
+                        Options.Add(opt);
+                        opt.PropertyChanged += Option_PropertyChanged;
+                    }
+                }
+                int index = 1;
+                foreach (var opt in Options)
+                    opt.Index = index++;
+                Options.CollectionChanged += Options_CollectionChanged;
+                ExamOption.Save(Options);
+
+                BackupFile(RoomList.FilePath);
+                Rooms.CollectionChanged -= Rooms_CollectionChanged;
+                Rooms.Clear();
+                if (configuration.Rooms != null)
+                {
+                    foreach (var room in configuration.Rooms)
+                        Rooms.Add(room);
+                }
+                Rooms.CollectionChanged += Rooms_CollectionChanged;
+                RoomList.Save(Rooms);
+
+                _hasChanges = false;
+            }
+            catch (Exception ex)
+            {
+                await ShowMessageAsync("Erreur d'import", $"Impossible de charger la configuration : {ex.Message}");
+            }
+            finally
+            {
+                _syncing = false;
+            }
         }
         private async Task TrySendExamOptionsAsync()
         {
@@ -336,6 +438,23 @@ namespace Client.Pages
             }
         }
 
+        private async Task ShowMessageAsync(string title, string message)
+        {
+            var dialog = new ContentDialog
+            {
+                Title = title,
+                Content = new TextBlock
+                {
+                    Text = message,
+                    TextWrapping = TextWrapping.Wrap
+                },
+                CloseButtonText = "OK",
+                XamlRoot = this.XamlRoot
+            };
+
+            await dialog.ShowAsync();
+        }
+
         private static bool AreExamOptionsEqual(IEnumerable<ExamOption> a, IEnumerable<ExamOption> b)
         {
             var ja = JsonConvert.SerializeObject(a);
@@ -366,6 +485,12 @@ namespace Client.Pages
                 }
             }
         }
+    }
+
+    internal class ExamRoomConfiguration
+    {
+        public List<ExamOption>? Exams { get; set; }
+        public List<string>? Rooms { get; set; }
     }
 }
 


### PR DESCRIPTION
## Summary
- enlarge the exam list action column and introduce an "Annotation de fin" column
- persist the new end annotation field on exam options
- add import/export actions that read and write .eyechatconfig files for exams and rooms

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0ef0d4cd08324bc39880449b6839d