### PR TITLE
Synchronize user settings exams with server options

### DIFF
--- a/Client/Pages/UserSettingsPage.xaml
+++ b/Client/Pages/UserSettingsPage.xaml
@@ -161,7 +161,7 @@
                                               ItemsSource="{x:Bind ExamOptions}"
                                               ItemTemplate="{StaticResource ExamOptionTemplate}"
                                               DisplayMemberPath="DisplayLabel"
-                                              SelectedValuePath="Description"
+                                              SelectedValuePath="Name"
                                               SelectedValue="{x:Bind ViewModelSettings.ShiftF9Exam, Mode=TwoWay}"/>
                                 </StackPanel>
                             </Border>

--- a/Client/Pages/UserSettingsPage.xaml.cs
+++ b/Client/Pages/UserSettingsPage.xaml.cs
@@ -1,16 +1,19 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Client.Helpers;
+using Client.Models;
 using Client.ViewModel;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System.Diagnostics;
-using Client.Models;
-using System.Collections.ObjectModel;
-using System.Threading.Tasks;
 using Windows.Storage.Pickers;
 using Windows.Storage;
 using WinRT.Interop;
 using System;
 using System.IO;
-using System.Linq;
 using Microsoft.UI.Xaml.Markup;
 
 namespace Client.Pages
@@ -26,8 +29,73 @@ namespace Client.Pages
         {
             this.InitializeComponent();
             this.DataContext = ViewModelSettings;
+            this.Loaded += UserSettingsPage_Loaded;
+            this.Unloaded += UserSettingsPage_Unloaded;
             ViewModelSettings.Load();
             Debug.WriteLine($"[UserSettingsPage] ViewModel instance: {ViewModelSettings.GetHashCode()}");
+        }
+
+        private async void UserSettingsPage_Loaded(object sender, RoutedEventArgs e)
+        {
+            App.ChatService.ExamOptionsUpdated += ChatService_ExamOptionsUpdated;
+            await RefreshExamOptionsAsync();
+        }
+
+        private void UserSettingsPage_Unloaded(object sender, RoutedEventArgs e)
+        {
+            App.ChatService.ExamOptionsUpdated -= ChatService_ExamOptionsUpdated;
+        }
+
+        private void ChatService_ExamOptionsUpdated(IEnumerable<ExamOption> options)
+        {
+            if (options is null)
+            {
+                return;
+            }
+
+            DispatcherQueue?.TryEnqueue(() => UpdateExamOptions(options));
+        }
+
+        private async Task RefreshExamOptionsAsync()
+        {
+            try
+            {
+                var serverOptions = await App.ChatService.GetExamOptionsAsync();
+                if (serverOptions?.Any() == true)
+                {
+                    UpdateExamOptions(serverOptions);
+                }
+                else
+                {
+                    ViewModelSettings.ValidateExamSelections(ExamOptions);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("UserSettingsPage.RefreshExamOptionsAsync failed", ex);
+            }
+        }
+
+        private void UpdateExamOptions(IEnumerable<ExamOption> options)
+        {
+            var sanitized = options
+                .Where(option => option is not null)
+                .Select(option =>
+                {
+                    option.Normalize();
+                    return option;
+                })
+                .OrderBy(option => option.Index)
+                .ToList();
+
+            ExamOptions.Clear();
+            foreach (var option in sanitized)
+            {
+                ExamOptions.Add(option);
+            }
+
+            ExamOption.Save(ExamOptions);
+            ViewModelSettings.ValidateExamSelections(ExamOptions);
         }
         private void Back_Click(object sender, RoutedEventArgs e)
         {

--- a/Client/ViewModel/SettingsViewModel.cs
+++ b/Client/ViewModel/SettingsViewModel.cs
@@ -446,13 +446,21 @@ namespace Client.ViewModel
             return string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
         }
 
+        public void ValidateExamSelections(IEnumerable<ExamOption> availableOptions)
+        {
+            ValidateExamSelectionsInternal(availableOptions);
+        }
+
         private void ValidateExamSelections()
+        {
+            ValidateExamSelectionsInternal(ExamOption.Load());
+        }
+
+        private void ValidateExamSelectionsInternal(IEnumerable<ExamOption> availableOptions)
         {
             try
             {
-                var validNames = BuildValidExamNameMap();
-
-                
+                var validNames = BuildValidExamNameMap(availableOptions);
 
                 ValidateExamSelection(_shiftF9Exam, value => ShiftF9Exam = value, validNames);
                 ValidateExamSelection(_ctrlF9Exam, value => CtrlF9Exam = value, validNames);
@@ -469,11 +477,16 @@ namespace Client.ViewModel
             }
         }
 
-        private static Dictionary<string, string> BuildValidExamNameMap()
+        private static Dictionary<string, string> BuildValidExamNameMap(IEnumerable<ExamOption> options)
         {
             var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-            foreach (var option in ExamOption.Load())
+            if (options is null)
+            {
+                return map;
+            }
+
+            foreach (var option in options)
             {
                 if (option is null)
                 {


### PR DESCRIPTION
## Summary
- subscribe the user settings page to server exam option updates and refresh the local list when the page is shown
- persist the refreshed exam options locally and revalidate the selected shortcuts against the available names
- expose validation helpers on the settings view model so the page can sanitize selections when new options arrive

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e1f8e6f4cc8324af4a11c7f0d7bcea