### PR TITLE
Fix patient hold action metadata updates

### DIFF
--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -859,13 +859,42 @@ namespace Client.Pages
             if (string.Equals(oldExam, "AT", StringComparison.OrdinalIgnoreCase))
                 return;
 
+            var wasTaken = patient.IsTaken;
+            var options = ExamOption.Load();
+            var holdOption = ExamOption.FindByIdentifier(options, "AT");
+
             patient.Exams = "AT";
             if (!string.IsNullOrWhiteSpace(oldExam))
             {
                 patient.Annotation = $"{oldExam} FAIT";
             }
 
+            if (holdOption != null)
+            {
+                if (!string.IsNullOrWhiteSpace(holdOption.Color))
+                {
+                    patient.Colors = holdOption.Color;
+                }
+
+                if (!string.IsNullOrWhiteSpace(holdOption.Floor))
+                {
+                    patient.Position = holdOption.Floor;
+                }
+            }
+
+            if (wasTaken)
+            {
+                patient.IsTaken = false;
+                patient.PickUpTime = null;
+            }
+
             UpdatePatientViews();
+
+            if (wasTaken)
+            {
+                await _service.SetPatientTakenAsync(patient.Id, false);
+            }
+
             await _service.UpdatePatientAsync(patient);
         }
 


### PR DESCRIPTION
## Summary
- load the AT exam option when marking a patient on hold so their color and floor follow the exam settings
- reset the taken flag and pickup time when moving a patient to the hold queue while keeping the end annotation update
- persist the updated patient details after adjusting the local view

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f148ba0c8324a277297e9bccfd5b