### PR TITLE
Add persistent IDs to exam options

### DIFF
--- a/Client/Models/ExamOption.cs
+++ b/Client/Models/ExamOption.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
@@ -11,6 +12,7 @@ namespace Client.Models
     public class ExamOption : INotifyPropertyChanged
     {
         private int _index;
+        private string _id = Guid.NewGuid().ToString();
         private string _name = string.Empty;
         private string _color = string.Empty;
         private string _codeMSG = string.Empty;
@@ -28,6 +30,25 @@ namespace Client.Models
                 {
                     _index = value;
                     OnPropertyChanged(nameof(Index));
+                }
+            }
+        }
+
+        public string Id
+        {
+            get => _id;
+            set
+            {
+                var sanitized = value?.Trim();
+                if (string.IsNullOrWhiteSpace(sanitized))
+                {
+                    sanitized = Guid.NewGuid().ToString();
+                }
+
+                if (_id != sanitized)
+                {
+                    _id = sanitized;
+                    OnPropertyChanged(nameof(Id));
                 }
             }
         }
@@ -217,6 +238,13 @@ namespace Client.Models
 
         public void Normalize()
         {
+            if (string.IsNullOrWhiteSpace(_id))
+            {
+                _id = Guid.NewGuid().ToString();
+                OnPropertyChanged(nameof(Id));
+            }
+
+            Id = Id;
             Name = Name;
             Description = Description;
             CodeMSG = CodeMSG;
@@ -252,5 +280,36 @@ namespace Client.Models
                 Description = Name;
             }
         }
+
+        public static ExamOption? FindByIdentifier(IEnumerable<ExamOption>? options, string? identifier)
+        {
+            if (options is null)
+            {
+                return null;
+            }
+
+            var normalized = NormalizeIdentifier(identifier);
+            if (string.IsNullOrEmpty(normalized))
+            {
+                return null;
+            }
+
+            return options.FirstOrDefault(option =>
+                       string.Equals(NormalizeIdentifier(option.Id), normalized, StringComparison.OrdinalIgnoreCase))
+                   ?? options.FirstOrDefault(option =>
+                       string.Equals(NormalizeIdentifier(option.Name), normalized, StringComparison.OrdinalIgnoreCase))
+                   ?? options.FirstOrDefault(option =>
+                       string.Equals(NormalizeIdentifier(option.Description), normalized, StringComparison.OrdinalIgnoreCase))
+                   ?? options.FirstOrDefault(option =>
+                       string.Equals(NormalizeIdentifier(option.CodeMSG), normalized, StringComparison.OrdinalIgnoreCase))
+                   ?? options.FirstOrDefault(option =>
+                       string.Equals(NormalizeIdentifier(option.Annotation), normalized, StringComparison.OrdinalIgnoreCase))
+                   ?? options.FirstOrDefault(option =>
+                       string.Equals(NormalizeIdentifier(option.EndAnnotation), normalized, StringComparison.OrdinalIgnoreCase))
+                   ?? options.FirstOrDefault(option =>
+                       string.Equals(NormalizeIdentifier(option.Floor), normalized, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public static string NormalizeIdentifier(string? value) => string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
     }
 }

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -426,9 +426,9 @@ namespace Client.Pages
                 {
                     var name = text.Substring(exam.CodeMSG.Length).Trim();
                     if (string.IsNullOrEmpty(name))
-                        _ = HotKeyService.ShowPatientDialogAsync(exam.Name);
+                        _ = HotKeyService.ShowPatientDialogAsync(exam.Id);
                     else
-                        _ = HotKeyService.DeclarePatientAsync(exam.Name, name);
+                        _ = HotKeyService.DeclarePatientAsync(exam.Id, name);
                     InputBox.Text = string.Empty;
                     return;
                 }
@@ -495,7 +495,7 @@ namespace Client.Pages
                     var title = TestTitles[Random.Shared.Next(TestTitles.Length)];
                     var fullName = $"{title} {lastName} {firstName}".Trim();
 
-                    await HotKeyService.DeclarePatientAsync(exam.Name, fullName);
+                    await HotKeyService.DeclarePatientAsync(exam.Id, fullName);
                 }
             }
             catch (Exception ex)

--- a/Client/Pages/UserSettingsPage.xaml
+++ b/Client/Pages/UserSettingsPage.xaml
@@ -177,7 +177,7 @@
                                                         <ComboBox Width="150"
                                                                   ItemsSource="{x:Bind AvailableExamOptions, Mode=OneWay}"
                                                                   ItemTemplate="{StaticResource ExamOptionTemplate}"
