### PR TITLE
Ajoute une description aux examens personnalisés

### DIFF
--- a/Client/Models/ExamOption.cs
+++ b/Client/Models/ExamOption.cs
@@ -15,6 +15,7 @@ namespace Client.Models
         private string _annotation = string.Empty;
         private string _endAnnotation = string.Empty;
         private string _floor = string.Empty;
+        private string _description = string.Empty;
 
         public int Index
         {
@@ -34,10 +35,27 @@ namespace Client.Models
             get => _name;
             set
             {
-                if (_name != value)
+                var sanitized = value ?? string.Empty;
+                if (_name != sanitized)
                 {
-                    _name = value;
+                    _name = sanitized;
                     OnPropertyChanged(nameof(Name));
+                    OnPropertyChanged(nameof(DisplayLabel));
+                }
+            }
+        }
+
+        public string Description
+        {
+            get => _description;
+            set
+            {
+                var sanitized = value ?? string.Empty;
+                if (_description != sanitized)
+                {
+                    _description = sanitized;
+                    OnPropertyChanged(nameof(Description));
+                    OnPropertyChanged(nameof(DisplayLabel));
                 }
             }
         }
@@ -112,6 +130,9 @@ namespace Client.Models
                 }
             }
         }
+
+        [JsonIgnore]
+        public string DisplayLabel => string.IsNullOrWhiteSpace(Description) ? Name : Description;
 
         public event PropertyChangedEventHandler? PropertyChanged;
         private void OnPropertyChanged(string propertyName) =>

--- a/Client/Pages/ExamRoomPage.xaml
+++ b/Client/Pages/ExamRoomPage.xaml
@@ -18,6 +18,7 @@
             <Grid  Padding="5" ColumnSpacing="5" Margin="10,10,0,0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="200" />
+                    <ColumnDefinition Width="220" />
                     <ColumnDefinition Width="100" />
                     <ColumnDefinition Width="150" />
                     <ColumnDefinition Width="200" />
@@ -26,12 +27,13 @@
                     <ColumnDefinition Width="280" />
                 </Grid.ColumnDefinitions>
                 <TextBlock Text="Nom" Grid.Column="0" TextAlignment="Center"/>
-                <TextBlock Text="Couleur" Grid.Column="1" TextAlignment="Center"/>
-                <TextBlock Text="Code clavier" Grid.Column="2" TextAlignment="Center"/>
-                <TextBlock Text="Annotation" Grid.Column="3" TextAlignment="Center"/>
-                <TextBlock Text="Annotation de fin" Grid.Column="4" TextAlignment="Center"/>
-                <TextBlock Text="Salle" Grid.Column="5" TextAlignment="Center"/>
-                <TextBlock Text="Actions" Grid.Column="6" TextAlignment="Center"/>
+                <TextBlock Text="Description" Grid.Column="1" TextAlignment="Center"/>
+                <TextBlock Text="Couleur" Grid.Column="2" TextAlignment="Center"/>
+                <TextBlock Text="Code clavier" Grid.Column="3" TextAlignment="Center"/>
+                <TextBlock Text="Annotation" Grid.Column="4" TextAlignment="Center"/>
+                <TextBlock Text="Annotation de fin" Grid.Column="5" TextAlignment="Center"/>
+                <TextBlock Text="Salle" Grid.Column="6" TextAlignment="Center"/>
+                <TextBlock Text="Actions" Grid.Column="7" TextAlignment="Center"/>
             </Grid>
 
             <ListView x:Name="OptionsList" ItemsSource="{x:Bind Options}" SelectionMode="None">
@@ -41,6 +43,7 @@
                             <Grid Padding="5" ColumnSpacing="5">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="200" />
+                                    <ColumnDefinition Width="220" />
                                     <ColumnDefinition Width="100" />
                                     <ColumnDefinition Width="150" />
                                     <ColumnDefinition Width="200" />
@@ -49,7 +52,8 @@
                                     <ColumnDefinition Width="280" />
                                 </Grid.ColumnDefinitions>
                                 <TextBox Text="{x:Bind Name, Mode=TwoWay}" Grid.Column="0"/>
-                                <Grid Grid.Column="1">
+                                <TextBox Text="{x:Bind Description, Mode=TwoWay}" Grid.Column="1"/>
+                                <Grid Grid.Column="2">
                                     <Button HorizontalAlignment="Stretch">
                                         <Rectangle Width="32" Height="16"
                                                    Fill="{x:Bind Color, Mode=OneWay , Converter={StaticResource StringToColorConverter}}"
@@ -64,13 +68,13 @@
                                     </Button>
                                 </Grid>
 
