### PR TITLE
Filter protected accounts out of UserManager server list

### DIFF
--- a/Client/Dialogs/UserManagerDialog.xaml.cs
+++ b/Client/Dialogs/UserManagerDialog.xaml.cs
@@ -141,7 +141,14 @@ namespace Client.Dialogs
                 var users = await _service.GetAllUsersAsync();
                 Debug.WriteLine($"[UserManagerDialog] Server users loaded: {users.Count()}");
                 ServerUsers.Clear();
-                foreach (var user in users.OrderBy(u => u.Name, StringComparer.OrdinalIgnoreCase))
+                var filteredUsers = users
+                    .Where(u => !IsProtectedUser(u.Username))
+                    .OrderBy(u => u.Name, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                Debug.WriteLine($"[UserManagerDialog] Server users after filtering protected accounts: {filteredUsers.Count}");
+
+                foreach (var user in filteredUsers)
                 {
                     var clone = CloneUser(user);
                     clone.CanRenameLocalUser = CanManageUser(clone.Username);


### PR DESCRIPTION
## Summary
- filter out the built-in "A Tous" and "Secrétariat" accounts when populating the server-side list in the UserManager dialog
- add logging to show how many accounts remain after filtering

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e78854b1208324946b1e782cd54fd6