### PR TITLE
Fix UserManager dialog cloning of rooms

### DIFF
--- a/Client/Dialogs/UserManagerDialog.xaml.cs
+++ b/Client/Dialogs/UserManagerDialog.xaml.cs
@@ -120,7 +120,7 @@ namespace Client.Dialogs
 
         private static UserInfo CloneUser(UserInfo user)
         {
-            return new UserInfo
+            var clone = new UserInfo
             {
                 Username = user.Username,
                 DisplayName = user.DisplayName,
@@ -128,8 +128,15 @@ namespace Client.Dialogs
                 ColorUserName = user.ColorUserName,
                 Note = user.Note,
                 IsOnline = user.IsOnline,
-                Rooms = new ObservableCollection<string>(user.Rooms)
+                CanRenameLocalUser = user.CanRenameLocalUser
             };
+
+            var roomsToCopy = user.Rooms?.Where(room => !string.IsNullOrWhiteSpace(room))
+                ?? Enumerable.Empty<string>();
+
+            clone.Rooms = new ObservableCollection<string>(roomsToCopy);
+
+            return clone;
         }
 
         private async void RenameLocal_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- prevent the User Manager dialog from crashing when cloning users whose room list is null or contains empty entries
- preserve the local rename flag while cloning user models

## Testing
- dotnet build *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e745d6ccf88324b4cdacca54a9827e