### PR TITLE
Fix exam shortcut bindings and defaults

### DIFF
--- a/Client/Pages/UserSettingsPage.xaml
+++ b/Client/Pages/UserSettingsPage.xaml
@@ -19,12 +19,7 @@
         </DataTemplate>
 
         <DataTemplate x:Key="ExamOptionTemplate" x:DataType="models:ExamOption">
-            <TextBlock>
-                <Run Text="{x:Bind DisplayLabel}"/>
-                <Run Text=" ("/>
-                <Run Text="{x:Bind Floor}"/>
-                <Run Text=")"/>
-            </TextBlock>
+            <TextBlock Text="{x:Bind DisplayLabel}"/>
         </DataTemplate>
     </Page.Resources>
     <ScrollViewer>

--- a/Client/Pages/UserSettingsPage.xaml.cs
+++ b/Client/Pages/UserSettingsPage.xaml.cs
@@ -32,18 +32,21 @@ namespace Client.Pages
             this.Loaded += UserSettingsPage_Loaded;
             this.Unloaded += UserSettingsPage_Unloaded;
             ViewModelSettings.Load();
+            Logger.Log($"[UserSettingsPage] Initialized with {ExamOptions.Count} cached exam option(s).");
             Debug.WriteLine($"[UserSettingsPage] ViewModel instance: {ViewModelSettings.GetHashCode()}");
         }
 
         private async void UserSettingsPage_Loaded(object sender, RoutedEventArgs e)
         {
             App.ChatService.ExamOptionsUpdated += ChatService_ExamOptionsUpdated;
+            Logger.Log("[UserSettingsPage] Page loaded.");
             await RefreshExamOptionsAsync();
         }
 
         private void UserSettingsPage_Unloaded(object sender, RoutedEventArgs e)
         {
             App.ChatService.ExamOptionsUpdated -= ChatService_ExamOptionsUpdated;
+            Logger.Log("[UserSettingsPage] Page unloaded.");
         }
 
         private void ChatService_ExamOptionsUpdated(IEnumerable<ExamOption> options)
@@ -96,6 +99,7 @@ namespace Client.Pages
 
             ExamOption.Save(ExamOptions);
             ViewModelSettings.ValidateExamSelections(ExamOptions);
