### PR TITLE
Use fixed password for protected system options

### DIFF
--- a/Client/Pages/SystemPage.xaml
+++ b/Client/Pages/SystemPage.xaml
@@ -7,12 +7,15 @@
 		<StackPanel Padding="20" Spacing="20">
 			<Button Content="← Retour" Click="Back_Click" HorizontalAlignment="Left"/>
 			<TextBlock Text="Système" FontSize="24" FontWeight="Bold"/>
-			<Border CornerRadius="8" Padding="20">
+                        <Border CornerRadius="8" Padding="20">
                                 <StackPanel Spacing="10">
                                         <TextBlock Text="Nom de la salle"/>
-                                        <TextBox x:Name="RoomBox" Text="{x:Bind RoomName, Mode=TwoWay}"/>
-                                        <ToggleSwitch x:Name="TimeModSwitch" Header="Afficher la modification du temps" IsOn="{x:Bind ShowTimeModification, Mode=TwoWay}"/>
-                                        <ToggleSwitch x:Name="ReminderPageSwitch" Header="Afficher la page de rappel" IsOn="{x:Bind ShowReminderPage, Mode=TwoWay}"/>
+                                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                                                <TextBox x:Name="RoomBox" Text="{x:Bind RoomName, Mode=TwoWay}" IsReadOnly="True" IsTabStop="False"/>
+                                                <Button Grid.Column="1" Content="Renommer" Click="RenameRoom_Click"/>
+                                        </Grid>
+                                        <ToggleSwitch x:Name="TimeModSwitch" Header="Afficher la modification du temps" IsOn="{x:Bind ShowTimeModification, Mode=TwoWay}" Toggled="TimeModSwitch_Toggled"/>
+                                        <ToggleSwitch x:Name="ReminderPageSwitch" Header="Afficher la page de rappel" IsOn="{x:Bind ShowReminderPage, Mode=TwoWay}" Toggled="ReminderPageSwitch_Toggled"/>
                                         <TextBlock Text="Utilisateur par défaut"/>
                                         <ComboBox ItemsSource="{x:Bind Users}" SelectedItem="{x:Bind DefaultUser, Mode=TwoWay}"/>
                                         <ToggleSwitch Header="Se connecter avec le dernier utilisateur" IsOn="{x:Bind ConnectLastUser, Mode=TwoWay}"/>

