### PR TITLE
Revamp user settings page layout and logging

### DIFF
--- a/Client/Pages/UserSettingsPage.xaml
+++ b/Client/Pages/UserSettingsPage.xaml
@@ -1,5 +1,6 @@
 <Page
     x:Class="Client.Pages.UserSettingsPage"
+    x:Name="Root"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -7,6 +8,8 @@
     xmlns:vm="using:Client.ViewModel"
     xmlns:helpers="using:Client.Helpers"
     xmlns:models="using:Client.Models"
+    xmlns:pages="using:Client.Pages"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
     <Page.Resources>
@@ -16,15 +19,6 @@
 
         <DataTemplate x:Key="AvatarTemplate">
             <Image Source="{Binding}" Width="60" Height="60"/>
-        </DataTemplate>
-
-        <DataTemplate x:Key="ExamOptionTemplate" x:DataType="models:ExamOption">
-            <TextBlock>
-                <Run Text="{x:Bind DisplayLabel}"/>
-                <Run Text=" ("/>
-                <Run Text="{x:Bind Floor}"/>
-                <Run Text=")"/>
-            </TextBlock>
         </DataTemplate>
     </Page.Resources>
     <ScrollViewer>
@@ -152,104 +146,36 @@
             <Border CornerRadius="8" Padding="20">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Raccourcis patient" FontSize="18" FontWeight="Bold"/>
