### PR TITLE
Fix string serialization in AppSettings

### DIFF
--- a/Client/Helpers/AppSettings.cs
+++ b/Client/Helpers/AppSettings.cs
@@ -91,15 +91,15 @@ namespace Client.Helpers
 
         public static void Set(string key, string value)
         {
-            _settings[key] = JsonDocument.Parse($"\"{value}\"").RootElement;
+            var safeValue = value ?? string.Empty;
+            _settings[key] = JsonSerializer.SerializeToElement(safeValue);
             Save();
             SettingsChanged?.Invoke();
         }
 
         public static void SetObject<T>(string key, T value)
         {
-            var json = JsonSerializer.Serialize(value);
-            _settings[key] = JsonDocument.Parse(json).RootElement;
+            _settings[key] = JsonSerializer.SerializeToElement(value);
             Save();
             SettingsChanged?.Invoke();
         }


### PR DESCRIPTION
## Summary
- update AppSettings string/object setters to use JsonSerializer.SerializeToElement so values containing special characters are persisted without throwing

## Testing
- dotnet build *(fails: `command not found: dotnet` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e138ff1e108324918d835e042ff406