### PR TITLE
Improve user list color contrast

### DIFF
--- a/Client/Models/ColorUtils.cs
+++ b/Client/Models/ColorUtils.cs
@@ -75,5 +75,92 @@ namespace Client.Models
             double luminance = (0.299 * background.R + 0.587 * background.G + 0.114 * background.B) / 255;
             return luminance > 0.5 ? Colors.Black : Colors.White;
         }
+
+        public static Color EnsureContrast(Color baseColor, Color background, double minimumContrastRatio = 3.0)
+        {
+            var currentContrast = GetContrastRatio(baseColor, background);
+            if (currentContrast >= minimumContrastRatio)
+            {
+                return baseColor;
+            }
+
+            var bestColor = baseColor;
+            double bestContrast = currentContrast;
+
+            var lighterCandidate = baseColor;
+            var darkerCandidate = baseColor;
+
+            for (int i = 0; i < 10; i++)
+            {
+                lighterCandidate = BlendTowards(lighterCandidate, Colors.White, 0.15);
+                var lighterContrast = GetContrastRatio(lighterCandidate, background);
+                if (lighterContrast > bestContrast)
+                {
+                    bestContrast = lighterContrast;
+                    bestColor = lighterCandidate;
+                    if (lighterContrast >= minimumContrastRatio)
+                    {
+                        return lighterCandidate;
+                    }
+                }
+
+                darkerCandidate = BlendTowards(darkerCandidate, Colors.Black, 0.15);
+                var darkerContrast = GetContrastRatio(darkerCandidate, background);
+                if (darkerContrast > bestContrast)
+                {
+                    bestContrast = darkerContrast;
+                    bestColor = darkerCandidate;
+                    if (darkerContrast >= minimumContrastRatio)
+                    {
+                        return darkerCandidate;
+                    }
+                }
+            }
+
+            return bestColor;
+        }
+
+        private static Color BlendTowards(Color source, Color target, double amount)
+        {
+            amount = Math.Clamp(amount, 0, 1);
+            byte a = source.A;
+            byte r = Lerp(source.R, target.R, amount);
+            byte g = Lerp(source.G, target.G, amount);
+            byte b = Lerp(source.B, target.B, amount);
+            return Color.FromArgb(a, r, g, b);
+        }
+
+        private static byte Lerp(byte start, byte end, double amount)
+        {
+            return (byte)Math.Clamp(Math.Round(start + (end - start) * amount), 0, 255);
+        }
+
+        private static double GetContrastRatio(Color first, Color second)
+        {
+            var l1 = GetRelativeLuminance(first);
+            var l2 = GetRelativeLuminance(second);
+            if (l1 < l2)
+            {
+                (l1, l2) = (l2, l1);
+            }
+
+            return (l1 + 0.05) / (l2 + 0.05);
+        }
+
+        private static double GetRelativeLuminance(Color color)
+        {
+            static double Linearize(double channel)
+            {
+                return channel <= 0.03928
+                    ? channel / 12.92
+                    : Math.Pow((channel + 0.055) / 1.055, 2.4);
+            }
+
+            var r = Linearize(color.R / 255.0);
+            var g = Linearize(color.G / 255.0);
+            var b = Linearize(color.B / 255.0);
+
+            return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+        }
     }
 }

--- a/Client/Models/UserInfo.cs
+++ b/Client/Models/UserInfo.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using Client.Helpers;
 
 namespace Client.Models
 {
@@ -10,10 +11,13 @@ namespace Client.Models
         public string Username { get; set; } = string.Empty;
         public string Avatar { get; set; } = string.Empty;
         private ObservableCollection<string> _rooms = new();
+        private string _colorUserName = string.Empty;
+        private string _accentAwareColorUserName = string.Empty;
 
         public UserInfo()
         {
             _rooms.CollectionChanged += Rooms_CollectionChanged;
+            UpdateAccentAwareColor();
         }
 
         public ObservableCollection<string> Rooms
@@ -34,7 +38,32 @@ namespace Client.Models
             }
         }
 