+            Logger.Log($"[UserSettingsPage] Exam options updated. Count={ExamOptions.Count}.");
         }
         private void Back_Click(object sender, RoutedEventArgs e)
         {

--- a/Client/Services/HotKeyService.cs
+++ b/Client/Services/HotKeyService.cs
@@ -213,11 +213,66 @@ namespace Client.Services
             eyeCombo.SelectedIndex = 0;
 
             var floorCombo = new ComboBox { Width = 600, ItemsSource = rooms };
+            var commentBox = new TextBox { PlaceholderText = "Commentaire", Width = 600 };
+            string? appliedAnnotation = string.Empty;
+
+            void ApplyExamDefaults(ExamOption? option)
+            {
+                if (option is null)
+                {
+                    return;
+                }
+
+                var floor = option.Floor?.Trim();
+                if (!string.IsNullOrWhiteSpace(floor))
+                {
+                    var existing = rooms.FirstOrDefault(r =>
+                        string.Equals(r, floor, StringComparison.OrdinalIgnoreCase));
+                    if (existing is null)
+                    {
+                        rooms.Add(floor);
+                        existing = floor;
+                    }
+
+                    floorCombo.SelectedItem = existing;
+                }
+
+                if (!string.IsNullOrWhiteSpace(option.Annotation))
+                {
+                    if (string.IsNullOrWhiteSpace(commentBox.Text) ||
+                        string.Equals(commentBox.Text, appliedAnnotation, StringComparison.Ordinal))
+                    {
+                        commentBox.Text = option.Annotation;
+                        appliedAnnotation = option.Annotation;
+                    }
+                }
+                else if (!string.IsNullOrWhiteSpace(appliedAnnotation) &&
+                         string.Equals(commentBox.Text, appliedAnnotation, StringComparison.Ordinal))
+                {
+                    commentBox.Text = string.Empty;
+                    appliedAnnotation = string.Empty;
+                }
+            }
+
+            commentBox.TextChanged += (s, _) =>
+            {
+                if (!string.Equals(commentBox.Text, appliedAnnotation, StringComparison.Ordinal))
+                {
+                    appliedAnnotation = commentBox.Text;
+                }
+            };
+
             var examOpt = options.FirstOrDefault(o =>
                 string.Equals(o?.Name?.Trim(), sanitizedExamName, StringComparison.OrdinalIgnoreCase));
-            if (examOpt != null && rooms.Contains(examOpt.Floor))
-                floorCombo.SelectedItem = examOpt.Floor;
-            var commentBox = new TextBox { PlaceholderText = "Commentaire", Width = 600 };
+            ApplyExamDefaults(examOpt);
+
+            examCombo.SelectionChanged += (s, _) =>
+            {
+                if (examCombo.SelectedItem is ExamOption selected)
+                {
+                    ApplyExamDefaults(selected);
+                }
+            };
 
             // Extract patient name either from parameter or active window title
             if (string.IsNullOrWhiteSpace(patientName))

--- a/Client/ViewModel/SettingsViewModel.cs
+++ b/Client/ViewModel/SettingsViewModel.cs
@@ -269,6 +269,7 @@ namespace Client.ViewModel
                 if (_ctrlF9Exam != normalized)
                 {
                     _ctrlF9Exam = normalized;
+                    Logger.Log($"[SettingsViewModel] CtrlF9Exam set to '{normalized}'.");
                     OnPropertyChanged(nameof(CtrlF9Exam));
                     Set("CtrlF9Exam", normalized);
                 }
@@ -284,6 +285,7 @@ namespace Client.ViewModel
                 if (_shiftF9Exam != normalized)
                 {
                     _shiftF9Exam = normalized;
+                    Logger.Log($"[SettingsViewModel] ShiftF9Exam set to '{normalized}'.");
                     OnPropertyChanged(nameof(ShiftF9Exam));
                     Set("ShiftF9Exam", normalized);
                 }
@@ -299,6 +301,7 @@ namespace Client.ViewModel
                 if (_ctrlF10Exam != normalized)
                 {
                     _ctrlF10Exam = normalized;
+                    Logger.Log($"[SettingsViewModel] CtrlF10Exam set to '{normalized}'.");
                     OnPropertyChanged(nameof(CtrlF10Exam));
                     Set("CtrlF10Exam", normalized);
                 }
@@ -314,6 +317,7 @@ namespace Client.ViewModel
                 if (_shiftF10Exam != normalized)
                 {
                     _shiftF10Exam = normalized;
+                    Logger.Log($"[SettingsViewModel] ShiftF10Exam set to '{normalized}'.");
                     OnPropertyChanged(nameof(ShiftF10Exam));
                     Set("ShiftF10Exam", normalized);
                 }
@@ -329,6 +333,7 @@ namespace Client.ViewModel
                 if (_ctrlF11Exam != normalized)
                 {
                     _ctrlF11Exam = normalized;
+                    Logger.Log($"[SettingsViewModel] CtrlF11Exam set to '{normalized}'.");
                     OnPropertyChanged(nameof(CtrlF11Exam));
                     Set("CtrlF11Exam", normalized);
                 }
@@ -344,6 +349,7 @@ namespace Client.ViewModel
                 if (_shiftF11Exam != normalized)
                 {
                     _shiftF11Exam = normalized;
+                    Logger.Log($"[SettingsViewModel] ShiftF11Exam set to '{normalized}'.");
                     OnPropertyChanged(nameof(ShiftF11Exam));
                     Set("ShiftF11Exam", normalized);
                 }
@@ -359,6 +365,7 @@ namespace Client.ViewModel
                 if (_ctrlF12Exam != normalized)
                 {
                     _ctrlF12Exam = normalized;
+                    Logger.Log($"[SettingsViewModel] CtrlF12Exam set to '{normalized}'.");
                     OnPropertyChanged(nameof(CtrlF12Exam));
                     Set("CtrlF12Exam", normalized);
                 }
@@ -374,6 +381,7 @@ namespace Client.ViewModel
                 if (_shiftF12Exam != normalized)
                 {
                     _shiftF12Exam = normalized;
+                    Logger.Log($"[SettingsViewModel] ShiftF12Exam set to '{normalized}'.");
                     OnPropertyChanged(nameof(ShiftF12Exam));
                     Set("ShiftF12Exam", normalized);
                 }
@@ -526,6 +534,7 @@ namespace Client.ViewModel
             var lookupKey = NormalizeExamValue(currentValue);
             if (string.IsNullOrWhiteSpace(lookupKey))
             {
+                Logger.Log($"[SettingsViewModel] Clearing exam shortcut because value '{currentValue}' is whitespace.");
                 setter(string.Empty);
                 return;
             }
@@ -534,11 +543,13 @@ namespace Client.ViewModel
             {
                 if (!string.Equals(currentValue, normalized, StringComparison.Ordinal))
                 {
+                    Logger.Log($"[SettingsViewModel] Normalized exam shortcut from '{currentValue}' to '{normalized}'.");
                     setter(normalized);
                 }
             }
             else
             {
+                Logger.Log($"[SettingsViewModel] Exam shortcut value '{currentValue}' not found. Clearing selection.");
                 setter(string.Empty);
             }
         }


### PR DESCRIPTION
## Summary
- show exam options using their description-only template on the user settings shortcut combos
- add logging around shortcut settings updates and option refreshes for easier troubleshooting
- default the patient dialog to the selected exam’s room and annotation, adding missing rooms automatically

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ffc9030c8324a26b2d10aee9b436