### PR TITLE
Add server support for end annotations in exam options

### DIFF
--- a/Serveur/Models/ExamOption.cs
+++ b/Serveur/Models/ExamOption.cs
@@ -8,6 +8,7 @@ namespace ChatServeur
         public string CodeMSG { get; set; } = string.Empty;
         public string ForegroundColor => ColorHelpers.GetForeground(Color);
         public string Annotation { get; set; } = string.Empty;
+        public string EndAnnotation { get; set; } = string.Empty;
         public string Floor { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
## Summary
- add the EndAnnotation field to the server-side exam option model so the value is preserved when syncing

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0f3f0bd5c83249dcf36d021f08dff