-        public string ColorUserName { get; set; } = string.Empty;
+        public string ColorUserName
+        {
+            get => _colorUserName;
+            set
+            {
+                var newValue = value ?? string.Empty;
+                if (_colorUserName != newValue)
+                {
+                    _colorUserName = newValue;
+                    OnPropertyChanged(nameof(ColorUserName));
+                    UpdateAccentAwareColor();
+                }
+            }
+        }
+        public string AccentAwareColorUserName
+        {
+            get => _accentAwareColorUserName;
+            private set
+            {
+                if (_accentAwareColorUserName != value)
+                {
+                    _accentAwareColorUserName = value;
+                    OnPropertyChanged(nameof(AccentAwareColorUserName));
+                }
+            }
+        }
         public string DisplayName { get; set; } = string.Empty;
 
         private bool _isOnline;
@@ -72,6 +101,20 @@ namespace Client.Models
         {
             IsOnline = _rooms.Count > 0;
             OnPropertyChanged(nameof(RoomsDisplay));
+        }
+
+        public void RefreshAccentAwareColor()
+        {
+            UpdateAccentAwareColor();
+        }
+
+        private void UpdateAccentAwareColor()
+        {
+            var colors = AppSettings.GetObject<AppColorSettings>("Colors");
+            var accent = ColorUtils.FromHex(colors.TitleBarColor);
+            var original = ColorUtils.FromHex(_colorUserName);
+            var adjusted = ColorUtils.EnsureContrast(original, accent);
+            AccentAwareColorUserName = ColorUtils.ToHex(adjusted);
         }
 
         public event PropertyChangedEventHandler? PropertyChanged;

--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -220,7 +220,7 @@
             <StackPanel Orientation="Horizontal" Spacing="8" Padding="4">
                 <Image Source="{x:Bind Avatar}" Width="32" Height="32"/>
                 <TextBlock Text="{x:Bind Name}" VerticalAlignment="Center"
-                           Foreground="{x:Bind ColorUserName, Converter={StaticResource StringToColorConverter}}"/>
+                           Foreground="{x:Bind AccentAwareColorUserName, Converter={StaticResource StringToColorConverter}}"/>
             </StackPanel>
         </DataTemplate>
 
@@ -413,8 +413,9 @@
                                 ContextFlyout="{StaticResource UserContextMenu}">
                             <Image Source="{x:Bind Avatar}" Width="40" Height="40"/>
                             <StackPanel>
-                                <TextBlock Text="{x:Bind Username}" Foreground="{x:Bind ColorUserName}" FontWeight="Bold"/>
-                                <TextBlock Text="{x:Bind RoomsDisplay, Mode=OneWay, FallbackValue='Offline'}"/>
+                                <TextBlock Text="{x:Bind Username}" Foreground="{x:Bind AccentAwareColorUserName, Converter={StaticResource StringToColorConverter}}" FontWeight="Bold"/>
+                                <TextBlock Text="{x:Bind RoomsDisplay, Mode=OneWay, FallbackValue='Offline'}"
+                                           Foreground="{x:Bind AccentAwareColorUserName, Converter={StaticResource StringToColorConverter}}"/>
                             </StackPanel>
                         </StackPanel>
                     </DataTemplate>

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -61,6 +61,27 @@ namespace Client.Services
             ServerAddress = cfg.ServerAddress;
             var machine = MachineConfig.Load();
             RoomName = machine.RoomName;
+            AppSettings.SettingsChanged += OnSettingsChanged;
+        }
+
+        private void OnSettingsChanged()
+        {
+            if (Dispatcher is DispatcherQueue dispatcher && !dispatcher.HasThreadAccess)
+            {
+                dispatcher.TryEnqueue(RefreshUserAccentColors);
+            }
+            else
+            {
+                RefreshUserAccentColors();
+            }
+        }
+
+        private void RefreshUserAccentColors()
+        {
+            foreach (var user in ConnectedUsers)
+            {
+                user.RefreshAccentAwareColor();
+            }
         }
 
         public event Action<ChatMessageModel>? OnMessageReceived;


### PR DESCRIPTION
## Summary
- add a color utility that adjusts username hues to maintain contrast with the accent background
- recalculate user display colors whenever client appearance settings change
- bind the user list templates to the adjusted colors to keep usernames and room lists readable when selected

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e389d3f3a08324b6d53bec6a4ab30d