-                                                                  SelectedValuePath="Name"
+                                                                  SelectedValuePath="Id"
                                                                   SelectedValue="{x:Bind SelectedExam, Mode=TwoWay}" />
                                                     </StackPanel>
                                                 </DataTemplate>

--- a/Client/Pages/UserSettingsPage.xaml.cs
+++ b/Client/Pages/UserSettingsPage.xaml.cs
@@ -409,7 +409,7 @@ namespace Client.Pages
             OnPropertyChanged(nameof(SelectedExam));
         }
 
-        private static string NormalizeExamValue(string? value) => string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
+        private static string NormalizeExamValue(string? value) => ExamOption.NormalizeIdentifier(value);
     }
 }
 

--- a/Client/Services/HotKeyService.cs
+++ b/Client/Services/HotKeyService.cs
@@ -177,7 +177,7 @@ namespace Client.Services
             }, IntPtr.Zero);
             return foundTitle;
         }
-        public static async Task ShowPatientDialogAsync(string examName, string? patientName = null)
+        public static async Task ShowPatientDialogAsync(string? examIdentifier, string? patientName = null)
         {
             var options = ExamOption.Load();
             var rooms = RoomList.Load();
@@ -197,13 +197,12 @@ namespace Client.Services
                 grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
 
             var nameBox = new TextBox { PlaceholderText = "Nom du patient" ,Width = 600};
-            var sanitizedExamName = examName?.Trim();
+            var sanitizedExamIdentifier = examIdentifier?.Trim();
             var examCombo = new ComboBox
             {
                 ItemsSource = options,
                 DisplayMemberPath = nameof(ExamOption.DisplayLabel),
-                SelectedValuePath = nameof(ExamOption.Name),
-                SelectedValue = sanitizedExamName,
+                SelectedValuePath = nameof(ExamOption.Id),
                 Width = 600
             };
             var eyeCombo = new ComboBox { Width = 600 };
@@ -262,8 +261,17 @@ namespace Client.Services
                 }
             };
 
-            var examOpt = options.FirstOrDefault(o =>
-                string.Equals(o?.Name?.Trim(), sanitizedExamName, StringComparison.OrdinalIgnoreCase));
+            var examOpt = ExamOption.FindByIdentifier(options, sanitizedExamIdentifier);
+            if (examOpt is not null)
+            {
+                examCombo.SelectedValue = examOpt.Id;
+            }
+            else if (!string.IsNullOrEmpty(sanitizedExamIdentifier) &&
+                     options.Any(o => string.Equals(o.Id, sanitizedExamIdentifier, StringComparison.OrdinalIgnoreCase)))
+            {
+                examCombo.SelectedValue = sanitizedExamIdentifier;
+            }
+
             ApplyExamDefaults(examOpt);
 
             examCombo.SelectionChanged += (s, _) =>
@@ -315,8 +323,9 @@ namespace Client.Services
                 PatientStringHelper.ExtractInfoFromInput(inputName,
                     out var titleBox, out var lastNameBox, out var firstNameBox);
 
-                var selectedExam = examCombo.SelectedValue as string ?? string.Empty;
-                var opt = options.FirstOrDefault(o => o.Name == selectedExam);
+                var selectedExamId = examCombo.SelectedValue as string ?? string.Empty;
+                var opt = ExamOption.FindByIdentifier(options, selectedExamId);
+                var resolvedExamName = opt?.Name ?? sanitizedExamIdentifier ?? string.Empty;
 
                 var patient = new Patient
                 {
@@ -325,7 +334,7 @@ namespace Client.Services
                     Title = titleBox,
                     LastName = lastNameBox,
                     FirstName = firstNameBox,
-                    Exams = selectedExam,
+                    Exams = resolvedExamName,
                     Eye = (eyeCombo.SelectedItem as ComboBoxItem)?.Content as string ?? string.Empty,
                     Annotation = string.IsNullOrWhiteSpace(commentBox.Text) ? opt?.Annotation ?? string.Empty : commentBox.Text.Trim(),
                     Position = floorCombo.SelectedItem as string ?? string.Empty,
@@ -365,12 +374,13 @@ namespace Client.Services
                 grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
 
             var nameBox = new TextBox { Width = 600, Text = $"{patient.Title} {patient.LastName} {patient.FirstName}".Trim() };
+            var selectedExam = ExamOption.FindByIdentifier(options, patient.Exams);
             var examCombo = new ComboBox
             {
                 ItemsSource = options,
-                DisplayMemberPath = "Name",
-                SelectedValuePath = "Name",
-                SelectedValue = patient.Exams,
+                DisplayMemberPath = nameof(ExamOption.DisplayLabel),
+                SelectedValuePath = nameof(ExamOption.Id),
+                SelectedValue = selectedExam?.Id,
                 Width = 600
             };
             var eyeCombo = new ComboBox { Width = 600 };
@@ -400,13 +410,13 @@ namespace Client.Services
                 PatientStringHelper.ExtractInfoFromInput(inputName,
                     out var titleBox, out var lastNameBox, out var firstNameBox);
 
-                var selectedExam = examCombo.SelectedValue as string ?? string.Empty;
-                var opt = options.FirstOrDefault(o => o.Name == selectedExam);
+                var selectedExamId = examCombo.SelectedValue as string ?? string.Empty;
+                var opt = ExamOption.FindByIdentifier(options, selectedExamId);
 
                 patient.Title = titleBox;
                 patient.LastName = lastNameBox;
                 patient.FirstName = firstNameBox;
-                patient.Exams = selectedExam;
+                patient.Exams = opt?.Name ?? patient.Exams;
                 patient.Eye = (eyeCombo.SelectedItem as ComboBoxItem)?.Content as string ?? string.Empty;
                 patient.Annotation = string.IsNullOrWhiteSpace(commentBox.Text) ? opt?.Annotation ?? string.Empty : commentBox.Text.Trim();
                 patient.Position = floorCombo.SelectedItem as string ?? string.Empty;
@@ -459,13 +469,15 @@ namespace Client.Services
             };
             await dialog.ShowAsync();
         }
