### PR TITLE
Fix nullability warnings and async usage

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -45,7 +45,7 @@ namespace Client
             };
         }
 
-        protected async override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
+        protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
         {
             m_window = new MainWindow();
             MainWindow = m_window;

--- a/Client/Helpers/StringToImageSourceConverter.cs
+++ b/Client/Helpers/StringToImageSourceConverter.cs
@@ -1,3 +1,4 @@
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Media.Imaging;
 using System;
@@ -18,7 +19,7 @@ namespace Client.Helpers
                 {
                 }
             }
-            return null;
+            return DependencyProperty.UnsetValue;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, string language)
@@ -27,7 +28,7 @@ namespace Client.Helpers
             {
                 return img.UriSource.AbsoluteUri;
             }
-            return null;
+            return DependencyProperty.UnsetValue;
         }
     }
 }

--- a/Client/MainWindow.xaml.cs
+++ b/Client/MainWindow.xaml.cs
@@ -60,7 +60,7 @@ namespace Client
             if (args.SelectedItem is NavigationViewItem item)
             {
                 var tag = item.Tag?.ToString();
-                Type pageType = tag switch
+                Type? pageType = tag switch
                 {
                     "ChatPage" => typeof(Pages.ChatPage),
                     "HistoryPage" => typeof(Pages.HistoryPage),
@@ -76,7 +76,7 @@ namespace Client
                 }
             }
         }
-        public Pages.ChatPage ShowChatPage()
+        public Pages.ChatPage? ShowChatPage()
         {
             var chatItem = nvSample.MenuItems.OfType<NavigationViewItem>()
                 .FirstOrDefault(item => (string)item.Tag == "ChatPage");

--- a/Client/Pages/AppearanceSettingsPage.xaml.cs
+++ b/Client/Pages/AppearanceSettingsPage.xaml.cs
@@ -57,9 +57,9 @@ namespace Client.Pages
             UpdateResourceBrush("SystemControlHighlightAccentBrush", args.NewColor);
             if (App.MainWindow.Content is FrameworkElement root)
             {
-                var titleBar = (Grid)root.FindName("AppTitleBar");
-                var nav = (NavigationView)root.FindName("nvSample");
-                var titleText = (TextBlock)root.FindName("TitleBarTextBlock");
+                var titleBar = root.FindName("AppTitleBar") as Grid;
+                var nav = root.FindName("nvSample") as NavigationView;
+                var titleText = root.FindName("TitleBarTextBlock") as TextBlock;
                 TitleBarZone.Background = new SolidColorBrush(ColorUtils.FromHex(currentSettings.TitleBarColor));
                 ApplyColors(currentSettings, titleBar, nav, titleText);
             }
@@ -73,7 +73,7 @@ namespace Client.Pages
             AppSettings.SetObject("Colors", currentSettings);
             if (App.MainWindow.Content is FrameworkElement root)
             {
-                var nav = (NavigationView)root.FindName("nvSample");
+                var nav = root.FindName("nvSample") as NavigationView;
                 NavZone.Background = new SolidColorBrush(ColorUtils.FromHex(currentSettings.NavigationViewColor));
                 ApplyNavigationColors(currentSettings, nav);
             }
@@ -116,9 +116,9 @@ namespace Client.Pages
             AppSettings.SetObject("Colors", currentSettings);
             if (App.MainWindow.Content is FrameworkElement root)
             {
-                var titleBar = (Grid)root.FindName("AppTitleBar");
-                var nav = (NavigationView)root.FindName("nvSample");
-                var titleText = (TextBlock)root.FindName("TitleBarTextBlock");
+                var titleBar = root.FindName("AppTitleBar") as Grid;
+                var nav = root.FindName("nvSample") as NavigationView;
+                var titleText = root.FindName("TitleBarTextBlock") as TextBlock;
                 MyMessageZone.Background = new SolidColorBrush(ColorUtils.FromHex(currentSettings.MyMessageColor));
                 ApplyColors(currentSettings, titleBar, nav, titleText);
             }
@@ -132,9 +132,9 @@ namespace Client.Pages
             AppSettings.SetObject("Colors", currentSettings);
             if (App.MainWindow.Content is FrameworkElement root)
             {
-                var titleBar = (Grid)root.FindName("AppTitleBar");
-                var nav = (NavigationView)root.FindName("nvSample");
-                var titleText = (TextBlock)root.FindName("TitleBarTextBlock");
+                var titleBar = root.FindName("AppTitleBar") as Grid;
+                var nav = root.FindName("nvSample") as NavigationView;
+                var titleText = root.FindName("TitleBarTextBlock") as TextBlock;
                 OtherMessageZone.Background = new SolidColorBrush(ColorUtils.FromHex(currentSettings.OtherMessageColor));
                 ApplyColors(currentSettings, titleBar, nav, titleText);
             }
@@ -153,9 +153,9 @@ namespace Client.Pages
             AppSettings.SetObject("Colors", currentSettings);
             if (App.MainWindow.Content is FrameworkElement root)
             {
-                var titleBar = (Grid)root.FindName("AppTitleBar");
-                var nav = (NavigationView)root.FindName("nvSample");
-                var titleText = (TextBlock)root.FindName("TitleBarTextBlock");
+                var titleBar = root.FindName("AppTitleBar") as Grid;
+                var nav = root.FindName("nvSample") as NavigationView;
+                var titleText = root.FindName("TitleBarTextBlock") as TextBlock;
                 ApplyColors(currentSettings, titleBar, nav, titleText);
             }
         }

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -151,11 +151,11 @@ namespace Client.Pages
                     Messages.Add(msg);
 
                 var result = await _service.LoadTodayMessagesAsync(App.UserName);
