### PR TITLE
Ensure UserManager dialog busy state updates on UI thread

### DIFF
--- a/Client/Dialogs/UserManagerDialog.xaml.cs
+++ b/Client/Dialogs/UserManagerDialog.xaml.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Client.Models;
 using Client.Services;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
@@ -39,6 +40,19 @@ namespace Client.Dialogs
             get => _isBusy;
             private set
             {
+                var dispatcher = DispatcherQueue
+                    ?? XamlRoot?.DispatcherQueue
+                    ?? App.MainWindow?.DispatcherQueue;
+
+                if (dispatcher is not null && !dispatcher.HasThreadAccess)
+                {
+                    if (!dispatcher.TryEnqueue(() => IsBusy = value))
+                    {
+                        Debug.WriteLine("[UserManagerDialog] Unable to marshal IsBusy change to dispatcher.");
+                    }
+                    return;
+                }
+
                 if (SetProperty(ref _isBusy, value))
                 {
                     OnPropertyChanged(nameof(IsIdle));


### PR DESCRIPTION
## Summary
- guard updates to the UserManager busy flag behind the dialog's dispatcher to avoid cross-thread UI access
- keep the primary button enablement in sync once marshalled back to the UI thread

## Testing
- not run (environment lacks dotnet)


------
https://chatgpt.com/codex/tasks/task_e_68e7713671888324bba4e8d5e0deb198