-                    <StackPanel Orientation="Horizontal" Spacing="10">
-                        <StackPanel Spacing="10">
-                            <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
-                                <StackPanel Spacing="10">
-                                    <TextBlock Text="Maj F9" FontWeight="Bold" HorizontalAlignment="Center"/>
-                                    <ComboBox Width="150"
-                                              ItemsSource="{x:Bind ExamOptions}"
-                                              ItemTemplate="{StaticResource ExamOptionTemplate}"
-                                              DisplayMemberPath="DisplayLabel"
-                                              SelectedValuePath="Name"
-                                              SelectedValue="{x:Bind ViewModelSettings.ShiftF9Exam, Mode=TwoWay}"/>
-                                </StackPanel>
-                            </Border>
-                            <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
-                                <StackPanel Spacing="10">
-                                    <TextBlock Text="Ctrl F9" FontWeight="Bold" HorizontalAlignment="Center"/>
-                                    <ComboBox Width="150"
-                                              ItemsSource="{x:Bind ExamOptions}"
-                                              ItemTemplate="{StaticResource ExamOptionTemplate}"
-                                              DisplayMemberPath="DisplayLabel"
-                                              SelectedValuePath="Name"
-                                              SelectedValue="{x:Bind ViewModelSettings.CtrlF9Exam, Mode=TwoWay}"/>
-                                </StackPanel>
-                            </Border>
-                        </StackPanel>
-                        <StackPanel Spacing="10">
-                            <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
-                                <StackPanel Spacing="10">
-                                    <TextBlock Text="Maj F10" FontWeight="Bold" HorizontalAlignment="Center"/>
-                                    <ComboBox Width="150"
-                                              ItemsSource="{x:Bind ExamOptions}"
-                                              ItemTemplate="{StaticResource ExamOptionTemplate}"
-                                              DisplayMemberPath="DisplayLabel"
-                                              SelectedValuePath="Name"
-                                              SelectedValue="{x:Bind ViewModelSettings.ShiftF10Exam, Mode=TwoWay}"/>
-                                </StackPanel>
-                            </Border>
-                            <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
-                                <StackPanel Spacing="10">
-                                    <TextBlock Text="Ctrl F10" FontWeight="Bold" HorizontalAlignment="Center"/>
-                                    <ComboBox Width="150"
-                                              ItemsSource="{x:Bind ExamOptions}"
-                                              ItemTemplate="{StaticResource ExamOptionTemplate}"
-                                              DisplayMemberPath="DisplayLabel"
-                                              SelectedValuePath="Name"
-                                              SelectedValue="{x:Bind ViewModelSettings.CtrlF10Exam, Mode=TwoWay}"/>
-                                </StackPanel>
-                            </Border>
-                        </StackPanel>
-                        <StackPanel Spacing="10">
-                            <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
-                                <StackPanel Spacing="10">
-                                    <TextBlock Text="Maj F11" FontWeight="Bold" HorizontalAlignment="Center"/>
-                                    <ComboBox Width="150"
-                                              ItemsSource="{x:Bind ExamOptions}"
-                                              ItemTemplate="{StaticResource ExamOptionTemplate}"
-                                              DisplayMemberPath="DisplayLabel"
-                                              SelectedValuePath="Name"
-                                              SelectedValue="{x:Bind ViewModelSettings.ShiftF11Exam, Mode=TwoWay}"/>
-                                </StackPanel>
-                            </Border>
-                            <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
-                                <StackPanel Spacing="10">
-                                    <TextBlock Text="Ctrl F11" FontWeight="Bold" HorizontalAlignment="Center"/>
-                                    <ComboBox Width="150"
-                                              ItemsSource="{x:Bind ExamOptions}"
-                                              ItemTemplate="{StaticResource ExamOptionTemplate}"
-                                              DisplayMemberPath="DisplayLabel"
-                                              SelectedValuePath="Name"
-                                              SelectedValue="{x:Bind ViewModelSettings.CtrlF11Exam, Mode=TwoWay}"/>
-                                </StackPanel>
-                            </Border>
-                        </StackPanel>
-                        <StackPanel Spacing="10">
-                            <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
-                                <StackPanel Spacing="10">
-                                    <TextBlock Text="Maj F12" FontWeight="Bold" HorizontalAlignment="Center"/>
-                                    <ComboBox Width="150"
-                                              ItemsSource="{x:Bind ExamOptions}"
-                                              ItemTemplate="{StaticResource ExamOptionTemplate}"
-                                              DisplayMemberPath="DisplayLabel"
-                                              SelectedValuePath="Name"
-                                              SelectedValue="{x:Bind ViewModelSettings.ShiftF12Exam, Mode=TwoWay}"/>
-                                </StackPanel>
-                            </Border>
-                            <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Width="200">
-                                <StackPanel Spacing="10">
-                                    <TextBlock Text="Ctrl F12" FontWeight="Bold" HorizontalAlignment="Center"/>
-                                    <ComboBox Width="150"
-                                              ItemsSource="{x:Bind ExamOptions}"
-                                              ItemTemplate="{StaticResource ExamOptionTemplate}"
-                                              DisplayMemberPath="DisplayLabel"
-                                              SelectedValuePath="Name"
-                                              SelectedValue="{x:Bind ViewModelSettings.CtrlF12Exam, Mode=TwoWay}"/>
-                                </StackPanel>
-                            </Border>
-                        </StackPanel>
-                    </StackPanel>
+                    <ItemsControl ItemsSource="{x:Bind Root.ExamShortcutGroups}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <controls:WrapPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Top" ItemWidth="220" ItemHeight="Auto" Margin="0"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="pages:ExamShortcutGroup">
+                                <Border BorderThickness="1" BorderBrush="Gray" Padding="10" CornerRadius="4" Margin="0,0,10,10" Width="220">
+                                    <StackPanel Spacing="8">
+                                        <TextBlock Text="{x:Bind Title}" FontWeight="Bold" HorizontalAlignment="Center"/>
+                                        <ItemsControl ItemsSource="{x:Bind Shortcuts}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate x:DataType="pages:ExamShortcutEntry">
+                                                    <StackPanel Spacing="4">
+                                                        <TextBlock Text="{x:Bind Label}" HorizontalAlignment="Center"/>
+                                                        <ComboBox Width="180"
+                                                                  ItemsSource="{x:Bind Root.ExamOptions}"
+                                                                  DisplayMemberPath="DisplayLabel"
+                                                                  SelectedValuePath="Name"
+                                                                  SelectedValue="{x:Bind Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                                    </StackPanel>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
                 </StackPanel>
             </Border>
         </StackPanel>