-                                <TextBox Text="{x:Bind CodeMSG, Mode=TwoWay}" Grid.Column="2"/>
-                                <TextBox Text="{x:Bind Annotation, Mode=TwoWay}" Grid.Column="3"/>
-                                <TextBox Text="{x:Bind EndAnnotation, Mode=TwoWay}" Grid.Column="4"/>
-                                <ComboBox Grid.Column="5" Width="200"
+                                <TextBox Text="{x:Bind CodeMSG, Mode=TwoWay}" Grid.Column="3"/>
+                                <TextBox Text="{x:Bind Annotation, Mode=TwoWay}" Grid.Column="4"/>
+                                <TextBox Text="{x:Bind EndAnnotation, Mode=TwoWay}" Grid.Column="5"/>
+                                <ComboBox Grid.Column="6" Width="200"
                                           ItemsSource="{Binding Rooms, ElementName=PageRoot}"
                                           SelectedItem="{x:Bind Floor, Mode=TwoWay}"/>
-                                <StackPanel Grid.Column="6" Orientation="Horizontal" Spacing="5" HorizontalAlignment="Center">
+                                <StackPanel Grid.Column="7" Orientation="Horizontal" Spacing="5" HorizontalAlignment="Center">
                                     <Button Content="Dupliquer" Click="DuplicateExam_Click"/>
                                     <Button Click="MoveExamUp_Click" ToolTipService.ToolTip="Monter">
                                         <FontIcon FontFamily="Segoe UI Symbol" Glyph="↑" />

