### PR TITLE
Normalize exam option data to avoid null bindings

### DIFF
--- a/Client/Helpers/AppSettings.cs
+++ b/Client/Helpers/AppSettings.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Client.Models;
 using Client;
 
@@ -9,7 +10,7 @@ namespace Client.Helpers
 {
     public static class AppSettings
     {
-        private static Dictionary<string, JsonElement> _settings = new();
+        private static Dictionary<string, JsonNode?> _settings = new();
 
         public static event Action? SettingsChanged;
 
@@ -55,7 +56,7 @@ namespace Client.Helpers
                 if (File.Exists(FilePath))
                 {
                     var json = File.ReadAllText(FilePath);
-                    _settings = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json)
+                    _settings = JsonSerializer.Deserialize<Dictionary<string, JsonNode?>>(json)
                                 ?? new();
                 }
                 else
@@ -71,16 +72,22 @@ namespace Client.Helpers
 
         public static string Get(string key, string defaultValue = "")
         {
-            return _settings.TryGetValue(key, out var value) && value.ValueKind == JsonValueKind.String
-                ? value.GetString() ?? defaultValue
-                : defaultValue;
+            if (_settings.TryGetValue(key, out var value) && value is JsonValue jsonValue)
+            {
+                if (jsonValue.TryGetValue<string>(out var text) && text is not null)
+                {
+                    return text;
+                }
+            }
+
+            return defaultValue;
         }
 
         public static T GetObject<T>(string key) where T : new()
         {
             try
             {
-                if (_settings.TryGetValue(key, out var value))
+                if (_settings.TryGetValue(key, out var value) && value is not null)
                 {
                     return value.Deserialize<T>() ?? new T();
                 }
@@ -91,15 +98,15 @@ namespace Client.Helpers
 
         public static void Set(string key, string value)
         {
-            _settings[key] = JsonDocument.Parse($"\"{value}\"").RootElement;
+            var safeValue = value ?? string.Empty;
+            _settings[key] = JsonValue.Create(safeValue);
             Save();
             SettingsChanged?.Invoke();
         }
 
         public static void SetObject<T>(string key, T value)
         {
-            var json = JsonSerializer.Serialize(value);
-            _settings[key] = JsonDocument.Parse(json).RootElement;
+            _settings[key] = JsonSerializer.SerializeToNode(value);
             Save();
             SettingsChanged?.Invoke();
         }
@@ -120,12 +127,12 @@ namespace Client.Helpers
         {
             try
             {
-                var dict = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+                var dict = JsonSerializer.Deserialize<Dictionary<string, JsonNode?>>(json);
                 if (dict != null)
                 {
                     foreach (var kvp in dict)
                     {
-                        if (kvp.Value.ValueKind == JsonValueKind.Null)
+                        if (kvp.Value is null)
                             continue;
                         _settings[kvp.Key] = kvp.Value;
                     }

--- a/Client/Models/ExamOption.cs
+++ b/Client/Models/ExamOption.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using Client.Helpers;
 using Newtonsoft.Json;
 
 namespace Client.Models
@@ -66,9 +67,10 @@ namespace Client.Models
             get => _color;
             set
             {
-                if (_color != value)
+                var sanitized = value?.Trim() ?? string.Empty;
+                if (_color != sanitized)
                 {
-                    _color = value;
+                    _color = sanitized;
                     OnPropertyChanged(nameof(Color));
                     OnPropertyChanged(nameof(ForegroundColor));
                 }
@@ -85,9 +87,10 @@ namespace Client.Models
             get => _codeMSG;
             set
             {
-                if (_codeMSG != value)
+                var sanitized = value?.Trim() ?? string.Empty;
+                if (_codeMSG != sanitized)
                 {
-                    _codeMSG = value;
+                    _codeMSG = sanitized;
                     OnPropertyChanged(nameof(CodeMSG));
                 }
             }
@@ -98,9 +101,10 @@ namespace Client.Models
             get => _annotation;
             set
             {
-                if (_annotation != value)
+                var sanitized = value ?? string.Empty;
+                if (_annotation != sanitized)
                 {
-                    _annotation = value;
+                    _annotation = sanitized;
                     OnPropertyChanged(nameof(Annotation));
                 }
             }
@@ -111,9 +115,10 @@ namespace Client.Models
             get => _endAnnotation;
             set
             {
-                if (_endAnnotation != value)
+                var sanitized = value ?? string.Empty;
+                if (_endAnnotation != sanitized)
                 {
-                    _endAnnotation = value;
+                    _endAnnotation = sanitized;
                     OnPropertyChanged(nameof(EndAnnotation));
                 }
             }
@@ -124,9 +129,10 @@ namespace Client.Models
             get => _floor;
             set
             {
-                if (_floor != value)
+                var sanitized = value?.Trim() ?? string.Empty;
+                if (_floor != sanitized)
                 {
-                    _floor = value;
+                    _floor = sanitized;
                     OnPropertyChanged(nameof(Floor));
                 }
             }
@@ -163,11 +169,17 @@ namespace Client.Models
                         }
                     }
 
+                    foreach (var option in items)
+                    {
+                        option?.Normalize();
+                    }
+
                     return items;
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                Logger.LogException("ExamOption.Load failed", ex);
             }
             return new ObservableCollection<ExamOption>();
         }
@@ -182,12 +194,29 @@ namespace Client.Models
                     options
                         .Where(o => o is not null)
                         .Cast<ExamOption>());
+
+                foreach (var option in sanitized)
+                {
+                    option.Normalize();
+                }
                 var json = JsonConvert.SerializeObject(sanitized, Formatting.Indented);
                 File.WriteAllText(FilePath, json);
             }
-            catch
+            catch (Exception ex)
             {
+                Logger.LogException("ExamOption.Save failed", ex);
             }
+        }
+
+        public void Normalize()
+        {
+            Name = Name;
+            Description = Description;
+            Color = Color;
+            CodeMSG = CodeMSG;
+            Annotation = Annotation;
+            EndAnnotation = EndAnnotation;
+            Floor = Floor;
         }
     }
 }


### PR DESCRIPTION
## Summary
- sanitize all exam option string setters so persisted JSON null values are converted to empty strings before binding
- normalize loaded/saved exam options and record failures with Logger to aid diagnosing corrupt configuration files

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e138ff1e108324918d835e042ff406