--- a/Client/Pages/UserSettingsPage.xaml.cs
+++ b/Client/Pages/UserSettingsPage.xaml.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -22,8 +23,10 @@ namespace Client.Pages
     {
         public SettingsViewModel ViewModelSettings { get; } = new();
         public ObservableCollection<ExamOption> ExamOptions { get; } = ExamOption.Load();
+        public ObservableCollection<ExamShortcutGroup> ExamShortcutGroups { get; } = new();
 
         private readonly ObservableCollection<string> _defaultAvatars = new();
+        private readonly Dictionary<string, ExamShortcutEntry> _shortcutEntryMap = new(StringComparer.OrdinalIgnoreCase);
 
         public UserSettingsPage()
         {
@@ -31,19 +34,27 @@ namespace Client.Pages
             this.DataContext = ViewModelSettings;
             this.Loaded += UserSettingsPage_Loaded;
             this.Unloaded += UserSettingsPage_Unloaded;
+            Logger.Log($"[UserSettingsPage] Constructed with {ExamOptions.Count} cached exam option(s).");
             ViewModelSettings.Load();
+            InitializeShortcutGroups();
+            RefreshShortcutEntries();
             Debug.WriteLine($"[UserSettingsPage] ViewModel instance: {ViewModelSettings.GetHashCode()}");
         }
 
         private async void UserSettingsPage_Loaded(object sender, RoutedEventArgs e)
         {
+            Logger.Log($"[UserSettingsPage] Loaded. Current shortcut groups: {ExamShortcutGroups.Count}.");
+            ViewModelSettings.PropertyChanged -= ViewModelSettings_PropertyChanged;
+            ViewModelSettings.PropertyChanged += ViewModelSettings_PropertyChanged;
             App.ChatService.ExamOptionsUpdated += ChatService_ExamOptionsUpdated;
             await RefreshExamOptionsAsync();
         }
 
         private void UserSettingsPage_Unloaded(object sender, RoutedEventArgs e)
         {
+            Logger.Log("[UserSettingsPage] Unloaded.");
             App.ChatService.ExamOptionsUpdated -= ChatService_ExamOptionsUpdated;
+            ViewModelSettings.PropertyChanged -= ViewModelSettings_PropertyChanged;
         }
 
         private void ChatService_ExamOptionsUpdated(IEnumerable<ExamOption> options)
@@ -53,6 +64,7 @@ namespace Client.Pages
                 return;
             }
 
+            Logger.Log($"[UserSettingsPage] Received ExamOptionsUpdated event with {options.Count()} option(s).");
             DispatcherQueue?.TryEnqueue(() => UpdateExamOptions(options));
         }
 
@@ -60,13 +72,16 @@ namespace Client.Pages
         {
             try
             {
+                Logger.Log("[UserSettingsPage] RefreshExamOptionsAsync starting.");
                 var serverOptions = await App.ChatService.GetExamOptionsAsync();
                 if (serverOptions?.Any() == true)
                 {
+                    Logger.Log($"[UserSettingsPage] Loaded {serverOptions.Count()} exam option(s) from server.");
                     UpdateExamOptions(serverOptions);
                 }
                 else
                 {
+                    Logger.Log("[UserSettingsPage] No server exam options received. Validating local selections only.");
                     ViewModelSettings.ValidateExamSelections(ExamOptions);
                 }
             }
@@ -94,8 +109,10 @@ namespace Client.Pages
                 ExamOptions.Add(option);
             }
 
+            Logger.Log($"[UserSettingsPage] Exam options updated. Total count: {ExamOptions.Count}.");
             ExamOption.Save(ExamOptions);
             ViewModelSettings.ValidateExamSelections(ExamOptions);