--- a/Client/Pages/SystemPage.xaml.cs
+++ b/Client/Pages/SystemPage.xaml.cs
@@ -4,12 +4,19 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Client.Helpers;
 
 namespace Client.Pages
 {
     public sealed partial class SystemPage : Page
     {
+        private const string SettingsPassword = "901027";
+        private readonly MachineConfig _config;
+        private bool _isLoaded;
+        private bool _suppressTimeToggle;
+        private bool _suppressReminderToggle;
+
         public string RoomName { get; set; } = string.Empty;
         public bool ShowTimeModification { get; set; }
         public bool ShowReminderPage { get; set; }
@@ -21,12 +28,12 @@ namespace Client.Pages
         {
 
             this.InitializeComponent();
-            var cfg = MachineConfig.Load();
-            ShowTimeModification = cfg.ShowTimeModification;
-            ShowReminderPage = cfg.ShowReminderPage;
-            RoomName = cfg.RoomName;
-            DefaultUser = cfg.DefaultUser;
-            ConnectLastUser = cfg.ConnectLastUser;
+            _config = MachineConfig.Load();
+            ShowTimeModification = _config.ShowTimeModification;
+            ShowReminderPage = _config.ShowReminderPage;
+            RoomName = _config.RoomName;
+            DefaultUser = _config.DefaultUser;
+            ConnectLastUser = _config.ConnectLastUser;
 
             var folder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat");
             if (Directory.Exists(folder))
@@ -38,6 +45,12 @@ namespace Client.Pages
                 Users.Add(DefaultUser);
 
             DataContext = this;
+            Loaded += SystemPage_Loaded;
+        }
+
+        private void SystemPage_Loaded(object sender, RoutedEventArgs e)
+        {
+            _isLoaded = true;
         }
 
         private void Back_Click(object sender, RoutedEventArgs e)
@@ -48,15 +61,202 @@ namespace Client.Pages
 
         private async void Save_Click(object sender, RoutedEventArgs e)
         {
-            var cfg = MachineConfig.Load();
-            cfg.RoomName = RoomName;
-            cfg.ShowTimeModification = ShowTimeModification;
-            cfg.ShowReminderPage = ShowReminderPage;
-            cfg.DefaultUser = DefaultUser;
-            cfg.ConnectLastUser = ConnectLastUser;
-            MachineConfig.Save(cfg);
+            _config.RoomName = RoomName;
+            _config.ShowTimeModification = ShowTimeModification;
+            _config.ShowReminderPage = ShowReminderPage;
+            _config.DefaultUser = DefaultUser;
+            _config.ConnectLastUser = ConnectLastUser;
+            MachineConfig.Save(_config);
             App.ChatService.RoomName = RoomName;
             await App.ChatService.UpdateRoomNameAsync(RoomName);
+        }
+
+        private async void RenameRoom_Click(object sender, RoutedEventArgs e)
+        {
+            if (!await EnsurePasswordAsync(sender as FrameworkElement))
+                return;
+
+            var xamlRoot = GetXamlRoot(sender as FrameworkElement);
+            if (xamlRoot is null)
+                return;
+
+            var nameBox = new TextBox
+            {
+                Text = RoomName,
+                PlaceholderText = "Nouveau nom de la salle"
+            };
+
+            var dialog = new ContentDialog
+            {
+                Title = "Renommer l'ordinateur",
+                PrimaryButtonText = "Valider",
+                CloseButtonText = "Annuler",
+                DefaultButton = ContentDialogButton.Primary,
+                Content = nameBox,
+                XamlRoot = xamlRoot
+            };
+
+            dialog.PrimaryButtonClick += async (s, args) =>
+            {
+                var trimmed = nameBox.Text.Trim();
+                if (string.IsNullOrEmpty(trimmed))
+                {
+                    args.Cancel = true;
+                    await ShowInfoDialogAsync("Nom invalide", "Le nom de la salle ne peut pas être vide.", xamlRoot);
+                    return;
+                }
+
+                RoomName = trimmed;
+                _config.RoomName = RoomName;
+                RoomBox.Text = RoomName;
+            };
+
+            await dialog.ShowAsync();
+        }
+
+        private async void TimeModSwitch_Toggled(object sender, RoutedEventArgs e)
+        {
+            if (!_isLoaded || _suppressTimeToggle)
+                return;
+
+            if (sender is not ToggleSwitch toggle)
+                return;
+
+            if (toggle.IsOn)
+            {
+                if (!await EnsurePasswordAsync(toggle))
+                {
+                    _suppressTimeToggle = true;
+                    toggle.IsOn = false;
+                    _suppressTimeToggle = false;
+                    ShowTimeModification = false;
+                    return;
+                }
+            }
+            else
+            {
+                if (!await ConfirmDisableAsync("Êtes-vous sûr de désactiver l'affichage de la modification du temps ?", toggle))
+                {
+                    _suppressTimeToggle = true;
+                    toggle.IsOn = true;
+                    _suppressTimeToggle = false;
+                    ShowTimeModification = true;
+                    return;
+                }
+            }
+
+            ShowTimeModification = toggle.IsOn;
+        }
+
+        private async void ReminderPageSwitch_Toggled(object sender, RoutedEventArgs e)
+        {
+            if (!_isLoaded || _suppressReminderToggle)
+                return;
+
+            if (sender is not ToggleSwitch toggle)
+                return;
+
+            if (toggle.IsOn)
+            {
+                if (!await EnsurePasswordAsync(toggle))
+                {
+                    _suppressReminderToggle = true;
+                    toggle.IsOn = false;
+                    _suppressReminderToggle = false;
+                    ShowReminderPage = false;
+                    return;
+                }
+            }
+            else
+            {
+                if (!await ConfirmDisableAsync("Êtes-vous sûr de désactiver l'affichage de la page de rappel ?", toggle))
+                {
+                    _suppressReminderToggle = true;
+                    toggle.IsOn = true;
+                    _suppressReminderToggle = false;
+                    ShowReminderPage = true;
+                    return;
+                }
+            }
+
+            ShowReminderPage = toggle.IsOn;
+        }
+
+        private async Task<bool> EnsurePasswordAsync(FrameworkElement? element)
+        {
+            var xamlRoot = GetXamlRoot(element);
+            if (xamlRoot is null)
+                return false;
+
+            while (true)
+            {
+                var passwordBox = new PasswordBox { PlaceholderText = "Mot de passe", Width = 300 };
+                var dialog = new ContentDialog
+                {
+                    Title = "Mot de passe requis",
+                    PrimaryButtonText = "Valider",
+                    CloseButtonText = "Annuler",
+                    DefaultButton = ContentDialogButton.Primary,
+                    Content = passwordBox,
+                    XamlRoot = xamlRoot
+                };
+
+                var result = await dialog.ShowAsync();
+                if (result != ContentDialogResult.Primary)
+                    return false;
+
+                if (ValidatePassword(passwordBox.Password))
+                    return true;
+
+                await ShowInfoDialogAsync("Accès refusé", "Mot de passe incorrect.", xamlRoot);
+            }
+        }
+
+        private bool ValidatePassword(string? password) =>
+            string.Equals(password, SettingsPassword, StringComparison.Ordinal);
+
+        private async Task<bool> ConfirmDisableAsync(string message, FrameworkElement? element)
+        {
+            var xamlRoot = GetXamlRoot(element);
+            if (xamlRoot is null)
+                return false;
+
+            var dialog = new ContentDialog
+            {
+                Title = "Confirmation",
+                Content = message,
+                PrimaryButtonText = "Oui",
+                CloseButtonText = "Non",
+                DefaultButton = ContentDialogButton.Close,
+                XamlRoot = xamlRoot
+            };
+
+            var result = await dialog.ShowAsync();
+            return result == ContentDialogResult.Primary;
+        }
+
+        private async Task ShowInfoDialogAsync(string title, string message, XamlRoot xamlRoot)
+        {
+            var dialog = new ContentDialog
+            {
+                Title = title,
+                Content = message,
+                CloseButtonText = "Fermer",
+                XamlRoot = xamlRoot
+            };
+
+            await dialog.ShowAsync();
+        }
+
+        private XamlRoot? GetXamlRoot(FrameworkElement? element)
+        {
+            if (element?.XamlRoot is XamlRoot root)
+                return root;
+
+            if (Content is FrameworkElement fe && fe.XamlRoot is not null)
+                return fe.XamlRoot;
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove the configurable settings password from the machine configuration model
- gate room renaming and protected toggles behind the fixed password 901027

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e27325d71c8324b7d260eb90c42a51