### PR TITLE
Broaden exam option fallback names

### DIFF
--- a/Client/Models/ExamOption.cs
+++ b/Client/Models/ExamOption.cs
@@ -219,11 +219,38 @@ namespace Client.Models
         {
             Name = Name;
             Description = Description;
-            Color = Color;
             CodeMSG = CodeMSG;
             Annotation = Annotation;
             EndAnnotation = EndAnnotation;
             Floor = Floor;
+            Color = Color;
+
+            if (string.IsNullOrWhiteSpace(Name))
+            {
+                // Certains environnements ne renseignent ni le nom ni la description. On essaye alors
+                // de dériver un identifiant stable à partir des autres champs disponibles pour que les
+                // ComboBox puissent toujours fournir un SelectedValue exploitable.
+                var fallback = new[]
+                {
+                    Description,
+                    CodeMSG,
+                    Annotation,
+                    EndAnnotation,
+                    Floor
+                }.FirstOrDefault(candidate => !string.IsNullOrWhiteSpace(candidate));
+
+                if (string.IsNullOrWhiteSpace(fallback))
+                {
+                    fallback = Index != 0 ? $"Examen {Index}" : "Examen";
+                }
+
+                Name = fallback;
+            }
+
+            if (string.IsNullOrWhiteSpace(Description))
+            {
+                Description = Name;
+            }
         }
     }
 }

--- a/Client/ViewModel/SettingsViewModel.cs
+++ b/Client/ViewModel/SettingsViewModel.cs
@@ -505,6 +505,8 @@ namespace Client.ViewModel
                     continue;
                 }
 
+                option.Normalize();
+
                 var name = NormalizeExamValue(option.Name);
                 if (string.IsNullOrWhiteSpace(name))
                 {
@@ -512,15 +514,25 @@ namespace Client.ViewModel
                 }
 
                 map[name] = name;
-
-                var description = NormalizeExamValue(option.Description);
-                if (!string.IsNullOrEmpty(description) && !map.ContainsKey(description))
-                {
-                    map[description] = name;
-                }
+                TryRegisterAlias(map, option.Description, name);
+                TryRegisterAlias(map, option.CodeMSG, name);
+                TryRegisterAlias(map, option.Annotation, name);
+                TryRegisterAlias(map, option.EndAnnotation, name);
+                TryRegisterAlias(map, option.Floor, name);
             }
 
             return map;
+        }
+
+        private static void TryRegisterAlias(IDictionary<string, string> map, string? value, string normalizedName)
+        {
+            var alias = NormalizeExamValue(value);
+            if (string.IsNullOrWhiteSpace(alias) || map.ContainsKey(alias))
+            {
+                return;
+            }
+
+            map[alias] = normalizedName;
         }
 
         private static void ValidateExamSelection(string currentValue, Action<string> setter, IReadOnlyDictionary<string, string> validNames, string propertyName)


### PR DESCRIPTION
## Summary
- derive a non-empty exam name from any available metadata so combo boxes always get a SelectedValue
- expand exam shortcut validation to accept descriptions, codes or annotations as aliases for the normalized name

## Testing
- dotnet build WebApplication1.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e210c112a08324ba0e206935d39b63