-                if (result.Success)
+                if (result.Success && result.Value is { } resultMessages)
                 {
                     foreach (var item in Messages.OfType<ChatMessageModel>().ToList())
                         Messages.Remove(item);
-                    foreach (var msg in result.Value)
+                    foreach (var msg in resultMessages)
                         Messages.Add(msg);
 
                     await _service.SaveTodayMessagesToDiskAsync();
@@ -331,7 +331,7 @@ namespace Client.Pages
             return count;
         }
 
-        private bool ShouldKeepMessage(object item, UserInfo? selected)
+        private bool ShouldKeepMessage(object? item, UserInfo? selected)
         {
             if (item is not ChatMessageModel msg)
                 return true;
@@ -707,15 +707,15 @@ namespace Client.Pages
                 _currentDate = _currentDate.AddDays(-1);
                 tryCount++;
 
-                var result = await _service.LoadMessagesForDateAsync(App.UserName, _currentDate);
+                  var result = await _service.LoadMessagesForDateAsync(App.UserName, _currentDate);
 
-                if (result.Success && result.Value.Any())
-                {
-                    int insertIndex = 1;
-                    foreach (var msg in result.Value.OrderBy(m => m.Timestamp))
-                    {
-                        Messages.Insert(insertIndex++, msg);
-                    }
+                  if (result.Success && result.Value is { } messages && messages.Any())
+                  {
+                      int insertIndex = 1;
+                      foreach (var msg in messages.OrderBy(m => m.Timestamp))
+                      {
+                          Messages.Insert(insertIndex++, msg);
+                      }
 
                     return;
                 }
@@ -1644,7 +1644,7 @@ namespace Client.Pages
         {
             var toRemove = collection.OfType<T>().ToList();
             foreach (var item in toRemove)
-                collection.Remove(item);
+                collection.Remove(item!);
         }
     }
 }

--- a/Client/Pages/ExamRoomPage.xaml.cs
+++ b/Client/Pages/ExamRoomPage.xaml.cs
@@ -27,7 +27,6 @@ namespace Client.Pages
         public ObservableCollection<string> Rooms { get; } = RoomList.Load();
 
         private bool _syncing;
-        private bool _hasChanges;
 
         public ExamRoomPage()
         {
@@ -41,7 +40,7 @@ namespace Client.Pages
             this.Unloaded += ExamRoomPage_Unloaded;
         }
 
-        private async void ExamRoomPage_Unloaded(object sender, RoutedEventArgs e)
+        private void ExamRoomPage_Unloaded(object sender, RoutedEventArgs e)
         {
             App.ChatService.ExamOptionsUpdated -= ChatService_ExamOptionsUpdated;
             App.ChatService.RoomsUpdated -= ChatService_RoomsUpdated;
@@ -260,7 +259,6 @@ namespace Client.Pages
                 Rooms.CollectionChanged += Rooms_CollectionChanged;
                 RoomList.Save(Rooms);
 
-                _hasChanges = false;
             }
             catch (Exception ex)
             {
@@ -307,7 +305,6 @@ namespace Client.Pages
         private void Option_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             if (_syncing) return;
-            _hasChanges = true;
             ExamOption.Save(Options);
         }
 
