### PR TITLE
Fix CanManageUser binding in user manager dialog

### DIFF
--- a/Client/Dialogs/UserManagerDialog.xaml
+++ b/Client/Dialogs/UserManagerDialog.xaml
@@ -5,6 +5,7 @@
     xmlns:local="using:Client.Dialogs"
     xmlns:models="using:Client.Models"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    x:Name="Dialog"
     Title="Gestion des utilisateurs"
     PrimaryButtonText="Fermer"
     DefaultButton="Primary"
@@ -30,13 +31,13 @@
                                         Content="Renommer"
                                         Click="RenameLocal_Click"
                                         Tag="{x:Bind Username}"
-                                        IsEnabled="{x:Bind CanManageUser(Username)}" />
+                                        IsEnabled="{x:Bind ElementName=Dialog, Path=CanManageUser(Username)}" />
                                     <Button
                                         Grid.Column="2"
                                         Content="Supprimer"
                                         Click="DeleteLocal_Click"
                                         Tag="{x:Bind Username}"
-                                        IsEnabled="{x:Bind CanManageUser(Username)}" />
+                                        IsEnabled="{x:Bind ElementName=Dialog, Path=CanManageUser(Username)}" />
                                 </Grid>
                             </DataTemplate>
                         </ListView.ItemTemplate>
@@ -61,13 +62,13 @@
                                         Content="Renommer"
                                         Click="RenameServer_Click"
                                         Tag="{x:Bind Username}"
-                                        IsEnabled="{x:Bind CanManageUser(Username)}" />
+                                        IsEnabled="{x:Bind ElementName=Dialog, Path=CanManageUser(Username)}" />
                                     <Button
                                         Grid.Column="2"
                                         Content="Supprimer"
                                         Click="DeleteServer_Click"
                                         Tag="{x:Bind Username}"
-                                        IsEnabled="{x:Bind CanManageUser(Username)}" />
+                                        IsEnabled="{x:Bind ElementName=Dialog, Path=CanManageUser(Username)}" />
                                 </Grid>
                             </DataTemplate>
                         </ListView.ItemTemplate>


### PR DESCRIPTION
## Summary
- ensure the user manager dialog can call CanManageUser from button bindings by referencing the dialog element

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e69965ba8483249ffef9ad91b5e891