### PR TITLE
Improve exam shortcut setup in user settings

### DIFF
--- a/Client/Pages/UserSettingsPage.xaml
+++ b/Client/Pages/UserSettingsPage.xaml
@@ -19,12 +19,7 @@
         </DataTemplate>
 
         <DataTemplate x:Key="ExamOptionTemplate" x:DataType="models:ExamOption">
-            <TextBlock>
-                <Run Text="{x:Bind DisplayLabel}"/>
-                <Run Text=" ("/>
-                <Run Text="{x:Bind Floor}"/>
-                <Run Text=")"/>
-            </TextBlock>
+            <TextBlock Text="{x:Bind DisplayLabel}"/>
         </DataTemplate>
     </Page.Resources>
     <ScrollViewer>

--- a/Client/Services/HotKeyService.cs
+++ b/Client/Services/HotKeyService.cs
@@ -215,9 +215,24 @@ namespace Client.Services
             var floorCombo = new ComboBox { Width = 600, ItemsSource = rooms };
             var examOpt = options.FirstOrDefault(o =>
                 string.Equals(o?.Name?.Trim(), sanitizedExamName, StringComparison.OrdinalIgnoreCase));
-            if (examOpt != null && rooms.Contains(examOpt.Floor))
-                floorCombo.SelectedItem = examOpt.Floor;
+            if (examOpt != null)
+            {
+                if (!string.IsNullOrWhiteSpace(examOpt.Floor))
+                {
+                    if (!rooms.Any(r => string.Equals(r, examOpt.Floor, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        rooms.Add(examOpt.Floor);
+                    }
+
+                    floorCombo.SelectedItem = rooms.FirstOrDefault(r =>
+                        string.Equals(r, examOpt.Floor, StringComparison.OrdinalIgnoreCase)) ?? examOpt.Floor;
+                }
+            }
             var commentBox = new TextBox { PlaceholderText = "Commentaire", Width = 600 };
+            if (!string.IsNullOrWhiteSpace(examOpt?.Annotation))
+            {
+                commentBox.Text = examOpt.Annotation.Trim();
+            }
 
             // Extract patient name either from parameter or active window title
             if (string.IsNullOrWhiteSpace(patientName))


### PR DESCRIPTION
## Summary
- show only the exam description in the shortcut combo boxes on the user settings page
- prefill the patient creation dialog with the selected exam's floor and annotation, adding the room if needed

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1ffc9030c8324a26b2d10aee9b436