### PR TITLE
Improve UserManager logging and data loading resilience

### DIFF
--- a/Client/Dialogs/UserManagerDialog.xaml.cs
+++ b/Client/Dialogs/UserManagerDialog.xaml.cs
@@ -17,6 +17,9 @@ namespace Client.Dialogs
     {
         private readonly SignalRService _service;
 
+        private const string LocalLoadErrorCode = "UM-LOCAL-ERR-001";
+        private const string ServerLoadErrorCode = "UM-SERVER-ERR-001";
+
         public ObservableCollection<UserInfo> LocalUsers { get; } = new();
         public ObservableCollection<UserInfo> ServerUsers { get; } = new();
 
@@ -110,13 +113,21 @@ namespace Client.Dialogs
             Debug.WriteLine("[UserManagerDialog] RefreshLocalAsync start");
             try
             {
-                var users = await _service.LoadUsersFromDiskAsync();
-                Debug.WriteLine($"[UserManagerDialog] Local users loaded: {users.Count()}");
                 LocalUsers.Clear();
-                foreach (var user in users.OrderBy(u => u.Name, StringComparer.OrdinalIgnoreCase))
+
+                var users = await _service.LoadUsersFromDiskAsync();
+                var userList = users
+                    .OrderBy(u => u.Name, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                Debug.WriteLine($"[UserManagerDialog] Local users loaded: {users.Count}");
+                Debug.WriteLine($"[UserManagerDialog] Local users after ordering: {userList.Count}");
+
+                foreach (var user in userList)
                 {
                     var clone = CloneUser(user);
                     clone.CanRenameLocalUser = CanManageUser(clone.Username);
+                    Debug.WriteLine($"[UserManagerDialog] Local user added: Username={clone.Username} Rooms={string.Join('|', clone.Rooms)} CanRename={clone.CanRenameLocalUser}");
                     LocalUsers.Add(clone);
                 }
 
@@ -127,8 +138,9 @@ namespace Client.Dialogs
             }
             catch (Exception ex)
             {
-                LocalStatus = $"Erreur de chargement local : {ex.Message}";
-                Debug.WriteLine($"[UserManagerDialog] Error loading local users: {ex}");
+                LocalUsers.Clear();
+                LocalStatus = $"{LocalLoadErrorCode} - Erreur de chargement local : {ex.Message}";
+                Debug.WriteLine($"[UserManagerDialog] Error loading local users ({LocalLoadErrorCode}): {ex}");
             }
             Debug.WriteLine("[UserManagerDialog] RefreshLocalAsync end");
         }
@@ -138,9 +150,10 @@ namespace Client.Dialogs
             Debug.WriteLine("[UserManagerDialog] RefreshServerAsync start");
             try
             {
-                var users = await _service.GetAllUsersAsync();
-                Debug.WriteLine($"[UserManagerDialog] Server users loaded: {users.Count()}");
                 ServerUsers.Clear();
+
+                var users = await _service.GetAllUsersAsync();
+                Debug.WriteLine($"[UserManagerDialog] Server users loaded: {users.Count}");
                 var filteredUsers = users
                     .Where(u => !IsProtectedUser(u.Username))
                     .OrderBy(u => u.Name, StringComparer.OrdinalIgnoreCase)
@@ -152,6 +165,7 @@ namespace Client.Dialogs
                 {
                     var clone = CloneUser(user);
                     clone.CanRenameLocalUser = CanManageUser(clone.Username);
+                    Debug.WriteLine($"[UserManagerDialog] Server user added: Username={clone.Username} Rooms={string.Join('|', clone.Rooms)} CanRename={clone.CanRenameLocalUser}");
                     ServerUsers.Add(clone);
                 }
 
@@ -162,8 +176,9 @@ namespace Client.Dialogs
             }
             catch (Exception ex)
             {
-                ServerStatus = $"Erreur de chargement serveur : {ex.Message}";
-                Debug.WriteLine($"[UserManagerDialog] Error loading server users: {ex}");
+                ServerUsers.Clear();
+                ServerStatus = $"{ServerLoadErrorCode} - Erreur de chargement serveur : {ex.Message}";
+                Debug.WriteLine($"[UserManagerDialog] Error loading server users ({ServerLoadErrorCode}): {ex}");
             }
             Debug.WriteLine("[UserManagerDialog] RefreshServerAsync end");
         }

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -820,28 +820,56 @@ namespace Client.Services
 
         public async Task<List<UserInfo>> LoadUsersFromDiskAsync()
         {
+            const string logPrefix = "[SignalRService][UM-LOCAL]";
+
             try
             {
                 var path = GetLocalUsersFilePath(false);
-                var folder = Path.GetDirectoryName(path)!;
-                if (Directory.Exists(folder) && File.Exists(path))
-                {
-                    var json = await File.ReadAllTextAsync(path);
-                    var users = JsonConvert.DeserializeObject<List<UserInfo>>(json) ?? new();
-                    foreach (var u in users)
-                    {
-                        if (u.Rooms.Count == 0)
-                            u.IsOnline = false;
+                var folder = Path.GetDirectoryName(path) ?? string.Empty;
+                var folderExists = !string.IsNullOrEmpty(folder) && Directory.Exists(folder);
+                var fileExists = folderExists && File.Exists(path);
 
-                        u.CanRenameLocalUser = !IsProtectedUser(u.Username);
+                Debug.WriteLine($"{logPrefix}-LOAD-START Path={path} FolderExists={folderExists} FileExists={fileExists}");
+
+                if (!folderExists || !fileExists)
+                {
+                    Debug.WriteLine($"{logPrefix}-LOAD-NOTFOUND Aucun fichier local users.json trouvé.");
+                    return new();
+                }
+
+                const int maxAttempts = 3;
+                for (var attempt = 1; attempt <= maxAttempts; attempt++)
+                {
+                    try
+                    {
+                        var json = await File.ReadAllTextAsync(path);
+                        var users = JsonConvert.DeserializeObject<List<UserInfo>>(json) ?? new();
+                        Debug.WriteLine($"{logPrefix}-LOAD-RAW Count={users.Count}");
+
+                        foreach (var u in users)
+                        {
+                            if (u.Rooms.Count == 0)
+                                u.IsOnline = false;
+
+                            u.CanRenameLocalUser = !IsProtectedUser(u.Username);
+                        }
+
+                        Debug.WriteLine($"{logPrefix}-LOAD-SUCCESS Count={users.Count}");
+                        return users;
                     }
-                    return users;
+                    catch (IOException ioEx) when (attempt < maxAttempts)
+                    {
+                        Debug.WriteLine($"{logPrefix}-LOAD-IORETRY Attempt={attempt} Error={ioEx.Message}");
+                        await Task.Delay(TimeSpan.FromMilliseconds(100 * attempt));
+                    }
                 }
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"Erreur lecture users cache : {ex.Message}");
+                Debug.WriteLine($"{logPrefix}-LOAD-ERROR {ex}");
             }
+
+            Debug.WriteLine($"{logPrefix}-LOAD-EMPTY Retour d'une liste vide.");
             return new();
         }
 
@@ -1138,26 +1166,44 @@ namespace Client.Services
 
         public async Task<List<UserInfo>> GetAllUsersAsync()
         {
+            const string logPrefix = "[SignalRService][UM-SERVER]";
+
             if (!TryGetActiveConnection(out var connection))
             {
+                Debug.WriteLine($"{logPrefix}-CONNECTION-MISSING Aucune connexion SignalR active.");
                 var connected = await TryReconnectAsync();
+                Debug.WriteLine($"{logPrefix}-CONNECTION-RETRY Result={connected}");
                 if (!connected || !TryGetActiveConnection(out connection))
+                {
+                    Debug.WriteLine($"{logPrefix}-CONNECTION-FAILED Impossible d'obtenir une connexion.");
                     return new List<UserInfo>();
+                }
             }
 
             try
             {
+                Debug.WriteLine($"{logPrefix}-LOAD-REQUEST Envoi de la requête GetAllUsers.");
                 var users = await connection.InvokeAsync<List<UserInfo>>("GetAllUsers");
+                var count = users?.Count ?? 0;
+                Debug.WriteLine($"{logPrefix}-LOAD-RESPONSE Count={count}");
+
+                if (users == null)
+                {
+                    Debug.WriteLine($"{logPrefix}-LOAD-NULL La réponse GetAllUsers est nulle.");
+                    return new List<UserInfo>();
+                }
+
                 foreach (var user in users)
                 {
                     user.CanRenameLocalUser = !IsProtectedUser(user.Username);
                 }
 
+                Debug.WriteLine($"{logPrefix}-LOAD-SUCCESS Count={users.Count}");
                 return users;
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"Erreur récupération utilisateurs : {ex.Message}");
+                Debug.WriteLine($"{logPrefix}-LOAD-ERROR {ex}");
                 return new List<UserInfo>();
             }
         }


### PR DESCRIPTION
## Summary
- add error codes and verbose debug output during UserManager local and server refresh operations
- harden SignalR local user cache loading with retries and detailed diagnostics, and log server retrieval states

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e78ba5b2d083248c77c21ee7f73b72