### PR TITLE
Add user manager dialog for slash command

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -16,9 +16,15 @@
     <None Remove="Pages\SystemPage.xaml" />
   </ItemGroup>
   <ItemGroup>
-	  <Content Include="Assets\earth.png" />
-	  <Content Include="Assets\EyeChat.png" />
-	  <Content Include="Assets\secretaria.png" />
+          <Content Include="Assets\earth.png" />
+          <Content Include="Assets\EyeChat.png" />
+          <Content Include="Assets\secretaria.png" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Page Include="Dialogs\UserManagerDialog.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
 
   <ItemGroup>

--- a/Client/Dialogs/UserManagerDialog.xaml
+++ b/Client/Dialogs/UserManagerDialog.xaml
@@ -1,0 +1,80 @@
+<ContentDialog
+    x:Class="Client.Dialogs.UserManagerDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Client.Dialogs"
+    xmlns:models="using:Client.Models"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    Title="Gestion des utilisateurs"
+    PrimaryButtonText="Fermer"
+    DefaultButton="Primary"
+    x:DefaultBindMode="OneWay">
+
+    <StackPanel Spacing="16" MinWidth="420">
+        <TextBlock Text="Gérez les utilisateurs enregistrés localement ou sur le serveur." TextWrapping="WrapWholeWords" />
+
+        <muxc:TabView>
+            <muxc:TabViewItem Header="Local">
+                <StackPanel Spacing="12">
+                    <TextBlock Text="Utilisateurs stockés localement" FontWeight="SemiBold" />
+                    <ListView ItemsSource="{x:Bind LocalUsers}" Height="260">
+                        <ListView.ItemTemplate>
+                            <DataTemplate x:DataType="models:UserInfo">
+                                <Grid ColumnDefinitions="* Auto Auto" ColumnSpacing="12" Padding="0,4,0,4">
+                                    <StackPanel>
+                                        <TextBlock Text="{x:Bind Name}" FontWeight="SemiBold" />
+                                        <TextBlock Text="{x:Bind RoomsDisplay}" Foreground="Gray" FontSize="12" />
+                                    </StackPanel>
+                                    <Button
+                                        Grid.Column="1"
+                                        Content="Renommer"
+                                        Click="RenameLocal_Click"
+                                        Tag="{x:Bind Username}"
+                                        IsEnabled="{x:Bind CanManageUser(Username)}" />
+                                    <Button
+                                        Grid.Column="2"
+                                        Content="Supprimer"
+                                        Click="DeleteLocal_Click"
+                                        Tag="{x:Bind Username}"
+                                        IsEnabled="{x:Bind CanManageUser(Username)}" />
+                                </Grid>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                    <TextBlock Text="{x:Bind LocalStatus}" Foreground="Gray" TextWrapping="WrapWholeWords" />
+                </StackPanel>
+            </muxc:TabViewItem>
+
+            <muxc:TabViewItem Header="Serveur">
+                <StackPanel Spacing="12">
+                    <TextBlock Text="Utilisateurs connus par le serveur" FontWeight="SemiBold" />
+                    <ListView ItemsSource="{x:Bind ServerUsers}" Height="260">
+                        <ListView.ItemTemplate>
+                            <DataTemplate x:DataType="models:UserInfo">
+                                <Grid ColumnDefinitions="* Auto Auto" ColumnSpacing="12" Padding="0,4,0,4">
+                                    <StackPanel>
+                                        <TextBlock Text="{x:Bind Name}" FontWeight="SemiBold" />
+                                        <TextBlock Text="{x:Bind RoomsDisplay}" Foreground="Gray" FontSize="12" />
+                                    </StackPanel>
+                                    <Button
+                                        Grid.Column="1"
+                                        Content="Renommer"
+                                        Click="RenameServer_Click"
+                                        Tag="{x:Bind Username}"
+                                        IsEnabled="{x:Bind CanManageUser(Username)}" />
+                                    <Button
+                                        Grid.Column="2"
+                                        Content="Supprimer"
+                                        Click="DeleteServer_Click"
+                                        Tag="{x:Bind Username}"
+                                        IsEnabled="{x:Bind CanManageUser(Username)}" />
+                                </Grid>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                    <TextBlock Text="{x:Bind ServerStatus}" Foreground="Gray" TextWrapping="WrapWholeWords" />
+                </StackPanel>
+            </muxc:TabViewItem>
+        </muxc:TabView>
+    </StackPanel>
+</ContentDialog>

