### PR TITLE
Fix hotkey exam dialog after ExamOption changes

### DIFF
--- a/Client/Services/HotKeyService.cs
+++ b/Client/Services/HotKeyService.cs
@@ -197,12 +197,13 @@ namespace Client.Services
                 grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
 
             var nameBox = new TextBox { PlaceholderText = "Nom du patient" ,Width = 600};
+            var sanitizedExamName = examName?.Trim();
             var examCombo = new ComboBox
             {
                 ItemsSource = options,
-                DisplayMemberPath = "Name",
-                SelectedValuePath = "Name",
-                SelectedValue = examName,
+                DisplayMemberPath = nameof(ExamOption.DisplayLabel),
+                SelectedValuePath = nameof(ExamOption.Name),
+                SelectedValue = sanitizedExamName,
                 Width = 600
             };
             var eyeCombo = new ComboBox { Width = 600 };
@@ -212,7 +213,8 @@ namespace Client.Services
             eyeCombo.SelectedIndex = 0;
 
             var floorCombo = new ComboBox { Width = 600, ItemsSource = rooms };
-            var examOpt = options.FirstOrDefault(o => o.Name == examName);
+            var examOpt = options.FirstOrDefault(o =>
+                string.Equals(o?.Name?.Trim(), sanitizedExamName, StringComparison.OrdinalIgnoreCase));
             if (examOpt != null && rooms.Contains(examOpt.Floor))
                 floorCombo.SelectedItem = examOpt.Floor;
             var commentBox = new TextBox { PlaceholderText = "Commentaire", Width = 600 };


### PR DESCRIPTION
## Summary
- display exam options in the hotkey patient dialog using the new ExamOption display label
- trim the selected exam name before matching the stored option so existing settings keep working

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e1f3edc0688324b408217d26c81151