--- a/Client/Pages/ExamRoomPage.xaml.cs
+++ b/Client/Pages/ExamRoomPage.xaml.cs
@@ -63,6 +63,7 @@ namespace Client.Pages
                 {
                     Color = opt.Color,
                     Name = GenerateDuplicateName(opt.Name),
+                    Description = opt.Description,
                     CodeMSG = opt.CodeMSG,
                     Annotation = opt.Annotation,
                     EndAnnotation = opt.EndAnnotation,
@@ -132,6 +133,7 @@ namespace Client.Pages
                 Index = Options.Count + 1,
                 Color = "#FF0000", // Default color red
                 Name = "Nouvel examen",
+                Description = "Nouvel examen",
                 CodeMSG = "examen",
                 Annotation = string.Empty,
                 EndAnnotation = string.Empty,

--- a/Client/Pages/UserSettingsPage.xaml
+++ b/Client/Pages/UserSettingsPage.xaml
@@ -20,7 +20,7 @@
 
         <DataTemplate x:Key="ExamOptionTemplate" x:DataType="models:ExamOption">
             <TextBlock>
-                <Run Text="{x:Bind Name}"/>
+                <Run Text="{x:Bind DisplayLabel}"/>
                 <Run Text=" ("/>
                 <Run Text="{x:Bind Floor}"/>
                 <Run Text=")"/>
@@ -159,7 +159,8 @@
                                     <TextBlock Text="Maj F9" FontWeight="Bold" HorizontalAlignment="Center"/>
                                     <ComboBox Width="150"
                                               ItemsSource="{x:Bind ExamOptions}"
-                                              DisplayMemberPath="Name"
+                                              ItemTemplate="{StaticResource ExamOptionTemplate}"
+                                              DisplayMemberPath="DisplayLabel"
                                               SelectedValuePath="Name"
                                               SelectedValue="{x:Bind ViewModelSettings.ShiftF9Exam, Mode=TwoWay}"/>
                                 </StackPanel>
@@ -169,7 +170,8 @@
                                     <TextBlock Text="Ctrl F9" FontWeight="Bold" HorizontalAlignment="Center"/>
                                     <ComboBox Width="150"
                                               ItemsSource="{x:Bind ExamOptions}"
-                                              DisplayMemberPath="Name"
+                                              ItemTemplate="{StaticResource ExamOptionTemplate}"
+                                              DisplayMemberPath="DisplayLabel"
                                               SelectedValuePath="Name"
                                               SelectedValue="{x:Bind ViewModelSettings.CtrlF9Exam, Mode=TwoWay}"/>
                                 </StackPanel>
@@ -181,7 +183,8 @@
                                     <TextBlock Text="Maj F10" FontWeight="Bold" HorizontalAlignment="Center"/>
                                     <ComboBox Width="150"
                                               ItemsSource="{x:Bind ExamOptions}"
-                                              DisplayMemberPath="Name"
+                                              ItemTemplate="{StaticResource ExamOptionTemplate}"
+                                              DisplayMemberPath="DisplayLabel"
                                               SelectedValuePath="Name"
                                               SelectedValue="{x:Bind ViewModelSettings.ShiftF10Exam, Mode=TwoWay}"/>
                                 </StackPanel>
@@ -191,7 +194,8 @@
                                     <TextBlock Text="Ctrl F10" FontWeight="Bold" HorizontalAlignment="Center"/>
                                     <ComboBox Width="150"
                                               ItemsSource="{x:Bind ExamOptions}"
-                                              DisplayMemberPath="Name"
+                                              ItemTemplate="{StaticResource ExamOptionTemplate}"
+                                              DisplayMemberPath="DisplayLabel"
                                               SelectedValuePath="Name"
                                               SelectedValue="{x:Bind ViewModelSettings.CtrlF10Exam, Mode=TwoWay}"/>
                                 </StackPanel>
@@ -203,7 +207,8 @@
                                     <TextBlock Text="Maj F11" FontWeight="Bold" HorizontalAlignment="Center"/>
                                     <ComboBox Width="150"
                                               ItemsSource="{x:Bind ExamOptions}"
-                                              DisplayMemberPath="Name"
+                                              ItemTemplate="{StaticResource ExamOptionTemplate}"
+                                              DisplayMemberPath="DisplayLabel"
                                               SelectedValuePath="Name"
                                               SelectedValue="{x:Bind ViewModelSettings.ShiftF11Exam, Mode=TwoWay}"/>
                                 </StackPanel>
@@ -213,7 +218,8 @@
                                     <TextBlock Text="Ctrl F11" FontWeight="Bold" HorizontalAlignment="Center"/>
                                     <ComboBox Width="150"
                                               ItemsSource="{x:Bind ExamOptions}"
-                                              DisplayMemberPath="Name"
+                                              ItemTemplate="{StaticResource ExamOptionTemplate}"
+                                              DisplayMemberPath="DisplayLabel"
                                               SelectedValuePath="Name"
                                               SelectedValue="{x:Bind ViewModelSettings.CtrlF11Exam, Mode=TwoWay}"/>
                                 </StackPanel>
@@ -225,7 +231,8 @@
                                     <TextBlock Text="Maj F12" FontWeight="Bold" HorizontalAlignment="Center"/>
                                     <ComboBox Width="150"
                                               ItemsSource="{x:Bind ExamOptions}"
-                                              DisplayMemberPath="Name"
+                                              ItemTemplate="{StaticResource ExamOptionTemplate}"
+                                              DisplayMemberPath="DisplayLabel"
                                               SelectedValuePath="Name"
                                               SelectedValue="{x:Bind ViewModelSettings.ShiftF12Exam, Mode=TwoWay}"/>
                                 </StackPanel>
@@ -235,7 +242,8 @@
                                     <TextBlock Text="Ctrl F12" FontWeight="Bold" HorizontalAlignment="Center"/>
                                     <ComboBox Width="150"
                                               ItemsSource="{x:Bind ExamOptions}"
-                                              DisplayMemberPath="Name"
+                                              ItemTemplate="{StaticResource ExamOptionTemplate}"
+                                              DisplayMemberPath="DisplayLabel"
                                               SelectedValuePath="Name"
                                               SelectedValue="{x:Bind ViewModelSettings.CtrlF12Exam, Mode=TwoWay}"/>
                                 </StackPanel>

--- a/Serveur/Models/ExamOption.cs
+++ b/Serveur/Models/ExamOption.cs
@@ -4,6 +4,7 @@ namespace ChatServeur
     {
         public int Index { get; set; }
         public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
         public string Color { get; set; } = string.Empty;
         public string CodeMSG { get; set; } = string.Empty;
         public string ForegroundColor => ColorHelpers.GetForeground(Color);

--- a/docs/Personnalisation.md
+++ b/docs/Personnalisation.md
@@ -68,7 +68,7 @@ public string ShortcutF5Refraction
 
 ## Liste des examens et salles
 
-La page `ExamRoomPage` permet de gérer la liste des examens médicaux disponibles et les salles associées. Chaque examen possède un nom, une couleur, un code clavier et une annotation. Les données sont sauvegardées dans `exam_options.json` via `ExamOption.Save` et dans `rooms.json` via `RoomList.Save` :
+La page `ExamRoomPage` permet de gérer la liste des examens médicaux disponibles et les salles associées. Chaque examen possède un nom, une description, une couleur, un code clavier et une annotation. Les données sont sauvegardées dans `exam_options.json` via `ExamOption.Save` et dans `rooms.json` via `RoomList.Save` :
 
 ```csharp
 public static readonly string FilePath = Path.Combine(


### PR DESCRIPTION
## Summary
- ajoute une propriété de description aux examens et l’affiche dans la grille de configuration
- utilise la description comme libellé dans les raccourcis patient tout en conservant le nom pour les étiquettes
- synchronise le nouveau champ côté serveur et documente la colonne supplémentaire

## Testing
- dotnet build *(échoue : commande introuvable dans l’environnement CI)*

------
https://chatgpt.com/codex/tasks/task_e_68e118afccd883249ac30d7834dd5eb4