### PR TITLE
Update patient cards layout

### DIFF
--- a/Client/Models/Patient.cs
+++ b/Client/Models/Patient.cs
@@ -27,6 +27,28 @@ namespace Client.Models
 
         public string HoldTimeFormatted => HoldTime.ToString("HH:mm");
         public string? PickUpTimeFormatted => PickUpTime?.ToString("HH:mm");
+        public string TimeSinceHoldTimeFormatted
+        {
+            get
+            {
+                var span = DateTime.Now - HoldTime;
+
+                if (span < TimeSpan.Zero)
+                {
+                    span = TimeSpan.Zero;
+                }
+
+                if (span.TotalDays >= 1)
+                {
+                    var days = (int)span.TotalDays;
+                    return $"{days}j {span:hh\\:mm}";
+                }
+
+                return span.TotalHours >= 1
+                    ? span.ToString("hh\\:mm")
+                    : span.ToString("mm\\:ss");
+            }
+        }
 
         public string ToggleExamLabel => IsTaken
             ? $"Annuler {Exams} de {FirstName} {LastName}"

--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -247,33 +247,46 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
 
-                    <!-- Première ligne : Titre, Nom, Prénom -->
-                    <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal" Spacing="4">
-                        <TextBlock Text="{x:Bind Title}" FontWeight="Bold" Foreground="{x:Bind ForegroundColor}"/>
-                        <TextBlock Text="{x:Bind LastName}" Margin="4,0" Foreground="{x:Bind ForegroundColor}"/>
-                        <TextBlock Text="{x:Bind FirstName}" Foreground="{x:Bind ForegroundColor}"/>
-                    </StackPanel>
+                    <Grid Grid.Row="0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="4" Margin="0,0,8,0">
+                            <TextBlock Text="{x:Bind Title}" FontWeight="Bold" Foreground="{x:Bind ForegroundColor}"/>
+                            <TextBlock Text="{x:Bind LastName}" Margin="4,0" Foreground="{x:Bind ForegroundColor}"/>
+                            <TextBlock Text="{x:Bind FirstName}" Foreground="{x:Bind ForegroundColor}"/>
+                        </StackPanel>
+                        <TextBlock Grid.Column="1"
+                                   Text="{x:Bind OperatorName}"
+                                   Foreground="{x:Bind ForegroundColor}"
+                                   HorizontalAlignment="Right"/>
+                    </Grid>
 
-                    <!-- Examinator à droite de la première ligne -->
-                    <TextBlock Grid.Row="0" Grid.Column="1"
-                       Text="{x:Bind Examinator}" Foreground="{x:Bind ForegroundColor}"
-                       HorizontalAlignment="Right"/>
+                    <Grid Grid.Row="1" Margin="0,2,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{x:Bind Exams}" FontWeight="Bold" Foreground="{x:Bind ForegroundColor}" Margin="0,0,8,0"/>
+                        <TextBlock Grid.Column="1" Text="{x:Bind Annotation}" Foreground="{x:Bind ForegroundColor}" TextTrimming="CharacterEllipsis" Margin="0,0,8,0"/>
+                        <TextBlock Grid.Column="2" Text="{x:Bind Eye}" Foreground="{x:Bind ForegroundColor}" Margin="0,0,8,0"/>
+                        <TextBlock Grid.Column="3" Text="{x:Bind HoldTimeFormatted}" Foreground="{x:Bind ForegroundColor}" FontWeight="Bold" HorizontalAlignment="Right"/>
+                    </Grid>
 