@@ -338,14 +335,12 @@ namespace Client.Pages
             foreach (var opt in Options)
                 opt.Index = index++;
 
-            _hasChanges = true;
             ExamOption.Save(Options);
         }
 
         private void Rooms_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
             if (_syncing) return;
-            _hasChanges = true;
             RoomList.Save(Rooms);
         }
         private void Back_Click(object sender, RoutedEventArgs e)
@@ -419,7 +414,6 @@ namespace Client.Pages
                 {
                     await App.ChatService.SendExamOptionsSilentAsync(Options);
                     await App.ChatService.SendRoomsSilentAsync(Rooms);
-                    _hasChanges = false;
                 }
             }
             catch (Exception ex)

--- a/Client/Pages/HistoryPage.xaml.cs
+++ b/Client/Pages/HistoryPage.xaml.cs
@@ -105,9 +105,9 @@ namespace Client.Pages
 
         private void Pivot_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (sender == NotArchivedPivot && ArchivedPivot.SelectedIndex != NotArchivedPivot.SelectedIndex)
+            if (ReferenceEquals(sender, NotArchivedPivot) && ArchivedPivot.SelectedIndex != NotArchivedPivot.SelectedIndex)
                 ArchivedPivot.SelectedIndex = NotArchivedPivot.SelectedIndex;
-            else if (sender == ArchivedPivot && NotArchivedPivot.SelectedIndex != ArchivedPivot.SelectedIndex)
+            else if (ReferenceEquals(sender, ArchivedPivot) && NotArchivedPivot.SelectedIndex != ArchivedPivot.SelectedIndex)
                 NotArchivedPivot.SelectedIndex = ArchivedPivot.SelectedIndex;
         }
 

--- a/Client/Services/HotKeyService.cs
+++ b/Client/Services/HotKeyService.cs
@@ -38,6 +38,9 @@ namespace Client.Services
         private const uint KEYEVENTF_KEYUP = 0x0002;
         public string RoomName { get; set; } = string.Empty;
 
+        private static XamlRoot? GetMainWindowXamlRoot()
+            => App.MainWindow?.Content is FrameworkElement root ? root.XamlRoot : null;
+
         [StructLayout(LayoutKind.Sequential)]
         private struct KBDLLHOOKSTRUCT
         {
@@ -182,12 +185,16 @@ namespace Client.Services
             var options = ExamOption.Load();
             var rooms = RoomList.Load();
 
+            var xamlRoot = GetMainWindowXamlRoot();
+            if (xamlRoot is null)
+                return;
+
             var dialog = new ContentDialog
             {
                 Title = "Ajout d'un patient",
                 PrimaryButtonText = "Valider",
                 CloseButtonText = "Annuler",
-                XamlRoot = App.MainWindow.Content.XamlRoot,
+                XamlRoot = xamlRoot,
             };
 
             var grid = new Grid { ColumnSpacing = 10, RowSpacing = 4 };
@@ -359,12 +366,16 @@ namespace Client.Services
             var options = ExamOption.Load();
             var rooms = RoomList.Load();
 
+            var xamlRoot = GetMainWindowXamlRoot();
+            if (xamlRoot is null)
+                return;
+
             var dialog = new ContentDialog
             {
                 Title = "Modifier un patient",
                 PrimaryButtonText = "Valider",
                 CloseButtonText = "Annuler",
-                XamlRoot = App.MainWindow.Content.XamlRoot,
+                XamlRoot = xamlRoot,
             };
 
             var grid = new Grid { ColumnSpacing = 10, RowSpacing = 4 };
@@ -457,6 +468,10 @@ namespace Client.Services
             foreach (var log in logs.OrderBy(l => l.Timestamp))
                 sb.AppendLine($"{log.Timestamp:dd/MM HH:mm} - {log.Username} - {log.Action} {log.Details}");
 
+            var xamlRoot = GetMainWindowXamlRoot();
+            if (xamlRoot is null)
+                return;
+
             var dialog = new ContentDialog
             {
                 Title = "Informations patient",
@@ -465,7 +480,7 @@ namespace Client.Services
                 {
                     Content = new TextBlock { Text = sb.ToString(), TextWrapping = TextWrapping.Wrap }
                 },
-                XamlRoot = App.MainWindow.Content.XamlRoot,
+                XamlRoot = xamlRoot,
             };
             await dialog.ShowAsync();
         }
