### PR TITLE
Handle missing SignalR connection when persisting user settings

### DIFF
--- a/Client/Helpers/AppSettings.cs
+++ b/Client/Helpers/AppSettings.cs
@@ -101,14 +101,14 @@ namespace Client.Helpers
             var safeValue = value ?? string.Empty;
             _settings[key] = JsonValue.Create(safeValue);
             Save();
-            SettingsChanged?.Invoke();
+            NotifySettingsChanged();
         }
 
         public static void SetObject<T>(string key, T value)
         {
             _settings[key] = JsonSerializer.SerializeToNode(value);
             Save();
-            SettingsChanged?.Invoke();
+            NotifySettingsChanged();
         }
 
         public static string Export()
@@ -158,6 +158,27 @@ namespace Client.Helpers
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"❌ Sauvegarde échouée : {ex.Message}");
+            }
+        }
+
+        private static void NotifySettingsChanged()
+        {
+            var handlers = SettingsChanged;
+            if (handlers is null)
+            {
+                return;
+            }
+
+            foreach (var handler in handlers.GetInvocationList())
+            {
+                try
+                {
+                    (handler as Action)?.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogException("[AppSettings] SettingsChanged handler failed", ex);
+                }
             }
         }
 

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -974,7 +974,10 @@ namespace Client.Services
         public async Task SaveUserSettingsAsync(string username, string json)
         {
             if (Connection is null || Connection.State != HubConnectionState.Connected)
-                throw new InvalidOperationException("Connexion SignalR non établie.");
+            {
+                Debug.WriteLine("SaveUserSettingsAsync ignoré : connexion SignalR indisponible.");
+                return;
+            }
 
             try
             {


### PR DESCRIPTION
## Summary
- guard AppSettings change notifications so a faulty subscriber cannot crash the app
- avoid throwing when saving settings without an active SignalR connection and log the skip instead

## Testing
- not run (UI solution not runnable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e22be7d1bc8324b660d8f005501d4d