### PR TITLE
Adjust user selection contrast handling

### DIFF
--- a/Client/Models/UserInfo.cs
+++ b/Client/Models/UserInfo.cs
@@ -13,6 +13,7 @@ namespace Client.Models
         private ObservableCollection<string> _rooms = new();
         private string _colorUserName = string.Empty;
         private string _accentAwareColorUserName = string.Empty;
+        private bool _usesAccentContrast;
 
         public UserInfo()
         {
@@ -108,8 +109,23 @@ namespace Client.Models
             UpdateAccentAwareColor();
         }
 
+        public void SetAccentSelection(bool isSelected)
+        {
+            if (_usesAccentContrast != isSelected)
+            {
+                _usesAccentContrast = isSelected;
+                UpdateAccentAwareColor();
+            }
+        }
+
         private void UpdateAccentAwareColor()
         {
+            if (!_usesAccentContrast || string.IsNullOrWhiteSpace(_colorUserName))
+            {
+                AccentAwareColorUserName = _colorUserName;
+                return;
+            }
+
             var colors = AppSettings.GetObject<AppColorSettings>("Colors");
             var accent = ColorUtils.FromHex(colors.TitleBarColor);
             var original = ColorUtils.FromHex(_colorUserName);

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -378,16 +378,27 @@ namespace Client.Pages
             if (_ignoreSelectionChanged)
                 return;
 
+            foreach (var removed in e.RemovedItems.OfType<UserInfo>())
+            {
+                removed.SetAccentSelection(false);
+            }
+
             if (UsersList.SelectedItem is UserInfo selected)
             {
                 if (selected.Username == App.UserName)
                 {
+                    selected.SetAccentSelection(false);
                     _ignoreSelectionChanged = true;
                     UsersList.SelectedItem = App.LastUserChanged ?? AppSettings.CurrentSelectedUser;
                     _ignoreSelectionChanged = false;
+                    if (UsersList.SelectedItem is UserInfo fallback)
+                    {
+                        fallback.SetAccentSelection(true);
+                    }
                     return;
                 }
 
+                selected.SetAccentSelection(true);
                 App.LastUserChanged = selected;
                 AppSettings.CurrentSelectedUser = selected;
                 InputBox.Focus(FocusState.Programmatic);


### PR DESCRIPTION
## Summary
- preserve each user's configured foreground color when they are not selected
- only run the contrast adjustment when a user entry is selected so the text stays legible on the accent background

## Testing
- dotnet build *(fails: dotnet CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ff8eee4c83249124233f020796f0