@@ -615,14 +630,14 @@ namespace Client.Services
                         {
                             var exam = AppSettings.Get(key, string.Empty);
 
-                            App.MainWindow?.DispatcherQueue?.TryEnqueue(() =>
+                            App.MainWindow?.DispatcherQueue?.TryEnqueue(async () =>
                             {
                                 BringMainWindowToForeground();
                                 if (App.MainWindow is MainWindow mw)
                                 {
-                                    var chat = mw.ShowChatPage();
-                                    ShowPatientDialogAsync(exam);
-                            }
+                                    mw.ShowChatPage();
+                                    await ShowPatientDialogAsync(exam);
+                                }
                             });
 
                         }

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -25,12 +25,18 @@ namespace Client.Services
 {
     public class SignalRService
     {
-        public HubConnection Connection { get; private set; }
-        public DispatcherQueue Dispatcher { get; set; }
+        public HubConnection? Connection { get; private set; }
+        public DispatcherQueue? Dispatcher { get; set; }
         public ObservableCollection<UserInfo> ConnectedUsers { get; } = new();
         public ObservableCollection<Patient> Patients { get; } = new();
         public ObservableCollection<object> Messages { get; } = new();
         public string RoomName { get; set; } = string.Empty;
+
+        private HubConnection? GetActiveConnection()
+            => Connection is { State: HubConnectionState.Connected } connection ? connection : null;
+
+        private HubConnection GetRequiredConnection()
+            => GetActiveConnection() ?? throw new InvalidOperationException("Connexion SignalR non établie.");
 
         private bool _initialized;
         private bool _historyLoaded;
@@ -152,16 +158,16 @@ namespace Client.Services
             return avatar;
         }
 
-        private string? ToClientAvatar(string? avatar)
+        private string ToClientAvatar(string? avatar)
         {
             if (string.IsNullOrWhiteSpace(avatar))
-                return null;
+                return string.Empty;
             if (Uri.TryCreate(avatar, UriKind.RelativeOrAbsolute, out var uri))
             {
                 if (!uri.IsAbsoluteUri && avatar.StartsWith("/"))
                     return $"{ServerAddress}{avatar}";
             }
-            return avatar;
+            return avatar ?? string.Empty;
         }
 
         public async Task InitializeAsync()
@@ -272,11 +278,13 @@ namespace Client.Services
                 }
             }
 
-            Connection = new HubConnectionBuilder()
+            var connection = new HubConnectionBuilder()
                 .WithUrl($"{ServerAddress}/chatHub")
                 .Build();
 
