### PR TITLE
Fix user manager dialog initialization

### DIFF
--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -494,17 +494,56 @@ namespace Client.Pages
         {
             try
             {
-                var dialog = new UserManagerDialog
+                if (DispatcherQueue != null && !DispatcherQueue.HasThreadAccess)
                 {
-                    XamlRoot = XamlRoot
-                };
+                    var tcs = new TaskCompletionSource<bool>();
+                    if (!DispatcherQueue.TryEnqueue(async () =>
+                    {
+                        try
+                        {
+                            await ShowUserManagerDialogCoreAsync();
+                            tcs.TrySetResult(true);
+                        }
+                        catch (Exception queueEx)
+                        {
+                            tcs.TrySetException(queueEx);
+                        }
+                    }))
+                    {
+                        await ShowUserManagerDialogCoreAsync();
+                        return;
+                    }
 
-                await dialog.ShowAsync();
+                    await tcs.Task;
+                    return;
+                }
+
+                await ShowUserManagerDialogCoreAsync();
             }
             catch (Exception ex)
             {
                 Debug.WriteLine($"[ChatPage] Erreur ouverture UserManager : {ex.Message}");
             }
+        }
+
+        private async Task ShowUserManagerDialogCoreAsync()
+        {
+            var xamlRoot = XamlRoot;
+            if (xamlRoot == null && App.MainWindow?.Content is FrameworkElement rootElement)
+                xamlRoot = rootElement.XamlRoot;
+
+            if (xamlRoot == null)
+            {
+                Debug.WriteLine("[ChatPage] Impossible d'ouvrir UserManager : XamlRoot introuvable.");
+                return;
+            }
+
+            var dialog = new UserManagerDialog
+            {
+                XamlRoot = xamlRoot
+            };
+
+            await dialog.ShowAsync();
         }
 
         private async Task AddTestPatientsAsync()


### PR DESCRIPTION
## Summary
- ensure the user manager dialog resolves a valid XamlRoot before opening
- marshal dialog creation back to the UI thread when invoked off-dispatcher

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e69c7acd5483249c5bd70e6778fcc5