### PR TITLE
Add toggle to control slash command list visibility

### DIFF
--- a/Client/Helpers/MachineConfig.cs
+++ b/Client/Helpers/MachineConfig.cs
@@ -20,6 +20,11 @@ namespace Client.Helpers
         /// </summary>
         public bool ShowReminderPage { get; set; }
 
+        /// <summary>
+        /// Show the slash command helper list in the chat input.
+        /// </summary>
+        public bool ShowSlashCommands { get; set; } = true;
+
         public static string FilePath =>
             Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                 "EyeChat", "machine.json");

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -37,6 +37,7 @@ namespace Client.Pages
         private bool _ignoreSelectionChanged;
         private bool _ignoreOrderChange;
         private bool _isApplyingSlashCommand;
+        private readonly bool _showSlashCommands;
         private ScrollViewer? _messagesScrollViewer;
         private readonly List<SlashCommandInfo> _slashCommands = new()
         {
@@ -72,6 +73,7 @@ namespace Client.Pages
             _service = App.ChatService;
             var cfg = MachineConfig.Load();
             ShowTimeModification = cfg.ShowTimeModification;
+            _showSlashCommands = cfg.ShowSlashCommands;
             DataContext = this;
 
             BuildRooms();
@@ -1128,6 +1130,12 @@ namespace Client.Pages
         {
             if (SlashCommandsFlyout == null)
                 return;
+
+            if (!_showSlashCommands)
+            {
+                HideSlashCommandsFlyout();
+                return;
+            }
 
             if (_isApplyingSlashCommand)
             {

--- a/Client/Pages/SystemPage.xaml
+++ b/Client/Pages/SystemPage.xaml
@@ -16,6 +16,7 @@
                                         </Grid>
                                         <ToggleSwitch x:Name="TimeModSwitch" Header="Afficher la modification du temps" IsOn="{x:Bind ShowTimeModification, Mode=TwoWay}" Toggled="TimeModSwitch_Toggled"/>
                                         <ToggleSwitch x:Name="ReminderPageSwitch" Header="Afficher la page de rappel" IsOn="{x:Bind ShowReminderPage, Mode=TwoWay}" Toggled="ReminderPageSwitch_Toggled"/>
+                                        <ToggleSwitch x:Name="SlashCommandsSwitch" Header="Afficher la liste des commandes" IsOn="{x:Bind ShowSlashCommands, Mode=TwoWay}" Toggled="SlashCommandsSwitch_Toggled"/>
                                         <TextBlock Text="Utilisateur par défaut"/>
                                         <ComboBox ItemsSource="{x:Bind Users}" SelectedItem="{x:Bind DefaultUser, Mode=TwoWay}"/>
                                         <ToggleSwitch Header="Se connecter avec le dernier utilisateur" IsOn="{x:Bind ConnectLastUser, Mode=TwoWay}"/>

--- a/Client/Pages/SystemPage.xaml.cs
+++ b/Client/Pages/SystemPage.xaml.cs
@@ -16,10 +16,12 @@ namespace Client.Pages
         private bool _isLoaded;
         private bool _suppressTimeToggle;
         private bool _suppressReminderToggle;
+        private bool _suppressSlashToggle;
 
         public string RoomName { get; set; } = string.Empty;
         public bool ShowTimeModification { get; set; }
         public bool ShowReminderPage { get; set; }
+        public bool ShowSlashCommands { get; set; }
         public List<string> Users { get; set; } = new();
         public string DefaultUser { get; set; } = string.Empty;
         public bool ConnectLastUser { get; set; }
@@ -34,6 +36,7 @@ namespace Client.Pages
             RoomName = _config.RoomName;
             DefaultUser = _config.DefaultUser;
             ConnectLastUser = _config.ConnectLastUser;
+            ShowSlashCommands = _config.ShowSlashCommands;
 
             var folder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat");
             if (Directory.Exists(folder))
@@ -64,6 +67,7 @@ namespace Client.Pages
             _config.RoomName = RoomName;
             _config.ShowTimeModification = ShowTimeModification;
             _config.ShowReminderPage = ShowReminderPage;
+            _config.ShowSlashCommands = ShowSlashCommands;
             _config.DefaultUser = DefaultUser;
             _config.ConnectLastUser = ConnectLastUser;
             MachineConfig.Save(_config);
@@ -180,6 +184,40 @@ namespace Client.Pages
             }
 
             ShowReminderPage = toggle.IsOn;
+        }
+
+        private async void SlashCommandsSwitch_Toggled(object sender, RoutedEventArgs e)
+        {
+            if (!_isLoaded || _suppressSlashToggle)
+                return;
+
+            if (sender is not ToggleSwitch toggle)
+                return;
+
+            if (toggle.IsOn)
+            {
+                if (!await EnsurePasswordAsync(toggle))
+                {
+                    _suppressSlashToggle = true;
+                    toggle.IsOn = false;
+                    _suppressSlashToggle = false;
+                    ShowSlashCommands = false;
+                    return;
+                }
+            }
+            else
+            {
+                if (!await ConfirmDisableAsync("Êtes-vous sûr de masquer la liste des commandes ?", toggle))
+                {
+                    _suppressSlashToggle = true;
+                    toggle.IsOn = true;
+                    _suppressSlashToggle = false;
+                    ShowSlashCommands = true;
+                    return;
+                }
+            }
+
+            ShowSlashCommands = toggle.IsOn;
         }
 
         private async Task<bool> EnsurePasswordAsync(FrameworkElement? element)


### PR DESCRIPTION
## Summary
- add a password-protected toggle in the system settings page to control slash command helper visibility
- persist the preference in the machine configuration and respect it in the chat input

## Testing
- dotnet build WebApplication1.sln *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e63934e9e48324b7b817edd1641a9a