-            Connection.Closed += async (error) =>
+            Connection = connection;
+
+            connection.Closed += async (error) =>
             {
                 if (EnableReconnect)
                 {
@@ -308,7 +316,7 @@ namespace Client.Services
                     StartReconnectTimer();
             };
 
-            Connection.On<UserInfo>("UserConnected", user =>
+            connection.On<UserInfo>("UserConnected", user =>
             {
                 Dispatcher?.TryEnqueue(async () =>
                 {
@@ -330,7 +338,7 @@ namespace Client.Services
             });
 
 
-            Connection.On<List<UserInfo>>("UserListUpdated", users =>
+            connection.On<List<UserInfo>>("UserListUpdated", users =>
             {
                 Dispatcher?.TryEnqueue(async () =>
                 {
@@ -365,7 +373,7 @@ namespace Client.Services
                 });
             });
 
-            Connection.On<List<string>>("UserListOrder", order =>
+            connection.On<List<string>>("UserListOrder", order =>
             {
                 Dispatcher?.TryEnqueue(() =>
                 {
@@ -382,7 +390,7 @@ namespace Client.Services
                 });
             });
 
-            Connection.On<int, string, string, string, string, string, DateTime>("ReceiveMessage", (id, user, room, destinataire, msg, avatar, time) =>
+            connection.On<int, string, string, string, string, string, DateTime>("ReceiveMessage", (id, user, room, destinataire, msg, avatar, time) =>
             {
                 var senderColor = ConnectedUsers.FirstOrDefault(u => u.Username == user)?.ColorUserName ?? "Black";
                 var destColor = ConnectedUsers.FirstOrDefault(u => u.Username == destinataire)?.ColorUserName ?? "Black";
@@ -409,7 +417,7 @@ namespace Client.Services
                 });
             });
 
-            Connection.On<string, string>("ReceiveCall", (caller, room) =>
+            connection.On<string, string>("ReceiveCall", (caller, room) =>
             {
                 Dispatcher?.TryEnqueue(async () =>
                 {
@@ -418,7 +426,7 @@ namespace Client.Services
                 });
             });
 
-            Connection.On<int>("MessageDeleted", id =>
+            connection.On<int>("MessageDeleted", id =>
             {
                 Dispatcher?.TryEnqueue(async () =>
                 {
@@ -431,7 +439,7 @@ namespace Client.Services
             });
 
 
-            Connection.On<Patient>("NewPatient", patient =>
+            connection.On<Patient>("NewPatient", patient =>
             {
                 Dispatcher?.TryEnqueue(() =>
                 {
@@ -440,7 +448,7 @@ namespace Client.Services
                 });
             });
 
-            Connection.On<string>("PatientRemoved", id =>
+            connection.On<string>("PatientRemoved", id =>
             {
                 Dispatcher?.TryEnqueue(() =>
                 {
@@ -451,7 +459,7 @@ namespace Client.Services
                 });
             });
 
-            Connection.On<Patient>("PatientUpdated", patient =>
+            connection.On<Patient>("PatientUpdated", patient =>
             {
                 Dispatcher?.TryEnqueue(() =>
                 {
@@ -469,17 +477,17 @@ namespace Client.Services
                 });
             });
 
-            Connection.On<IEnumerable<ExamOption>>("ExamOptionsUpdated", opts =>
+            connection.On<IEnumerable<ExamOption>>("ExamOptionsUpdated", opts =>
             {
                 ExamOptionsUpdated?.Invoke(opts);
             });
 
-            Connection.On<IEnumerable<string>>("RoomsUpdated", rooms =>
+            connection.On<IEnumerable<string>>("RoomsUpdated", rooms =>
             {
                 RoomsUpdated?.Invoke(rooms);
             });
 
-            Connection.On<string, string>("UserSettingsUpdated", (username, json) =>
+            connection.On<string, string>("UserSettingsUpdated", (username, json) =>
             {
                 Dispatcher?.TryEnqueue(() =>
                 {
@@ -506,8 +514,8 @@ namespace Client.Services
 
             try
             {
-                await Connection.StartAsync();
-                await Connection.InvokeAsync("RegisterUser", username, ToServerAvatar(avatar), room, color);
+                await connection.StartAsync();
+                await connection.InvokeAsync("RegisterUser", username, ToServerAvatar(avatar), room, color);
                 StopReconnectTimer();
             }
             catch (Exception ex)
@@ -556,31 +564,33 @@ namespace Client.Services
 
         public async Task SendMessage(string sender, string roomname, string destinataire, string message, string avatar, DateTime timemessage)
         {
-            if (Connection is null || Connection.State != HubConnectionState.Connected)
-                throw new InvalidOperationException("Connexion SignalR non établie.");
-            await Connection.InvokeAsync("SendMessage", sender, roomname, destinataire, message, ToServerAvatar(avatar), timemessage);
+            var connection = GetRequiredConnection();
+            await connection.InvokeAsync("SendMessage", sender, roomname, destinataire, message, ToServerAvatar(avatar), timemessage);
 
         }
 
         public async Task CallUser(string sender, string roomname, string destinataire)
         {
-            if (Connection is null || Connection.State != HubConnectionState.Connected)
-                throw new InvalidOperationException("Connexion SignalR non établie.");
-            await Connection.InvokeAsync("CallUser", sender, roomname, destinataire);
+            var connection = GetRequiredConnection();
+            await connection.InvokeAsync("CallUser", sender, roomname, destinataire);
         }
 
         public async Task<Result<List<ChatMessageModel>>> LoadTodayMessagesAsync(string username)
         {
-            if (Connection is null || Connection.State != HubConnectionState.Connected)
+            var connection = GetActiveConnection();
+            if (connection is null)
             {
                 var connected = await TryReconnectAsync();
                 if (!connected)
                     return Result<List<ChatMessageModel>>.Fail("Serveur injoignable.");
+                connection = GetActiveConnection();
+                if (connection is null)
+                    return Result<List<ChatMessageModel>>.Fail("Connexion indisponible.");
             }
 
             try
             {
-                var raw = await Connection.InvokeAsync<List<ChatMessageModel>>("GetTodayMessages", username);
+                var raw = await connection.InvokeAsync<List<ChatMessageModel>>("GetTodayMessages", username);
 
                 var messages = raw.Select(m => new ChatMessageModel
                 {
@@ -607,12 +617,13 @@ namespace Client.Services
         }
         public async Task<Result<List<ChatMessageModel>>> LoadMessagesForDateAsync(string username, DateTime date)
         {
-            if (Connection is null || Connection.State != HubConnectionState.Connected)
+            var connection = GetActiveConnection();
+            if (connection is null)
                 return Result<List<ChatMessageModel>>.Fail("Déconnecté");
 
             try
             {
-                var raw = await Connection.InvokeAsync<List<ChatMessageModel>>("GetMessagesForDate", username, date);
+                var raw = await connection.InvokeAsync<List<ChatMessageModel>>("GetMessagesForDate", username, date);
 
                 return Result<List<ChatMessageModel>>.Ok(
                     raw.Select(m => new ChatMessageModel
@@ -723,37 +734,43 @@ namespace Client.Services
 
         public async Task DeclarePatient(Patient p)
         {
-            await Connection.InvokeAsync("DeclarePatient", p);
+            var connection = GetRequiredConnection();
+            await connection.InvokeAsync("DeclarePatient", p);
         }
 
         public async Task RemovePatientAsync(string id)
         {
-            if (Connection != null && Connection.State == HubConnectionState.Connected)
-                await Connection.InvokeAsync("RemovePatient", id);
+            var connection = GetActiveConnection();
+            if (connection != null)
+                await connection.InvokeAsync("RemovePatient", id);
         }
 
         public async Task SetPatientTakenAsync(string id, bool isTaken)
         {
-            if (Connection != null && Connection.State == HubConnectionState.Connected)
-                await Connection.InvokeAsync("UpdatePatientIsTaken", id, isTaken);
+            var connection = GetActiveConnection();
+            if (connection != null)
+                await connection.InvokeAsync("UpdatePatientIsTaken", id, isTaken);
         }
 
         public async Task UpdatePatientHoldTimeAsync(string id, DateTime newTime)
         {
-            if (Connection != null && Connection.State == HubConnectionState.Connected)
-                await Connection.InvokeAsync("UpdatePatientHoldTime", id, newTime);
+            var connection = GetActiveConnection();
+            if (connection != null)
+                await connection.InvokeAsync("UpdatePatientHoldTime", id, newTime);
         }
 
         public async Task UpdatePatientAsync(Patient patient)
         {
-            if (Connection != null && Connection.State == HubConnectionState.Connected)
-                await Connection.InvokeAsync("UpdatePatient", patient);
+            var connection = GetActiveConnection();
+            if (connection != null)
+                await connection.InvokeAsync("UpdatePatient", patient);
         }
 
         public async Task DeleteMessageAsync(int id)
         {
-            if (Connection != null && Connection.State == HubConnectionState.Connected)
-                await Connection.InvokeAsync("DeleteMessage", id);
+            var connection = GetActiveConnection();
+            if (connection != null)
+                await connection.InvokeAsync("DeleteMessage", id);
         }
         public async Task<List<ChatMessageModel>> LoadTodayMessagesFromDiskAsync()
         {


### PR DESCRIPTION
## Summary
- remove unused async modifiers and tighten null-handling in the WinUI app bootstrap, converters, and navigation logic
- harden appearance and chat pages against nullable data and update helper routines accordingly
- adjust hotkey service dialogs to validate XAML roots before use and guard SignalR helper routines

## Testing
- not run (environment missing dotnet SDK)


------
https://chatgpt.com/codex/tasks/task_e_68e7460073e08324848693799f057359