### PR TITLE
Fix UserManager dialog permissions

### DIFF
--- a/Client/Dialogs/UserManagerDialog.xaml.cs
+++ b/Client/Dialogs/UserManagerDialog.xaml.cs
@@ -114,7 +114,11 @@ namespace Client.Dialogs
                 Debug.WriteLine($"[UserManagerDialog] Local users loaded: {users.Count()}");
                 LocalUsers.Clear();
                 foreach (var user in users.OrderBy(u => u.Name, StringComparer.OrdinalIgnoreCase))
-                    LocalUsers.Add(CloneUser(user));
+                {
+                    var clone = CloneUser(user);
+                    clone.CanRenameLocalUser = CanManageUser(clone.Username);
+                    LocalUsers.Add(clone);
+                }
 
                 LocalStatus = LocalUsers.Count == 0
                     ? "Aucun utilisateur local enregistré."
@@ -138,7 +142,11 @@ namespace Client.Dialogs
                 Debug.WriteLine($"[UserManagerDialog] Server users loaded: {users.Count()}");
                 ServerUsers.Clear();
                 foreach (var user in users.OrderBy(u => u.Name, StringComparer.OrdinalIgnoreCase))
-                    ServerUsers.Add(CloneUser(user));
+                {
+                    var clone = CloneUser(user);
+                    clone.CanRenameLocalUser = CanManageUser(clone.Username);
+                    ServerUsers.Add(clone);
+                }
 
                 ServerStatus = ServerUsers.Count == 0
                     ? "Aucun utilisateur connu sur le serveur."

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -832,6 +832,8 @@ namespace Client.Services
                     {
                         if (u.Rooms.Count == 0)
                             u.IsOnline = false;
+
+                        u.CanRenameLocalUser = !IsProtectedUser(u.Username);
                     }
                     return users;
                 }
@@ -1145,7 +1147,13 @@ namespace Client.Services
 
             try
             {
-                return await connection.InvokeAsync<List<UserInfo>>("GetAllUsers");
+                var users = await connection.InvokeAsync<List<UserInfo>>("GetAllUsers");
+                foreach (var user in users)
+                {
+                    user.CanRenameLocalUser = !IsProtectedUser(user.Username);
+                }
+
+                return users;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- ensure UserManager dialog clones mark users as manageable when populating local and server lists
- propagate non-protected status to cached and server user lists so rename/delete actions become available

## Testing
- dotnet build WebApplication1.sln *(fails: dotnet unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e77e8b21c48324848c5cb637bfad3b