### PR TITLE
Improve user manager dialog dispatching

### DIFF
--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -40,6 +40,7 @@ namespace Client.Pages
         private bool _isApplyingSlashCommand;
         private readonly bool _showSlashCommands;
         private ScrollViewer? _messagesScrollViewer;
+        private bool _isUserManagerDialogOpen;
         private readonly List<SlashCommandInfo> _slashCommands = new()
         {
             new SlashCommandInfo("/getallroom", "Afficher toutes les salles et leurs membres"),
@@ -494,17 +495,97 @@ namespace Client.Pages
         {
             try
             {
-                var dialog = new UserManagerDialog
-                {
-                    XamlRoot = XamlRoot
-                };
+                var dispatcher = DispatcherQueue
+                    ?? App.MainWindow?.DispatcherQueue
+                    ?? DispatcherQueue.GetForCurrentThread();
 
-                await dialog.ShowAsync();
+                if (dispatcher == null)
+                {
+                    Debug.WriteLine("[ChatPage] Impossible d'ouvrir UserManager : aucun dispatcher disponible.");
+                    return;
+                }
+
+                if (!dispatcher.HasThreadAccess)
+                {
+                    await RunOnDispatcherAsync(dispatcher, ShowUserManagerDialogCoreAsync);
+                    return;
+                }
+
+                await ShowUserManagerDialogCoreAsync();
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"[ChatPage] Erreur ouverture UserManager : {ex.Message}");
+                Debug.WriteLine($"[ChatPage] Erreur ouverture UserManager : {ex}");
             }
+        }
+
+        private async Task ShowUserManagerDialogCoreAsync()
+        {
+            if (_isUserManagerDialogOpen)
+            {
+                Debug.WriteLine("[ChatPage] UserManager déjà ouvert, requête ignorée.");
+                return;
+            }
+
+            var xamlRoot = ResolveUserManagerXamlRoot();
+            if (xamlRoot == null)
+            {
+                Debug.WriteLine("[ChatPage] Impossible d'ouvrir UserManager : XamlRoot introuvable.");
+                return;
+            }
+
+            var dialog = new UserManagerDialog
+            {
+                XamlRoot = xamlRoot
+            };
+
+            try
+            {
+                _isUserManagerDialogOpen = true;
+                await dialog.ShowAsync();
+            }
+            finally
+            {
+                _isUserManagerDialogOpen = false;
+            }
+        }
+
+        private XamlRoot? ResolveUserManagerXamlRoot()
+        {
+            if (XamlRoot != null)
+            {
+                return XamlRoot;
+            }
+
+            if (App.MainWindow?.Content is FrameworkElement rootElement)
+            {
+                return rootElement.XamlRoot;
+            }
+
+            return null;
+        }
+
+        private static Task RunOnDispatcherAsync(DispatcherQueue dispatcher, Func<Task> asyncAction)
+        {
+            var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            if (!dispatcher.TryEnqueue(async () =>
+            {
+                try
+                {
+                    await asyncAction();
+                    tcs.TrySetResult(null);
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            }))
+            {
+                tcs.TrySetException(new InvalidOperationException("Impossible d'enfiler l'action sur le dispatcher."));
+            }
+
+            return tcs.Task;
         }
 
         private async Task AddTestPatientsAsync()


### PR DESCRIPTION
## Summary
- resolve an appropriate dispatcher before showing the user manager dialog and marshal back to it when necessary
- prevent duplicate user manager dialog instances and fall back to the main window XamlRoot when needed
- add a dispatcher helper to surface failures when queuing the dialog show action

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e69c7acd5483249c5bd70e6778fcc5