--- a/Client/Dialogs/UserManagerDialog.xaml.cs
+++ b/Client/Dialogs/UserManagerDialog.xaml.cs
@@ -1,0 +1,358 @@
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Client.Models;
+using Client.Services;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Client.Dialogs
+{
+    public sealed partial class UserManagerDialog : ContentDialog, INotifyPropertyChanged
+    {
+        private readonly SignalRService _service;
+
+        public ObservableCollection<UserInfo> LocalUsers { get; } = new();
+        public ObservableCollection<UserInfo> ServerUsers { get; } = new();
+
+        private string _localStatus = string.Empty;
+        public string LocalStatus
+        {
+            get => _localStatus;
+            set => SetProperty(ref _localStatus, value);
+        }
+
+        private string _serverStatus = string.Empty;
+        public string ServerStatus
+        {
+            get => _serverStatus;
+            set => SetProperty(ref _serverStatus, value);
+        }
+
+        private bool _isBusy;
+        public bool IsBusy
+        {
+            get => _isBusy;
+            private set
+            {
+                if (SetProperty(ref _isBusy, value))
+                {
+                    OnPropertyChanged(nameof(IsIdle));
+                    IsPrimaryButtonEnabled = !value;
+                }
+            }
+        }
+
+        public bool IsIdle => !IsBusy;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public UserManagerDialog()
+        {
+            InitializeComponent();
+            _service = App.ChatService;
+            DataContext = this;
+            Opened += UserManagerDialog_Opened;
+        }
+
+        private async void UserManagerDialog_Opened(ContentDialog sender, ContentDialogOpenedEventArgs args)
+        {
+            await LoadAsync();
+        }
+
+        private async Task LoadAsync()
+        {
+            if (IsBusy)
+                return;
+
+            IsBusy = true;
+            try
+            {
+                await RefreshLocalAsync();
+                await RefreshServerAsync();
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        private async Task RefreshLocalAsync()
+        {
+            try
+            {
+                var users = await _service.LoadUsersFromDiskAsync();
+                LocalUsers.Clear();
+                foreach (var user in users.OrderBy(u => u.Name, StringComparer.OrdinalIgnoreCase))
+                    LocalUsers.Add(CloneUser(user));
+
+                LocalStatus = LocalUsers.Count == 0
+                    ? "Aucun utilisateur local enregistré."
+                    : $"{LocalUsers.Count} utilisateur(s) local(aux).";
+            }
+            catch (Exception ex)
+            {
+                LocalStatus = $"Erreur de chargement local : {ex.Message}";
+            }
+        }
+
+        private async Task RefreshServerAsync()
+        {
+            try
+            {
+                var users = await _service.GetAllUsersAsync();
+                ServerUsers.Clear();
+                foreach (var user in users.OrderBy(u => u.Name, StringComparer.OrdinalIgnoreCase))
+                    ServerUsers.Add(CloneUser(user));
+
+                ServerStatus = ServerUsers.Count == 0
+                    ? "Aucun utilisateur connu sur le serveur."
+                    : $"{ServerUsers.Count} utilisateur(s) serveur.";
+            }
+            catch (Exception ex)
+            {
+                ServerStatus = $"Erreur de chargement serveur : {ex.Message}";
+            }
+        }
+
+        private static UserInfo CloneUser(UserInfo user)
+        {
+            return new UserInfo
+            {
+                Username = user.Username,
+                DisplayName = user.DisplayName,
+                Avatar = user.Avatar,
+                ColorUserName = user.ColorUserName,
+                Note = user.Note,
+                IsOnline = user.IsOnline,
+                Rooms = new ObservableCollection<string>(user.Rooms)
+            };
+        }
+
+        private async void RenameLocal_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not Button button || button.Tag is not string username)
+                return;
+
+            await RenameLocalAsync(username);
+        }
+
+        private async Task RenameLocalAsync(string username)
+        {
+            if (IsProtectedUser(username) || IsBusy)
+                return;
+
+            var newName = await PromptForNameAsync(username, "Renommer l'utilisateur local");
+            if (string.IsNullOrWhiteSpace(newName) || string.Equals(newName, username, StringComparison.OrdinalIgnoreCase))
+            {
+                LocalStatus = "Renommage annulé.";
+                return;
+            }
+
+            IsBusy = true;
+            try
+            {
+                var success = await _service.RenameLocalUserAsync(username, newName);
+                if (success)
+                {
+                    LocalStatus = $"Utilisateur local « {username} » renommé en « {newName} ».";
+                    await RefreshLocalAsync();
+                }
+                else
+                {
+                    LocalStatus = $"Impossible de renommer « {username} ». Vérifiez que le nom est disponible.";
+                }
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        private async void DeleteLocal_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not Button button || button.Tag is not string username)
+                return;
+
+            await DeleteLocalAsync(username);
+        }
+
+        private async Task DeleteLocalAsync(string username)
+        {
+            if (IsProtectedUser(username) || IsBusy)
+                return;
+
+            if (!await ConfirmDeleteAsync(username, false))
+                return;
+
+            IsBusy = true;
+            try
+            {
+                var success = await _service.DeleteLocalUserAsync(username);
+                if (success)
+                {
+                    LocalStatus = $"Utilisateur local « {username} » supprimé.";
+                    await RefreshLocalAsync();
+                }
+                else
+                {
+                    LocalStatus = $"Impossible de supprimer « {username} ».";
+                }
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        private async void RenameServer_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not Button button || button.Tag is not string username)
+                return;
+
+            await RenameServerAsync(username);
+        }
+
+        private async Task RenameServerAsync(string username)
+        {
+            if (IsProtectedUser(username) || IsBusy)
+                return;
+
+            var newName = await PromptForNameAsync(username, "Renommer l'utilisateur serveur");
+            if (string.IsNullOrWhiteSpace(newName) || string.Equals(newName, username, StringComparison.OrdinalIgnoreCase))
+            {
+                ServerStatus = "Renommage annulé.";
+                return;
+            }
+
+            IsBusy = true;
+            try
+            {
+                var success = await _service.RenameServerUserAsync(username, newName);
+                if (success)
+                {
+                    ServerStatus = $"Utilisateur serveur « {username} » renommé en « {newName} ».";
+                    await _service.RenameLocalUserAsync(username, newName);
+                    await RefreshServerAsync();
+                    await RefreshLocalAsync();
+                }
+                else
+                {
+                    ServerStatus = $"Impossible de renommer « {username} » sur le serveur.";
+                }
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        private async void DeleteServer_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not Button button || button.Tag is not string username)
+                return;
+
+            await DeleteServerAsync(username);
+        }
+
+        private async Task DeleteServerAsync(string username)
+        {
+            if (IsProtectedUser(username) || IsBusy)
+                return;
+
+            if (!await ConfirmDeleteAsync(username, true))
+                return;
+
+            IsBusy = true;
+            try
+            {
+                var success = await _service.DeleteServerUserAsync(username);
+                if (success)
+                {
+                    ServerStatus = $"Utilisateur serveur « {username} » supprimé.";
+                    await _service.DeleteLocalUserAsync(username);
+                    await RefreshServerAsync();
+                    await RefreshLocalAsync();
+                }
+                else
+                {
+                    ServerStatus = $"Impossible de supprimer « {username} » sur le serveur.";
+                }
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        private async Task<string?> PromptForNameAsync(string currentName, string title)
+        {
+            var box = new TextBox
+            {
+                Text = currentName,
+                PlaceholderText = "Nouveau nom"
+            };
+
+            var dialog = new ContentDialog
+            {
+                Title = title,
+                PrimaryButtonText = "Valider",
+                CloseButtonText = "Annuler",
+                DefaultButton = ContentDialogButton.Primary,
+                Content = box,
+                XamlRoot = XamlRoot
+            };
+
+            var result = await dialog.ShowAsync();
+            if (result == ContentDialogResult.Primary)
+            {
+                var text = box.Text?.Trim();
+                return string.IsNullOrWhiteSpace(text) ? null : text;
+            }
+
+            return null;
+        }
+
+        private async Task<bool> ConfirmDeleteAsync(string username, bool server)
+        {
+            var text = server
+                ? $"Supprimer « {username} » des utilisateurs serveur ?"
+                : $"Supprimer « {username} » du cache local ?";
+
+            var dialog = new ContentDialog
+            {
+                Title = "Confirmation",
+                Content = new TextBlock { Text = text, TextWrapping = TextWrapping.WrapWholeWords },
+                PrimaryButtonText = "Supprimer",
+                CloseButtonText = "Annuler",
+                DefaultButton = ContentDialogButton.Close,
+                XamlRoot = XamlRoot
+            };
+
+            var result = await dialog.ShowAsync();
+            return result == ContentDialogResult.Primary;
+        }
+
+        public bool CanManageUser(string username) => !IsProtectedUser(username);
+
+        private static bool IsProtectedUser(string username)
+            => string.Equals(username, "A Tous", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(username, "Secrétariat", StringComparison.OrdinalIgnoreCase);
+
+        private bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string? propertyName = null)
+        {
+            if (Equals(storage, value))
+                return false;
+
+            storage = value;
+            OnPropertyChanged(propertyName);
+            return true;
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
 using Client.Models;
 using Client.Services;
+using Client.Dialogs;
 using Client.Helpers;
 using Client;
 using System.Text;
@@ -46,6 +47,7 @@ namespace Client.Pages
             new SlashCommandInfo("/clearallpatientday", "Supprimer tous les patients du jour"),
             new SlashCommandInfo("/clearallmessageday", "Supprimer tous les messages du jour"),
             new SlashCommandInfo("/generatemessage", "Générer des messages de démonstration"),
+            new SlashCommandInfo("/usermanager", "Gérer les utilisateurs locaux et serveur"),
         };
         private static readonly string[] TestFirstNames = new[]
         {
@@ -474,10 +476,32 @@ namespace Client.Pages
                     _ = _service.GenerateSampleMessagesAsync();
                     InputBox.Text = string.Empty;
                 }
+                else if (string.Equals(text, "/usermanager", StringComparison.OrdinalIgnoreCase))
+                {
+                    _ = ShowUserManagerDialogAsync();
+                    InputBox.Text = string.Empty;
+                }
                 else
                 {
                     Send_Click(sender, e);
                 }
+            }
+        }
+
+        private async Task ShowUserManagerDialogAsync()
+        {
+            try
+            {
+                var dialog = new UserManagerDialog
+                {
+                    XamlRoot = XamlRoot
+                };
+
+                await dialog.ShowAsync();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[ChatPage] Erreur ouverture UserManager : {ex.Message}");
             }
         }
 

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -64,6 +64,28 @@ namespace Client.Services
             AppSettings.SettingsChanged += OnSettingsChanged;
         }
 
+        private static string GetLocalDataFolderPath()
+            => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat");
+
+        private static string GetLocalUsersFilePath(bool ensureDirectory)
+        {
+            var folder = GetLocalDataFolderPath();
+            if (ensureDirectory && !Directory.Exists(folder))
+                Directory.CreateDirectory(folder);
+            return Path.Combine(folder, "users.json");
+        }
+
+        private static async Task WriteUsersToDiskAsync(IEnumerable<UserInfo> users)
+        {
+            var path = GetLocalUsersFilePath(true);
+            var json = JsonConvert.SerializeObject(users, Formatting.Indented);
+            await File.WriteAllTextAsync(path, json);
+        }
+
+        private static bool IsProtectedUser(string username)
+            => string.Equals(username, "A Tous", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(username, "Secrétariat", StringComparison.OrdinalIgnoreCase);
+
         private void OnSettingsChanged()
         {
             if (Dispatcher is DispatcherQueue dispatcher && !dispatcher.HasThreadAccess)
@@ -776,8 +798,9 @@ namespace Client.Services
         {
             try
             {
-                var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat", "users.json");
-                if (File.Exists(path))
+                var path = GetLocalUsersFilePath(false);
+                var folder = Path.GetDirectoryName(path)!;
+                if (Directory.Exists(folder) && File.Exists(path))
                 {
                     var json = await File.ReadAllTextAsync(path);
                     var users = JsonConvert.DeserializeObject<List<UserInfo>>(json) ?? new();
@@ -800,9 +823,7 @@ namespace Client.Services
         {
             try
             {
-                var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat", "users.json");
-                var json = JsonConvert.SerializeObject(ConnectedUsers.ToList(), Formatting.Indented);
-                await File.WriteAllTextAsync(path, json);
+                await WriteUsersToDiskAsync(ConnectedUsers.ToList());
             }
             catch (Exception ex)
             {
@@ -810,11 +831,128 @@ namespace Client.Services
             }
         }
 
+        public async Task<bool> RenameLocalUserAsync(string oldName, string newName)
+        {
+            if (string.IsNullOrWhiteSpace(oldName) || string.IsNullOrWhiteSpace(newName))
+                return false;
+
+            oldName = oldName.Trim();
+            newName = newName.Trim();
+
+            if (string.Equals(oldName, newName, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            if (IsProtectedUser(oldName) || IsProtectedUser(newName))
+                return false;
+
+            try
+            {
+                var users = await LoadUsersFromDiskAsync();
+                var existing = users.FirstOrDefault(u => string.Equals(u.Username, oldName, StringComparison.OrdinalIgnoreCase));
+                if (existing == null)
+                    return false;
+
+                if (users.Any(u => string.Equals(u.Username, newName, StringComparison.OrdinalIgnoreCase)))
+                    return false;
+
+                var originalDisplay = existing.DisplayName;
+                existing.Username = newName;
+                if (string.IsNullOrWhiteSpace(originalDisplay) || string.Equals(originalDisplay, oldName, StringComparison.OrdinalIgnoreCase))
+                    existing.DisplayName = newName;
+
+                await WriteUsersToDiskAsync(users);
+
+                Dispatcher?.TryEnqueue(() =>
+                {
+                    var item = ConnectedUsers.FirstOrDefault(u => string.Equals(u.Username, oldName, StringComparison.OrdinalIgnoreCase));
+                    if (item != null)
+                    {
+                        item.Username = newName;
+                        if (string.IsNullOrWhiteSpace(item.DisplayName) || string.Equals(item.DisplayName, oldName, StringComparison.OrdinalIgnoreCase))
+                            item.DisplayName = newName;
+                    }
+                });
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[SignalRService] RenameLocalUserAsync erreur : {ex.Message}");
+            }
+
+            return false;
+        }
+
+        public async Task<bool> DeleteLocalUserAsync(string username)
+        {
+            if (string.IsNullOrWhiteSpace(username) || IsProtectedUser(username))
+                return false;
+
+            username = username.Trim();
+
+            try
+            {
+                var users = await LoadUsersFromDiskAsync();
+                var removed = users.RemoveAll(u => string.Equals(u.Username, username, StringComparison.OrdinalIgnoreCase));
+                if (removed == 0)
+                    return false;
+
+                await WriteUsersToDiskAsync(users);
+
+                Dispatcher?.TryEnqueue(() =>
+                {
+                    var item = ConnectedUsers.FirstOrDefault(u => string.Equals(u.Username, username, StringComparison.OrdinalIgnoreCase));
+                    if (item != null)
+                        ConnectedUsers.Remove(item);
+                });
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[SignalRService] DeleteLocalUserAsync erreur : {ex.Message}");
+            }
+
+            return false;
+        }
+
+        public async Task<bool> RenameServerUserAsync(string oldName, string newName)
+        {
+            if (Connection == null || Connection.State != HubConnectionState.Connected)
+                return false;
+
+            try
+            {
+                return await Connection.InvokeAsync<bool>("RenameKnownUser", oldName, newName);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[SignalRService] RenameServerUserAsync erreur : {ex.Message}");
+                return false;
+            }
+        }
+
+        public async Task<bool> DeleteServerUserAsync(string username)
+        {
+            if (Connection == null || Connection.State != HubConnectionState.Connected)
+                return false;
+
+            try
+            {
+                return await Connection.InvokeAsync<bool>("DeleteKnownUser", username);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[SignalRService] DeleteServerUserAsync erreur : {ex.Message}");
+                return false;
+            }
+        }
+
         public void ClearLocalData()
         {
             try
             {
-                var folder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat");
+                var folder = GetLocalDataFolderPath();
                 if (Directory.Exists(folder))
                 {
                     foreach (var file in Directory.GetFiles(folder, "chat_*.json"))

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -45,6 +45,54 @@ namespace ChatServeur
             }
         };
 
+        private static bool IsProtectedUser(string username)
+            => BaseUsers.Any(u => string.Equals(u.Username, username, StringComparison.OrdinalIgnoreCase));
+
+        private static bool TryGetUserEntry(string username, out string actualKey, out UserInfo user)
+        {
+            foreach (var pair in AllUsers)
+            {
+                if (string.Equals(pair.Key, username, StringComparison.OrdinalIgnoreCase))
+                {
+                    actualKey = pair.Key;
+                    user = pair.Value;
+                    return true;
+                }
+            }
+
+            actualKey = string.Empty;
+            user = null!;
+            return false;
+        }
+
+        private static bool TryGetConnectionEntry(string username, out string actualKey, out HashSet<string> connections)
+        {
+            foreach (var pair in _userToConnectionId)
+            {
+                if (string.Equals(pair.Key, username, StringComparison.OrdinalIgnoreCase))
+                {
+                    actualKey = pair.Key;
+                    connections = pair.Value;
+                    return true;
+                }
+            }
+
+            actualKey = string.Empty;
+            connections = null!;
+            return false;
+        }
+
+        private static string? FindMember(HashSet<string> members, string username)
+        {
+            foreach (var member in members)
+            {
+                if (string.Equals(member, username, StringComparison.OrdinalIgnoreCase))
+                    return member;
+            }
+
+            return null;
+        }
+
         private void EnsureUsersLoaded()
         {
             if (_usersLoaded)
@@ -643,6 +691,145 @@ namespace ChatServeur
             EnsureUsersLoaded();
             var userList = BaseUsers.Concat(AllUsers.Values).ToList();
             return Task.FromResult(userList);
+        }
+
+        public async Task<bool> RenameKnownUser(string oldName, string newName)
+        {
+            EnsureUsersLoaded();
+
+            if (string.IsNullOrWhiteSpace(oldName) || string.IsNullOrWhiteSpace(newName))
+                return false;
+
+            oldName = oldName.Trim();
+            newName = newName.Trim();
+
+            if (string.Equals(oldName, newName, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            if (IsProtectedUser(oldName) || IsProtectedUser(newName))
+                return false;
+
+            if (!TryGetUserEntry(oldName, out var actualOldKey, out var user))
+                return false;
+
+            if (TryGetUserEntry(newName, out _, out _))
+                return false;
+
+            var originalDisplay = user.DisplayName;
+
+            if (TryGetConnectionEntry(actualOldKey, out var connectionKey, out var connections) && connections.Count > 0)
+            {
+                _userToConnectionId.Remove(connectionKey);
+                _userToConnectionId[newName] = connections;
+
+                foreach (var conn in connections)
+                {
+                    if (ConnectedUsers.TryGetValue(conn, out var connectedUser))
+                    {
+                        connectedUser.Username = newName;
+                        if (string.IsNullOrWhiteSpace(connectedUser.DisplayName) || string.Equals(connectedUser.DisplayName, actualOldKey, StringComparison.OrdinalIgnoreCase))
+                            connectedUser.DisplayName = newName;
+                        ConnectedUsers[conn] = connectedUser;
+                    }
+                }
+            }
+
+            AllUsers.Remove(actualOldKey);
+            user.Username = newName;
+            if (string.IsNullOrWhiteSpace(originalDisplay) || string.Equals(originalDisplay, actualOldKey, StringComparison.OrdinalIgnoreCase))
+                user.DisplayName = newName;
+            AllUsers[newName] = user;
+
+            foreach (var key in GroupMembers.Keys.ToList())
+            {
+                var members = GroupMembers[key];
+                var existing = FindMember(members, actualOldKey);
+                if (existing != null)
+                {
+                    members.Remove(existing);
+                    members.Add(newName);
+                }
+            }
+
+            var dbUser = await _db.KnownUsers.FirstOrDefaultAsync(u => u.Username == actualOldKey);
+            if (dbUser != null)
+            {
+                dbUser.Username = newName;
+                if (string.IsNullOrWhiteSpace(dbUser.DisplayName) || string.Equals(dbUser.DisplayName, actualOldKey, StringComparison.OrdinalIgnoreCase))
+                    dbUser.DisplayName = newName;
+                _db.KnownUsers.Update(dbUser);
+            }
+
+            var memberships = await _db.GroupMemberships.Where(m => m.Username == actualOldKey).ToListAsync();
+            if (memberships.Count > 0)
+            {
+                foreach (var membership in memberships)
+                    membership.Username = newName;
+                _db.GroupMemberships.UpdateRange(memberships);
+            }
+
+            var settings = await _db.UserSettings.FirstOrDefaultAsync(s => s.Username == actualOldKey);
+            if (settings != null)
+            {
+                settings.Username = newName;
+                _db.UserSettings.Update(settings);
+            }
+
+            await _db.SaveChangesAsync();
+
+            var userList = BaseUsers.Concat(AllUsers.Values).ToList();
+            await Clients.All.SendAsync("UserListUpdated", userList);
+
+            return true;
+        }
+
+        public async Task<bool> DeleteKnownUser(string username)
+        {
+            EnsureUsersLoaded();
+
+            if (string.IsNullOrWhiteSpace(username))
+                return false;
+
+            username = username.Trim();
+
+            if (IsProtectedUser(username))
+                return false;
+
+            if (!TryGetUserEntry(username, out var actualKey, out _))
+                return false;
+
+            if (TryGetConnectionEntry(actualKey, out _, out var connections) && connections.Count > 0)
+                return false;
+
+            AllUsers.Remove(actualKey);
+            _userToConnectionId.Remove(actualKey);
+
+            foreach (var key in GroupMembers.Keys.ToList())
+            {
+                var members = GroupMembers[key];
+                var existing = FindMember(members, actualKey);
+                if (existing != null)
+                    members.Remove(existing);
+            }
+
+            var dbUser = await _db.KnownUsers.FirstOrDefaultAsync(u => u.Username == actualKey);
+            if (dbUser != null)
+                _db.KnownUsers.Remove(dbUser);
+
+            var memberships = await _db.GroupMemberships.Where(m => m.Username == actualKey).ToListAsync();
+            if (memberships.Count > 0)
+                _db.GroupMemberships.RemoveRange(memberships);
+
+            var settings = await _db.UserSettings.FirstOrDefaultAsync(s => s.Username == actualKey);
+            if (settings != null)
+                _db.UserSettings.Remove(settings);
+
+            await _db.SaveChangesAsync();
+
+            var userList = BaseUsers.Concat(AllUsers.Values).ToList();
+            await Clients.All.SendAsync("UserListUpdated", userList);
+
+            return true;
         }
 
         public async Task SaveExamOptions(IEnumerable<ExamOption> options)


### PR DESCRIPTION
## Summary
- add the `/usermanager` slash command so operators can launch a dedicated management dialog
- introduce a user manager dialog that can rename or remove users stored locally or on the server
- extend the client SignalR service and server hub with APIs to persist user rename/delete operations and keep caches in sync

## Testing
- $HOME/.dotnet/dotnet build *(fails: NETSDK1100 because Windows targeting isn't available on this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e638bd2c3c8324bd83a9dd2ebfe569