-        public static async Task DeclarePatientAsync(string examName, string patientName)
+        public static async Task DeclarePatientAsync(string examIdentifier, string patientName)
         {
             var options = ExamOption.Load();
-            var opt = options.FirstOrDefault(o => o.Name.Equals(examName, StringComparison.OrdinalIgnoreCase));
+            var opt = ExamOption.FindByIdentifier(options, examIdentifier);
 
             PatientStringHelper.ExtractInfoFromInput(patientName.Trim(),
                 out var title, out var lastName, out var firstName);
+
+            var resolvedExamName = opt?.Name ?? examIdentifier;
 
             var patient = new Patient
             {
@@ -474,7 +486,7 @@ namespace Client.Services
                 Title = title,
                 LastName = lastName,
                 FirstName = firstName,
-                Exams = examName,
+                Exams = resolvedExamName ?? string.Empty,
                 Eye = "ODG",
                 Annotation = opt?.Annotation ?? string.Empty,
                 Position = opt?.Floor ?? string.Empty,

--- a/Client/ViewModel/SettingsViewModel.cs
+++ b/Client/ViewModel/SettingsViewModel.cs
@@ -453,10 +453,7 @@ namespace Client.ViewModel
             Logger.Log("[SettingsViewModel] Settings loaded.");
         }
 
-        private static string NormalizeExamValue(string? value)
-        {
-            return string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
-        }
+        private static string NormalizeExamValue(string? value) => ExamOption.NormalizeIdentifier(value);
 
         public void ValidateExamSelections(IEnumerable<ExamOption> availableOptions)
         {
@@ -472,16 +469,16 @@ namespace Client.ViewModel
         {
             try
             {
-                var validNames = BuildValidExamNameMap(availableOptions);
+                var validIdentifiers = BuildValidExamIdentifierMap(availableOptions);
 
-                ValidateExamSelection(_shiftF9Exam, value => ShiftF9Exam = value, validNames, nameof(ShiftF9Exam));
-                ValidateExamSelection(_ctrlF9Exam, value => CtrlF9Exam = value, validNames, nameof(CtrlF9Exam));
-                ValidateExamSelection(_shiftF10Exam, value => ShiftF10Exam = value, validNames, nameof(ShiftF10Exam));
-                ValidateExamSelection(_ctrlF10Exam, value => CtrlF10Exam = value, validNames, nameof(CtrlF10Exam));
-                ValidateExamSelection(_shiftF11Exam, value => ShiftF11Exam = value, validNames, nameof(ShiftF11Exam));
-                ValidateExamSelection(_ctrlF11Exam, value => CtrlF11Exam = value, validNames, nameof(CtrlF11Exam));
-                ValidateExamSelection(_shiftF12Exam, value => ShiftF12Exam = value, validNames, nameof(ShiftF12Exam));
-                ValidateExamSelection(_ctrlF12Exam, value => CtrlF12Exam = value, validNames, nameof(CtrlF12Exam));
+                ValidateExamSelection(_shiftF9Exam, value => ShiftF9Exam = value, validIdentifiers, nameof(ShiftF9Exam));
+                ValidateExamSelection(_ctrlF9Exam, value => CtrlF9Exam = value, validIdentifiers, nameof(CtrlF9Exam));
+                ValidateExamSelection(_shiftF10Exam, value => ShiftF10Exam = value, validIdentifiers, nameof(ShiftF10Exam));
+                ValidateExamSelection(_ctrlF10Exam, value => CtrlF10Exam = value, validIdentifiers, nameof(CtrlF10Exam));
+                ValidateExamSelection(_shiftF11Exam, value => ShiftF11Exam = value, validIdentifiers, nameof(ShiftF11Exam));
+                ValidateExamSelection(_ctrlF11Exam, value => CtrlF11Exam = value, validIdentifiers, nameof(CtrlF11Exam));
+                ValidateExamSelection(_shiftF12Exam, value => ShiftF12Exam = value, validIdentifiers, nameof(ShiftF12Exam));
+                ValidateExamSelection(_ctrlF12Exam, value => CtrlF12Exam = value, validIdentifiers, nameof(CtrlF12Exam));
             }
             catch (Exception ex)
             {
@@ -489,7 +486,7 @@ namespace Client.ViewModel
             }
         }
 
-        private static Dictionary<string, string> BuildValidExamNameMap(IEnumerable<ExamOption> options)
+        private static Dictionary<string, string> BuildValidExamIdentifierMap(IEnumerable<ExamOption> options)
         {
             var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
@@ -507,32 +504,33 @@ namespace Client.ViewModel
 
                 option.Normalize();
 
-                var name = NormalizeExamValue(option.Name);
-                if (string.IsNullOrWhiteSpace(name))
+                var identifier = NormalizeExamValue(option.Id);
+                if (string.IsNullOrWhiteSpace(identifier))
                 {
                     continue;
                 }
 
-                map[name] = name;
-                TryRegisterAlias(map, option.Description, name);
-                TryRegisterAlias(map, option.CodeMSG, name);
-                TryRegisterAlias(map, option.Annotation, name);
-                TryRegisterAlias(map, option.EndAnnotation, name);
-                TryRegisterAlias(map, option.Floor, name);
+                map[identifier] = identifier;
+                TryRegisterAlias(map, option.Name, identifier);
+                TryRegisterAlias(map, option.Description, identifier);
+                TryRegisterAlias(map, option.CodeMSG, identifier);
+                TryRegisterAlias(map, option.Annotation, identifier);
+                TryRegisterAlias(map, option.EndAnnotation, identifier);
+                TryRegisterAlias(map, option.Floor, identifier);
             }
 
             return map;
         }
 
-        private static void TryRegisterAlias(IDictionary<string, string> map, string? value, string normalizedName)
+        private static void TryRegisterAlias(IDictionary<string, string> map, string? value, string normalizedIdentifier)
         {
             var alias = NormalizeExamValue(value);
-            if (string.IsNullOrWhiteSpace(alias) || map.ContainsKey(alias))
+            if (string.IsNullOrWhiteSpace(alias) || map.ContainsKey(alias) || string.IsNullOrWhiteSpace(normalizedIdentifier))
             {
                 return;
             }
 
-            map[alias] = normalizedName;
+            map[alias] = normalizedIdentifier;
         }
 
         private static void ValidateExamSelection(string currentValue, Action<string> setter, IReadOnlyDictionary<string, string> validNames, string propertyName)

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -663,7 +664,7 @@ namespace ChatServeur
             var changed = new List<Patient>();
             foreach (var p in patients)
             {
-                var opt = opts.SingleOrDefault(o => o.Name == p.Exams);
+                var opt = opts.FirstOrDefault(o => string.Equals(o.Name, p.Exams, StringComparison.OrdinalIgnoreCase));
                 if (opt != null && p.Colors != opt.Color)
                 {
                     p.Colors = opt.Color;
@@ -699,7 +700,7 @@ namespace ChatServeur
             var changed = new List<Patient>();
             foreach (var p in patients)
             {
-                var opt = opts.SingleOrDefault(o => o.Name == p.Exams);
+                var opt = opts.FirstOrDefault(o => string.Equals(o.Name, p.Exams, StringComparison.OrdinalIgnoreCase));
                 if (opt != null && p.Colors != opt.Color)
                 {
                     p.Colors = opt.Color;

--- a/Serveur/Models/ExamOption.cs
+++ b/Serveur/Models/ExamOption.cs
@@ -1,7 +1,10 @@
+using System;
+
 namespace ChatServeur
 {
     public class ExamOption
     {
+        public string Id { get; set; } = Guid.NewGuid().ToString();
         public int Index { get; set; }
         public string Name { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;


### PR DESCRIPTION
## Summary
- add unique identifier support to exam options on both client and server models
- update hotkey dialogs, chat shortcuts, and settings bindings to rely on the new identifiers while keeping existing aliases working
- make server-side patient color updates resilient when exam names are duplicated

## Testing
- dotnet build WebApplication1.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e24984953c83248e460359778202f7