-                    <!-- Deuxième ligne : examens, œil, annotation et heure -->
-                    <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" Spacing="4">
-                        <TextBlock Text="{x:Bind Exams}" FontWeight="Bold" Foreground="{x:Bind ForegroundColor}"/>
-                        <TextBlock Text="{x:Bind Eye}" Foreground="{x:Bind ForegroundColor}"/>
-                        <TextBlock Text="{x:Bind Annotation}" Foreground="{x:Bind ForegroundColor}"/>
-                    </StackPanel>
-                    <TextBlock Grid.Row="1" Grid.Column="1"
-                       Text="{x:Bind HoldTimeFormatted}" Foreground="{x:Bind ForegroundColor}"
-                       FontWeight="Bold" HorizontalAlignment="Right"/>
+                    <Grid Grid.Row="2" Margin="0,2,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{x:Bind Position}" Foreground="{x:Bind ForegroundColor}" Margin="0,0,8,0"/>
+                        <TextBlock Grid.Column="1" Text="{x:Bind TimeSinceHoldTimeFormatted}" Foreground="{x:Bind ForegroundColor}" HorizontalAlignment="Right"/>
+                    </Grid>
                 </Grid>
             </Border>
         </DataTemplate>

--- a/Client/Pages/HistoryPage.xaml
+++ b/Client/Pages/HistoryPage.xaml
@@ -25,24 +25,46 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal" Spacing="4">
-                        <TextBlock Text="{x:Bind Title}" FontWeight="Bold" Foreground="{x:Bind ForegroundColor}"/>
-                        <TextBlock Text="{x:Bind LastName}" Margin="4,0" Foreground="{x:Bind ForegroundColor}"/>
-                        <TextBlock Text="{x:Bind FirstName}" Foreground="{x:Bind ForegroundColor}"/>
-                    </StackPanel>
-                    <TextBlock Grid.Row="0" Grid.Column="1" Text="{x:Bind Examinator}" Foreground="{x:Bind ForegroundColor}" HorizontalAlignment="Right"/>
-                    <!-- Deuxième ligne : examens, œil, annotation et heure -->
-                    <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" Spacing="4">
-                        <TextBlock Text="{x:Bind Exams}" FontWeight="Bold" Foreground="{x:Bind ForegroundColor}"/>
-                        <TextBlock Text="{x:Bind Eye}" Foreground="{x:Bind ForegroundColor}"/>
-                        <TextBlock Text="{x:Bind Annotation}" Foreground="{x:Bind ForegroundColor}"/>
-                    </StackPanel>
-                    <TextBlock Grid.Row="1" Grid.Column="1" Text="{x:Bind HoldTimeFormatted}" Foreground="{x:Bind ForegroundColor}" FontWeight="Bold" HorizontalAlignment="Right"/>
+
+                    <Grid Grid.Row="0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="4" Margin="0,0,8,0">
+                            <TextBlock Text="{x:Bind Title}" FontWeight="Bold" Foreground="{x:Bind ForegroundColor}"/>
+                            <TextBlock Text="{x:Bind LastName}" Margin="4,0" Foreground="{x:Bind ForegroundColor}"/>
+                            <TextBlock Text="{x:Bind FirstName}" Foreground="{x:Bind ForegroundColor}"/>
+                        </StackPanel>
+                        <TextBlock Grid.Column="1"
+                                   Text="{x:Bind OperatorName}"
+                                   Foreground="{x:Bind ForegroundColor}"
+                                   HorizontalAlignment="Right"/>
+                    </Grid>
+
+                    <Grid Grid.Row="1" Margin="0,2,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{x:Bind Exams}" FontWeight="Bold" Foreground="{x:Bind ForegroundColor}" Margin="0,0,8,0"/>
+                        <TextBlock Grid.Column="1" Text="{x:Bind Annotation}" Foreground="{x:Bind ForegroundColor}" TextTrimming="CharacterEllipsis" Margin="0,0,8,0"/>
+                        <TextBlock Grid.Column="2" Text="{x:Bind Eye}" Foreground="{x:Bind ForegroundColor}" Margin="0,0,8,0"/>
+                        <TextBlock Grid.Column="3" Text="{x:Bind HoldTimeFormatted}" Foreground="{x:Bind ForegroundColor}" FontWeight="Bold" HorizontalAlignment="Right"/>
+                    </Grid>
+
+                    <Grid Grid.Row="2" Margin="0,2,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{x:Bind Position}" Foreground="{x:Bind ForegroundColor}" Margin="0,0,8,0"/>
+                        <TextBlock Grid.Column="1" Text="{x:Bind TimeSinceHoldTimeFormatted}" Foreground="{x:Bind ForegroundColor}" HorizontalAlignment="Right"/>
+                    </Grid>
                 </Grid>
             </Border>
         </DataTemplate>
