### PR TITLE
Add clone helper to UserInfo model

### DIFF
--- a/Client/Dialogs/UserManagerDialog.xaml.cs
+++ b/Client/Dialogs/UserManagerDialog.xaml.cs
@@ -118,26 +118,7 @@ namespace Client.Dialogs
             }
         }
 
-        private static UserInfo CloneUser(UserInfo user)
-        {
-            var clone = new UserInfo
-            {
-                Username = user.Username,
-                DisplayName = user.DisplayName,
-                Avatar = user.Avatar,
-                ColorUserName = user.ColorUserName,
-                Note = user.Note,
-                IsOnline = user.IsOnline,
-                CanRenameLocalUser = user.CanRenameLocalUser
-            };
-
-            var roomsToCopy = user.Rooms?.Where(room => !string.IsNullOrWhiteSpace(room))
-                ?? Enumerable.Empty<string>();
-
-            clone.Rooms = new ObservableCollection<string>(roomsToCopy);
-
-            return clone;
-        }
+        private static UserInfo CloneUser(UserInfo user) => user.Clone();
 
         private async void RenameLocal_Click(object sender, RoutedEventArgs e)
         {

--- a/Client/Models/UserInfo.cs
+++ b/Client/Models/UserInfo.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Linq;
 using Client.Helpers;
 
 namespace Client.Models
@@ -140,5 +141,28 @@ namespace Client.Models
 
         // Propriétés manquantes pour la correction XLS0432
         public bool CanRenameLocalUser { get; set; }
+
+        public UserInfo Clone()
+        {
+            var clone = new UserInfo
+            {
+                ConnectionId = ConnectionId,
+                Username = Username,
+                DisplayName = DisplayName,
+                Avatar = Avatar,
+                ColorUserName = ColorUserName,
+                Note = Note,
+                IsOnline = IsOnline,
+                CanRenameLocalUser = CanRenameLocalUser
+            };
+
+            var roomsToCopy = Rooms?.Where(room => !string.IsNullOrWhiteSpace(room))
+                ?? Enumerable.Empty<string>();
+
+            clone.Rooms = new ObservableCollection<string>(roomsToCopy);
+            clone.SetAccentSelection(_usesAccentContrast);
+
+            return clone;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a cloning helper to UserInfo so that all fields, rooms, and accent selection are carried over when duplicating a user
- update UserManagerDialog to rely on the new helper for creating user clones

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e75ca3d4b08324b49bd0d977fcd4be