+            RefreshShortcutEntries();
         }
         private void Back_Click(object sender, RoutedEventArgs e)
         {
@@ -107,6 +124,7 @@ namespace Client.Pages
 
         private async void ChangeAvatar_Click(object sender, RoutedEventArgs e)
         {
+            Logger.Log("[UserSettingsPage] ChangeAvatar_Click invoked.");
             var serverAvatars = await App.ChatService.GetAvailableAvatarsAsync();
             _defaultAvatars.Clear();
             foreach (var avatar in serverAvatars.Distinct())
@@ -173,6 +191,7 @@ namespace Client.Pages
             var file = await picker.PickSingleFileAsync();
             if (file != null)
             {
+                Logger.Log($"[UserSettingsPage] Importing avatar '{file.Name}'.");
                 var folder = await ApplicationData.Current.LocalFolder.CreateFolderAsync("Avatars", CreationCollisionOption.OpenIfExists);
                 var newFile = await file.CopyAsync(folder, file.Name, NameCollisionOption.GenerateUniqueName);
 
@@ -190,6 +209,122 @@ namespace Client.Pages
                     _defaultAvatars.Add(path);
                 list.SelectedItem = null;
             }
+        }
+
+        private void InitializeShortcutGroups()
+        {
+            ExamShortcutGroups.Clear();
+            _shortcutEntryMap.Clear();
+
+            ExamShortcutGroups.Add(new ExamShortcutGroup("F9", new[]
+            {
+                CreateShortcutEntry("Maj F9", nameof(SettingsViewModel.ShiftF9Exam), () => ViewModelSettings.ShiftF9Exam, value => ViewModelSettings.ShiftF9Exam = value),
+                CreateShortcutEntry("Ctrl F9", nameof(SettingsViewModel.CtrlF9Exam), () => ViewModelSettings.CtrlF9Exam, value => ViewModelSettings.CtrlF9Exam = value)
+            }));
+
+            ExamShortcutGroups.Add(new ExamShortcutGroup("F10", new[]
+            {
+                CreateShortcutEntry("Maj F10", nameof(SettingsViewModel.ShiftF10Exam), () => ViewModelSettings.ShiftF10Exam, value => ViewModelSettings.ShiftF10Exam = value),
+                CreateShortcutEntry("Ctrl F10", nameof(SettingsViewModel.CtrlF10Exam), () => ViewModelSettings.CtrlF10Exam, value => ViewModelSettings.CtrlF10Exam = value)
+            }));
+
+            ExamShortcutGroups.Add(new ExamShortcutGroup("F11", new[]
+            {
+                CreateShortcutEntry("Maj F11", nameof(SettingsViewModel.ShiftF11Exam), () => ViewModelSettings.ShiftF11Exam, value => ViewModelSettings.ShiftF11Exam = value),
+                CreateShortcutEntry("Ctrl F11", nameof(SettingsViewModel.CtrlF11Exam), () => ViewModelSettings.CtrlF11Exam, value => ViewModelSettings.CtrlF11Exam = value)
+            }));
+
+            ExamShortcutGroups.Add(new ExamShortcutGroup("F12", new[]
+            {
+                CreateShortcutEntry("Maj F12", nameof(SettingsViewModel.ShiftF12Exam), () => ViewModelSettings.ShiftF12Exam, value => ViewModelSettings.ShiftF12Exam = value),
+                CreateShortcutEntry("Ctrl F12", nameof(SettingsViewModel.CtrlF12Exam), () => ViewModelSettings.CtrlF12Exam, value => ViewModelSettings.CtrlF12Exam = value)
+            }));
+
+            Logger.Log($"[UserSettingsPage] Initialized {ExamShortcutGroups.Count} shortcut group(s).");
+        }
+
+        private ExamShortcutEntry CreateShortcutEntry(string label, string propertyName, Func<string> getter, Action<string> setter)
+        {
+            var entry = new ExamShortcutEntry(label, getter, setter);
+            _shortcutEntryMap[propertyName] = entry;
+            return entry;
+        }
+
+        private void RefreshShortcutEntries()
+        {
+            foreach (var entry in _shortcutEntryMap.Values)
+            {
+                entry.Refresh();
+            }
+        }
+
+        private void ViewModelSettings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (string.IsNullOrEmpty(e.PropertyName))
+            {
+                Logger.Log("[UserSettingsPage] ViewModelSettings signaled full refresh.");
+                RefreshShortcutEntries();
+                return;
+            }
+
+            if (_shortcutEntryMap.TryGetValue(e.PropertyName, out var entry))
+            {
+                Logger.Log($"[UserSettingsPage] ViewModel property '{e.PropertyName}' changed. Refreshing shortcut entry.");
+                entry.Refresh();
+            }
+        }
+    }
+    public sealed class ExamShortcutGroup
+    {
+        public ExamShortcutGroup(string title, IEnumerable<ExamShortcutEntry> shortcuts)
+        {
+            Title = title;
+            Shortcuts = new ObservableCollection<ExamShortcutEntry>(shortcuts ?? Enumerable.Empty<ExamShortcutEntry>());
+        }
+
+        public string Title { get; }
+
+        public ObservableCollection<ExamShortcutEntry> Shortcuts { get; }
+    }
+
+    public sealed class ExamShortcutEntry : INotifyPropertyChanged
+    {
+        private readonly Func<string> _getter;
+        private readonly Action<string> _setter;
+
+        public ExamShortcutEntry(string label, Func<string> getter, Action<string> setter)
+        {
+            Label = label;
+            _getter = getter ?? throw new ArgumentNullException(nameof(getter));
+            _setter = setter ?? throw new ArgumentNullException(nameof(setter));
+        }
+
+        public string Label { get; }
+
+        public string Value
+        {
+            get => _getter();
+            set
+            {
+                var sanitized = value?.Trim() ?? string.Empty;
+                if (!string.Equals(_getter(), sanitized, StringComparison.Ordinal))
+                {
+                    _setter(sanitized);
+                    OnPropertyChanged(nameof(Value));
+                }
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public void Refresh()
+        {
+            OnPropertyChanged(nameof(Value));
+        }
+
+        private void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Client/Services/HotKeyService.cs
+++ b/Client/Services/HotKeyService.cs
@@ -215,9 +215,24 @@ namespace Client.Services
             var floorCombo = new ComboBox { Width = 600, ItemsSource = rooms };
             var examOpt = options.FirstOrDefault(o =>
                 string.Equals(o?.Name?.Trim(), sanitizedExamName, StringComparison.OrdinalIgnoreCase));
-            if (examOpt != null && rooms.Contains(examOpt.Floor))
-                floorCombo.SelectedItem = examOpt.Floor;
+            if (examOpt != null)
+            {
+                if (!string.IsNullOrWhiteSpace(examOpt.Floor))
+                {
+                    if (!rooms.Any(r => string.Equals(r, examOpt.Floor, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        rooms.Add(examOpt.Floor);
+                    }
+
+                    floorCombo.SelectedItem = rooms.FirstOrDefault(r =>
+                        string.Equals(r, examOpt.Floor, StringComparison.OrdinalIgnoreCase)) ?? examOpt.Floor;
+                }
+            }
             var commentBox = new TextBox { PlaceholderText = "Commentaire", Width = 600 };
+            if (!string.IsNullOrWhiteSpace(examOpt?.Annotation))
+            {
+                commentBox.Text = examOpt.Annotation.Trim();
+            }
 
             // Extract patient name either from parameter or active window title
             if (string.IsNullOrWhiteSpace(patientName))

--- a/Client/ViewModel/SettingsViewModel.cs
+++ b/Client/ViewModel/SettingsViewModel.cs
@@ -269,6 +269,7 @@ namespace Client.ViewModel
                 if (_ctrlF9Exam != normalized)
                 {
                     _ctrlF9Exam = normalized;
+                    Logger.Log($"[SettingsViewModel] CtrlF9Exam set to '{normalized}'.");
                     OnPropertyChanged(nameof(CtrlF9Exam));
                     Set("CtrlF9Exam", normalized);
                 }
@@ -284,6 +285,7 @@ namespace Client.ViewModel
                 if (_shiftF9Exam != normalized)
                 {
                     _shiftF9Exam = normalized;
+                    Logger.Log($"[SettingsViewModel] ShiftF9Exam set to '{normalized}'.");
                     OnPropertyChanged(nameof(ShiftF9Exam));
                     Set("ShiftF9Exam", normalized);
                 }
@@ -299,6 +301,7 @@ namespace Client.ViewModel
                 if (_ctrlF10Exam != normalized)
                 {
                     _ctrlF10Exam = normalized;
+                    Logger.Log($"[SettingsViewModel] CtrlF10Exam set to '{normalized}'.");
                     OnPropertyChanged(nameof(CtrlF10Exam));
                     Set("CtrlF10Exam", normalized);
                 }
@@ -314,6 +317,7 @@ namespace Client.ViewModel
                 if (_shiftF10Exam != normalized)
                 {
                     _shiftF10Exam = normalized;
+                    Logger.Log($"[SettingsViewModel] ShiftF10Exam set to '{normalized}'.");
                     OnPropertyChanged(nameof(ShiftF10Exam));
                     Set("ShiftF10Exam", normalized);
                 }
@@ -329,6 +333,7 @@ namespace Client.ViewModel
                 if (_ctrlF11Exam != normalized)
                 {
                     _ctrlF11Exam = normalized;
+                    Logger.Log($"[SettingsViewModel] CtrlF11Exam set to '{normalized}'.");
                     OnPropertyChanged(nameof(CtrlF11Exam));
                     Set("CtrlF11Exam", normalized);
                 }
@@ -344,6 +349,7 @@ namespace Client.ViewModel
                 if (_shiftF11Exam != normalized)
                 {
                     _shiftF11Exam = normalized;
+                    Logger.Log($"[SettingsViewModel] ShiftF11Exam set to '{normalized}'.");
                     OnPropertyChanged(nameof(ShiftF11Exam));
                     Set("ShiftF11Exam", normalized);
                 }
@@ -359,6 +365,7 @@ namespace Client.ViewModel
                 if (_ctrlF12Exam != normalized)
                 {
                     _ctrlF12Exam = normalized;
+                    Logger.Log($"[SettingsViewModel] CtrlF12Exam set to '{normalized}'.");
                     OnPropertyChanged(nameof(CtrlF12Exam));
                     Set("CtrlF12Exam", normalized);
                 }
@@ -374,6 +381,7 @@ namespace Client.ViewModel
                 if (_shiftF12Exam != normalized)
                 {
                     _shiftF12Exam = normalized;
+                    Logger.Log($"[SettingsViewModel] ShiftF12Exam set to '{normalized}'.");
                     OnPropertyChanged(nameof(ShiftF12Exam));
                     Set("ShiftF12Exam", normalized);
                 }
@@ -382,6 +390,7 @@ namespace Client.ViewModel
 
         public void Load()
         {
+            Logger.Log("[SettingsViewModel] Loading settings.");
             var style = AppSettings.Get("ChatDisplayStyle", "Modern");
             _isOldSchoolMode = style == "OldSchool";
             if (double.TryParse(AppSettings.Get("MessageFontSize", "14"), out var size))
@@ -439,6 +448,7 @@ namespace Client.ViewModel
                 pic.Initials = _initials;
             }
             OnPropertyChanged(string.Empty);
+            Logger.Log("[SettingsViewModel] Settings loaded.");
         }
 
         private static string NormalizeExamValue(string? value)
@@ -462,18 +472,18 @@ namespace Client.ViewModel
             {
                 var validNames = BuildValidExamNameMap(availableOptions);
 
-                ValidateExamSelection(_shiftF9Exam, value => ShiftF9Exam = value, validNames);
-                ValidateExamSelection(_ctrlF9Exam, value => CtrlF9Exam = value, validNames);
-                ValidateExamSelection(_shiftF10Exam, value => ShiftF10Exam = value, validNames);
-                ValidateExamSelection(_ctrlF10Exam, value => CtrlF10Exam = value, validNames);
-                ValidateExamSelection(_shiftF11Exam, value => ShiftF11Exam = value, validNames);
-                ValidateExamSelection(_ctrlF11Exam, value => CtrlF11Exam = value, validNames);
-                ValidateExamSelection(_shiftF12Exam, value => ShiftF12Exam = value, validNames);
-                ValidateExamSelection(_ctrlF12Exam, value => CtrlF12Exam = value, validNames);
+                ValidateExamSelection(_shiftF9Exam, value => ShiftF9Exam = value, validNames, nameof(ShiftF9Exam));
+                ValidateExamSelection(_ctrlF9Exam, value => CtrlF9Exam = value, validNames, nameof(CtrlF9Exam));
+                ValidateExamSelection(_shiftF10Exam, value => ShiftF10Exam = value, validNames, nameof(ShiftF10Exam));
+                ValidateExamSelection(_ctrlF10Exam, value => CtrlF10Exam = value, validNames, nameof(CtrlF10Exam));
+                ValidateExamSelection(_shiftF11Exam, value => ShiftF11Exam = value, validNames, nameof(ShiftF11Exam));
+                ValidateExamSelection(_ctrlF11Exam, value => CtrlF11Exam = value, validNames, nameof(CtrlF11Exam));
+                ValidateExamSelection(_shiftF12Exam, value => ShiftF12Exam = value, validNames, nameof(ShiftF12Exam));
+                ValidateExamSelection(_ctrlF12Exam, value => CtrlF12Exam = value, validNames, nameof(CtrlF12Exam));
             }
-            catch
+            catch (Exception ex)
             {
-                // Ignore validation failures – settings remain unchanged if exam options cannot be loaded.
+                Logger.LogException("[SettingsViewModel] ValidateExamSelectionsInternal failed", ex);
             }
         }
 
@@ -511,7 +521,7 @@ namespace Client.ViewModel
             return map;
         }
 
-        private static void ValidateExamSelection(string currentValue, Action<string> setter, IReadOnlyDictionary<string, string> validNames)
+        private static void ValidateExamSelection(string currentValue, Action<string> setter, IReadOnlyDictionary<string, string> validNames, string propertyName)
         {
             if (setter is null)
             {
@@ -520,12 +530,14 @@ namespace Client.ViewModel
 
             if (string.IsNullOrWhiteSpace(currentValue))
             {
+                Logger.Log($"[SettingsViewModel] {propertyName} is empty during validation.");
                 return;
             }
 
             var lookupKey = NormalizeExamValue(currentValue);
             if (string.IsNullOrWhiteSpace(lookupKey))
             {
+                Logger.Log($"[SettingsViewModel] {propertyName} contains only whitespace. Clearing setting.");
                 setter(string.Empty);
                 return;
             }
@@ -534,11 +546,17 @@ namespace Client.ViewModel
             {
                 if (!string.Equals(currentValue, normalized, StringComparison.Ordinal))
                 {
+                    Logger.Log($"[SettingsViewModel] {propertyName} normalized from '{currentValue}' to '{normalized}'.");
                     setter(normalized);
+                }
+                else
+                {
+                    Logger.Log($"[SettingsViewModel] {propertyName} validated with value '{normalized}'.");
                 }
             }
             else
             {
+                Logger.Log($"[SettingsViewModel] {propertyName} value '{currentValue}' not found in available exam options. Clearing setting.");
                 setter(string.Empty);
             }
         }


### PR DESCRIPTION
## Summary
- rebuild the user settings exam shortcut section using grouped combo boxes bound to dynamic shortcut definitions
- ensure combo boxes list all exam options by description while still saving the exam name for the hotkeys
- add extensive logging in the user settings page and settings view model to help diagnose shortcut selection issues

## Testing
- Not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e1ffc9030c8324a26b2d10aee9b436