@@ -89,24 +111,46 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal" Spacing="4">
-                        <TextBlock Text="{x:Bind Title}" FontWeight="Bold" Foreground="{x:Bind ForegroundColor}"/>
-                        <TextBlock Text="{x:Bind LastName}" Margin="4,0" Foreground="{x:Bind ForegroundColor}"/>
-                        <TextBlock Text="{x:Bind FirstName}" Foreground="{x:Bind ForegroundColor}"/>
-                    </StackPanel>
-                    <TextBlock Grid.Row="0" Grid.Column="1" Text="{x:Bind Examinator}" Foreground="{x:Bind ForegroundColor}" HorizontalAlignment="Right"/>
-                    <!-- Deuxième ligne : examens, œil, annotation et heure -->
-                    <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" Spacing="4">
-                        <TextBlock Text="{x:Bind Exams}" FontWeight="Bold" Foreground="{x:Bind ForegroundColor}"/>
-                        <TextBlock Text="{x:Bind Eye}" Foreground="{x:Bind ForegroundColor}"/>
-                        <TextBlock Text="{x:Bind Annotation}" Foreground="{x:Bind ForegroundColor}"/>
-                    </StackPanel>
-                    <TextBlock Grid.Row="1" Grid.Column="1" Text="{x:Bind HoldTimeFormatted}" Foreground="{x:Bind ForegroundColor}" FontWeight="Bold" HorizontalAlignment="Right"/>
+
+                    <Grid Grid.Row="0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="4" Margin="0,0,8,0">
+                            <TextBlock Text="{x:Bind Title}" FontWeight="Bold" Foreground="{x:Bind ForegroundColor}"/>
+                            <TextBlock Text="{x:Bind LastName}" Margin="4,0" Foreground="{x:Bind ForegroundColor}"/>
+                            <TextBlock Text="{x:Bind FirstName}" Foreground="{x:Bind ForegroundColor}"/>
+                        </StackPanel>
+                        <TextBlock Grid.Column="1"
+                                   Text="{x:Bind OperatorName}"
+                                   Foreground="{x:Bind ForegroundColor}"
+                                   HorizontalAlignment="Right"/>
+                    </Grid>
+
+                    <Grid Grid.Row="1" Margin="0,2,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{x:Bind Exams}" FontWeight="Bold" Foreground="{x:Bind ForegroundColor}" Margin="0,0,8,0"/>
+                        <TextBlock Grid.Column="1" Text="{x:Bind Annotation}" Foreground="{x:Bind ForegroundColor}" TextTrimming="CharacterEllipsis" Margin="0,0,8,0"/>
+                        <TextBlock Grid.Column="2" Text="{x:Bind Eye}" Foreground="{x:Bind ForegroundColor}" Margin="0,0,8,0"/>
+                        <TextBlock Grid.Column="3" Text="{x:Bind HoldTimeFormatted}" Foreground="{x:Bind ForegroundColor}" FontWeight="Bold" HorizontalAlignment="Right"/>
+                    </Grid>
+
+                    <Grid Grid.Row="2" Margin="0,2,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{x:Bind Position}" Foreground="{x:Bind ForegroundColor}" Margin="0,0,8,0"/>
+                        <TextBlock Grid.Column="1" Text="{x:Bind TimeSinceHoldTimeFormatted}" Foreground="{x:Bind ForegroundColor}" HorizontalAlignment="Right"/>
+                    </Grid>
                 </Grid>
             </Border>
         </DataTemplate>


### PR DESCRIPTION
## Summary
- reorganize the non pris-en-charge patient templates into three lines with separate grids
- show the operator name on the first line and reorganize exam, annotation, eye, and declaration time across four columns
- add the displayed floor and elapsed time since declaration in the third line along with a new computed property

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e7aaf559148324bc66224b0f396719