### PR TITLE
Add configurable wait time alerts for patients

### DIFF
--- a/Client/Helpers/MachineConfig.cs
+++ b/Client/Helpers/MachineConfig.cs
@@ -25,6 +25,11 @@ namespace Client.Helpers
         /// </summary>
         public bool ShowSlashCommands { get; set; } = true;
 
+        /// <summary>
+        /// Delay in minutes before highlighting waiting patients.
+        /// </summary>
+        public int PickupAlertThresholdMinutes { get; set; }
+
         public static string FilePath =>
             Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                 "EyeChat", "machine.json");

--- a/Client/Models/Patient.cs
+++ b/Client/Models/Patient.cs
@@ -1,8 +1,9 @@
 using System;
+using System.ComponentModel;
 
 namespace Client.Models
 {
-    public class Patient
+    public class Patient : INotifyPropertyChanged
     {
         public string Id { get; set; } = string.Empty;
         public string Colors { get; set; } = string.Empty;
@@ -25,33 +26,56 @@ namespace Client.Models
         public bool IsTaken { get; set; }
         public bool IsArchived { get; set; }
 
+        private int _pickupAlertThresholdMinutes;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
         public string HoldTimeFormatted => HoldTime.ToString("HH:mm");
         public string? PickUpTimeFormatted => PickUpTime?.ToString("HH:mm");
         public string TimeSinceHoldTimeFormatted
         {
             get
             {
-                var span = DateTime.Now - HoldTime;
+                var span = GetElapsedHoldTime();
+                var minutes = (int)Math.Max(0, Math.Round(span.TotalMinutes, MidpointRounding.AwayFromZero));
+                var formatted = $"{minutes} min";
 
-                if (span < TimeSpan.Zero)
-                {
-                    span = TimeSpan.Zero;
-                }
-
-                if (span.TotalDays >= 1)
-                {
-                    var days = (int)span.TotalDays;
-                    return $"{days}j {span:hh\\:mm}";
-                }
-
-                return span.TotalHours >= 1
-                    ? span.ToString("hh\\:mm")
-                    : span.ToString("mm\\:ss");
+                return IsAlertActive(span)
+                    ? $"⚠️ {formatted}"
+                    : formatted;
             }
+        }
+
+        public bool RequiresPickupAttention => IsAlertActive(GetElapsedHoldTime());
+
+        public void RefreshHoldTimeInfo(int pickupAlertThresholdMinutes)
+        {
+            _pickupAlertThresholdMinutes = Math.Max(0, pickupAlertThresholdMinutes);
+            OnPropertyChanged(nameof(TimeSinceHoldTimeFormatted));
+            OnPropertyChanged(nameof(RequiresPickupAttention));
         }
 
         public string ToggleExamLabel => IsTaken
             ? $"Annuler {Exams} de {FirstName} {LastName}"
             : $"Faire passer {Exams} de {FirstName} {LastName}";
+
+        private TimeSpan GetElapsedHoldTime()
+        {
+            var span = DateTime.Now - HoldTime;
+            return span < TimeSpan.Zero ? TimeSpan.Zero : span;
+        }
+
+        private bool IsAlertActive(TimeSpan span)
+        {
+            if (IsTaken || _pickupAlertThresholdMinutes <= 0)
+            {
+                return false;
+            }
+
+            return span.TotalMinutes >= _pickupAlertThresholdMinutes;
+        }
+
+        private void OnPropertyChanged(string propertyName)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 }

--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -285,7 +285,11 @@
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
                         <TextBlock Grid.Column="0" Text="{x:Bind Position}" Foreground="{x:Bind ForegroundColor}" Margin="0,0,8,0"/>
-                        <TextBlock Grid.Column="1" Text="{x:Bind TimeSinceHoldTimeFormatted}" Foreground="{x:Bind ForegroundColor}" HorizontalAlignment="Right"/>
+                        <TextBlock Grid.Column="1"
+                                   Text="{x:Bind TimeSinceHoldTimeFormatted, Mode=OneWay}"
+                                   Foreground="{x:Bind RequiresPickupAttention ? \"#FFFF5555\" : ForegroundColor, Mode=OneWay}"
+                                   FontWeight="{x:Bind RequiresPickupAttention ? FontWeights.Bold : FontWeights.Normal, Mode=OneWay}"
+                                   HorizontalAlignment="Right"/>
                     </Grid>
                 </Grid>
             </Border>

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -969,6 +969,7 @@ namespace Client.Pages
                 var newValue = !patient.IsTaken;
                 patient.IsTaken = newValue;
                 patient.PickUpTime = newValue ? DateTime.Now : null;
+                _service.RefreshPatientHoldTimeInfo(patient);
                 UpdatePatientViews();
                 await _service.SetPatientTakenAsync(patient.Id, newValue);
             }
@@ -1012,6 +1013,7 @@ namespace Client.Pages
                 patient.PickUpTime = null;
             }
 
+            _service.RefreshPatientHoldTimeInfo(patient);
             UpdatePatientViews();
 
             if (wasTaken)
@@ -1048,6 +1050,7 @@ namespace Client.Pages
                     }
 
                     patient.HoldTime = newTime;
+                    _service.RefreshPatientHoldTimeInfo(patient);
                     UpdatePatientViews();
                     await _service.UpdatePatientHoldTimeAsync(patient.Id, newTime);
                 }
@@ -1067,6 +1070,7 @@ namespace Client.Pages
                     var avgTicks = (h1.Ticks + h2.Ticks) / 2;
                     var newTime = new DateTime(avgTicks);
                     patient.HoldTime = newTime;
+                    _service.RefreshPatientHoldTimeInfo(patient);
                     UpdatePatientViews();
                     await _service.UpdatePatientHoldTimeAsync(patient.Id, newTime);
                 }
@@ -1086,6 +1090,7 @@ namespace Client.Pages
                     var avgTicks = (h1.Ticks + h2.Ticks) / 2;
                     var newTime = new DateTime(avgTicks);
                     patient.HoldTime = newTime;
+                    _service.RefreshPatientHoldTimeInfo(patient);
                     UpdatePatientViews();
                     await _service.UpdatePatientHoldTimeAsync(patient.Id, newTime);
                 }

--- a/Client/Pages/HistoryPage.xaml
+++ b/Client/Pages/HistoryPage.xaml
@@ -63,7 +63,11 @@
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
                         <TextBlock Grid.Column="0" Text="{x:Bind Position}" Foreground="{x:Bind ForegroundColor}" Margin="0,0,8,0"/>
-                        <TextBlock Grid.Column="1" Text="{x:Bind TimeSinceHoldTimeFormatted}" Foreground="{x:Bind ForegroundColor}" HorizontalAlignment="Right"/>
+                        <TextBlock Grid.Column="1"
+                                   Text="{x:Bind TimeSinceHoldTimeFormatted, Mode=OneWay}"
+                                   Foreground="{x:Bind RequiresPickupAttention ? \"#FFFF5555\" : ForegroundColor, Mode=OneWay}"
+                                   FontWeight="{x:Bind RequiresPickupAttention ? FontWeights.Bold : FontWeights.Normal, Mode=OneWay}"
+                                   HorizontalAlignment="Right"/>
                     </Grid>
                 </Grid>
             </Border>
@@ -149,7 +153,11 @@
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
                         <TextBlock Grid.Column="0" Text="{x:Bind Position}" Foreground="{x:Bind ForegroundColor}" Margin="0,0,8,0"/>
-                        <TextBlock Grid.Column="1" Text="{x:Bind TimeSinceHoldTimeFormatted}" Foreground="{x:Bind ForegroundColor}" HorizontalAlignment="Right"/>
+                        <TextBlock Grid.Column="1"
+                                   Text="{x:Bind TimeSinceHoldTimeFormatted, Mode=OneWay}"
+                                   Foreground="{x:Bind RequiresPickupAttention ? \"#FFFF5555\" : ForegroundColor, Mode=OneWay}"
+                                   FontWeight="{x:Bind RequiresPickupAttention ? FontWeights.Bold : FontWeights.Normal, Mode=OneWay}"
+                                   HorizontalAlignment="Right"/>
                     </Grid>
                 </Grid>
             </Border>

--- a/Client/Pages/HistoryPage.xaml.cs
+++ b/Client/Pages/HistoryPage.xaml.cs
@@ -8,6 +8,7 @@ using Client.Models;
 using Client.Services;
 using Client.Helpers;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Dispatching;
 using System;
 
 namespace Client.Pages
@@ -19,6 +20,7 @@ namespace Client.Pages
         public ObservableCollection<string> Rooms { get; } = RoomList.Load();
         private ObservableCollection<string> RoomsWithAll { get; } = new();
         private readonly SignalRService _service;
+        private DispatcherQueueTimer? _holdTimeTimer;
 
         public bool ShowTimeModification { get; private set; }
         public Visibility TimeModificationVisibility => ShowTimeModification ? Visibility.Visible : Visibility.Collapsed;
@@ -31,12 +33,19 @@ namespace Client.Pages
             ShowTimeModification = cfg.ShowTimeModification;
             DataContext = this;
             Loaded += HistoryPage_Loaded;
+            Unloaded += HistoryPage_Unloaded;
             Rooms.CollectionChanged += Rooms_CollectionChanged;
         }
 
         private async void HistoryPage_Loaded(object sender, RoutedEventArgs e)
         {
             await LoadPatientsAsync();
+            StartHoldTimeTimer();
+        }
+
+        private void HistoryPage_Unloaded(object sender, RoutedEventArgs e)
+        {
+            StopHoldTimeTimer();
         }
 
         private async Task LoadPatientsAsync()
@@ -44,12 +53,18 @@ namespace Client.Pages
             var notArchived = await _service.GetPatientsAsync();
             NonArchivedPatients.Clear();
             foreach (var p in notArchived.OrderBy(p => p.HoldTime))
+            {
+                App.ChatService.RefreshPatientHoldTimeInfo(p);
                 NonArchivedPatients.Add(p);
+            }
 
             var archived = await _service.GetArchivedPatientsAsync();
             ArchivedPatients.Clear();
             foreach (var p in archived.OrderBy(p => p.HoldTime))
+            {
+                App.ChatService.RefreshPatientHoldTimeInfo(p);
                 ArchivedPatients.Add(p);
+            }
 
             BuildRooms();
         }
@@ -66,6 +81,7 @@ namespace Client.Pages
                 var newValue = !patient.IsTaken;
                 patient.IsTaken = newValue;
                 patient.PickUpTime = newValue ? DateTime.Now : null;
+                App.ChatService.RefreshPatientHoldTimeInfo(patient);
                 BuildRooms();
                 await _service.SetPatientTakenAsync(patient.Id, newValue);
             }
@@ -194,6 +210,7 @@ namespace Client.Pages
                     }
 
                     patient.HoldTime = newTime;
+                    App.ChatService.RefreshPatientHoldTimeInfo(patient);
                     BuildRooms();
                     await _service.UpdatePatientHoldTimeAsync(patient.Id, newTime);
                 }
@@ -213,6 +230,7 @@ namespace Client.Pages
                     var avgTicks = (h1.Ticks + h2.Ticks) / 2;
                     var newTime = new DateTime(avgTicks);
                     patient.HoldTime = newTime;
+                    App.ChatService.RefreshPatientHoldTimeInfo(patient);
                     BuildRooms();
                     await _service.UpdatePatientHoldTimeAsync(patient.Id, newTime);
                 }
@@ -232,9 +250,53 @@ namespace Client.Pages
                     var avgTicks = (h1.Ticks + h2.Ticks) / 2;
                     var newTime = new DateTime(avgTicks);
                     patient.HoldTime = newTime;
+                    App.ChatService.RefreshPatientHoldTimeInfo(patient);
                     BuildRooms();
                     await _service.UpdatePatientHoldTimeAsync(patient.Id, newTime);
                 }
+            }
+        }
+
+        private void StartHoldTimeTimer()
+        {
+            if (_holdTimeTimer is null)
+            {
+                _holdTimeTimer = DispatcherQueue.CreateTimer();
+                _holdTimeTimer.Interval = TimeSpan.FromSeconds(30);
+                _holdTimeTimer.Tick += HoldTimeTimer_Tick;
+            }
+
+            _holdTimeTimer.Start();
+            RefreshDisplayedHoldTimes();
+        }
+
+        private void StopHoldTimeTimer()
+        {
+            if (_holdTimeTimer is null)
+            {
+                return;
+            }
+
+            _holdTimeTimer.Tick -= HoldTimeTimer_Tick;
+            _holdTimeTimer.Stop();
+            _holdTimeTimer = null;
+        }
+
+        private void HoldTimeTimer_Tick(DispatcherQueueTimer sender, object args)
+        {
+            RefreshDisplayedHoldTimes();
+        }
+
+        private void RefreshDisplayedHoldTimes()
+        {
+            foreach (var patient in NonArchivedPatients.ToList())
+            {
+                App.ChatService.RefreshPatientHoldTimeInfo(patient);
+            }
+
+            foreach (var patient in ArchivedPatients.ToList())
+            {
+                App.ChatService.RefreshPatientHoldTimeInfo(patient);
             }
         }
 

--- a/Client/Pages/SystemPage.xaml
+++ b/Client/Pages/SystemPage.xaml
@@ -17,6 +17,14 @@
                                         <ToggleSwitch x:Name="TimeModSwitch" Header="Afficher la modification du temps" IsOn="{x:Bind ShowTimeModification, Mode=TwoWay}" Toggled="TimeModSwitch_Toggled"/>
                                         <ToggleSwitch x:Name="ReminderPageSwitch" Header="Afficher la page de rappel" IsOn="{x:Bind ShowReminderPage, Mode=TwoWay}" Toggled="ReminderPageSwitch_Toggled"/>
                                         <ToggleSwitch x:Name="SlashCommandsSwitch" Header="Afficher la liste des commandes" IsOn="{x:Bind ShowSlashCommands, Mode=TwoWay}" Toggled="SlashCommandsSwitch_Toggled"/>
+                                        <TextBlock Text="Alerte de prise en charge (minutes)"/>
+                                        <NumberBox
+                                            x:Name="PickupAlertBox"
+                                            Value="{x:Bind PickupAlertThresholdMinutes, Mode=TwoWay}"
+                                            Minimum="0"
+                                            SmallChange="1"
+                                            SpinButtonPlacementMode="Compact"/>
+                                        <TextBlock Text="Mettre 0 pour désactiver l'alerte." FontStyle="Italic" Opacity="0.7"/>
                                         <TextBlock Text="Utilisateur par défaut"/>
                                         <ComboBox
                                             x:Name="UsersComboBox"

--- a/Client/Pages/SystemPage.xaml.cs
+++ b/Client/Pages/SystemPage.xaml.cs
@@ -28,6 +28,7 @@ namespace Client.Pages
         public ObservableCollection<string> Users { get; } = new();
         public string DefaultUser { get; set; } = string.Empty;
         public bool ConnectLastUser { get; set; }
+        public double PickupAlertThresholdMinutes { get; set; }
 
         public SystemPage()
         {
@@ -40,11 +41,13 @@ namespace Client.Pages
             DefaultUser = _config.DefaultUser;
             ConnectLastUser = _config.ConnectLastUser;
             ShowSlashCommands = _config.ShowSlashCommands;
+            PickupAlertThresholdMinutes = _config.PickupAlertThresholdMinutes;
 
             var initialUsers = LoadUsernamesFromSettingsFiles();
             UpdateUsersCollection(initialUsers);
 
             DataContext = this;
+            PickupAlertBox.Value = PickupAlertThresholdMinutes;
             Loaded += SystemPage_Loaded;
         }
 
@@ -68,9 +71,13 @@ namespace Client.Pages
             _config.ShowSlashCommands = ShowSlashCommands;
             _config.DefaultUser = DefaultUser;
             _config.ConnectLastUser = ConnectLastUser;
+            _config.PickupAlertThresholdMinutes = (int)Math.Max(0, Math.Round(PickupAlertThresholdMinutes));
+            PickupAlertThresholdMinutes = _config.PickupAlertThresholdMinutes;
+            PickupAlertBox.Value = PickupAlertThresholdMinutes;
             MachineConfig.Save(_config);
             App.ChatService.RoomName = RoomName;
             await App.ChatService.UpdateRoomNameAsync(RoomName);
+            App.ChatService.PickupAlertThresholdMinutes = _config.PickupAlertThresholdMinutes;
         }
 
         private async void RenameRoom_Click(object sender, RoutedEventArgs e)

--- a/Client/Services/HotKeyService.cs
+++ b/Client/Services/HotKeyService.cs
@@ -434,6 +434,7 @@ namespace Client.Services
                 patient.Colors = opt?.Color ?? string.Empty;
                 var date = patient.HoldTime.Date;
                 patient.HoldTime = date + timePicker.Time;
+                App.ChatService.RefreshPatientHoldTimeInfo(patient);
 
                 try
                 {

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -27,7 +27,24 @@ namespace Client.Services
     public class SignalRService
     {
         public HubConnection? Connection { get; private set; }
-        public DispatcherQueue? Dispatcher { get; set; }
+        private DispatcherQueue? _dispatcher;
+        private DispatcherQueueTimer? _holdTimeUpdateTimer;
+        private int _pickupAlertThresholdMinutes;
+
+        public DispatcherQueue? Dispatcher
+        {
+            get => _dispatcher;
+            set
+            {
+                if (_dispatcher == value)
+                {
+                    return;
+                }
+
+                _dispatcher = value;
+                InitializeHoldTimeTimer();
+            }
+        }
         public ObservableCollection<UserInfo> ConnectedUsers { get; } = new();
         public ObservableCollection<Patient> Patients { get; } = new();
         public ObservableCollection<object> Messages { get; } = new();
@@ -68,12 +85,29 @@ namespace Client.Services
             set => _serverAddress = NormalizeServerAddress(value);
         }
 
+        public int PickupAlertThresholdMinutes
+        {
+            get => _pickupAlertThresholdMinutes;
+            set
+            {
+                var normalized = Math.Max(0, value);
+                if (_pickupAlertThresholdMinutes == normalized)
+                {
+                    return;
+                }
+
+                _pickupAlertThresholdMinutes = normalized;
+                RefreshAllPatientHoldTimes();
+            }
+        }
+
         public SignalRService()
         {
             var cfg = ConnectionConfig.Load();
             ServerAddress = cfg.ServerAddress;
             var machine = MachineConfig.Load();
             RoomName = machine.RoomName;
+            PickupAlertThresholdMinutes = machine.PickupAlertThresholdMinutes;
             AppSettings.SettingsChanged += OnSettingsChanged;
         }
 
@@ -126,6 +160,58 @@ namespace Client.Services
             {
                 user.RefreshAccentAwareColor();
             }
+        }
+
+        private void InitializeHoldTimeTimer()
+        {
+            if (_holdTimeUpdateTimer is { } existing)
+            {
+                existing.Tick -= HoldTimeTimer_Tick;
+                existing.Stop();
+            }
+
+            if (_dispatcher is null)
+            {
+                _holdTimeUpdateTimer = null;
+                return;
+            }
+
+            var timer = _dispatcher.CreateTimer();
+            timer.Interval = TimeSpan.FromSeconds(30);
+            timer.IsRepeating = true;
+            timer.Tick += HoldTimeTimer_Tick;
+            timer.Start();
+            _holdTimeUpdateTimer = timer;
+
+            RefreshAllPatientHoldTimes();
+        }
+
+        private void HoldTimeTimer_Tick(DispatcherQueueTimer sender, object args)
+        {
+            RefreshAllPatientHoldTimes();
+        }
+
+        private void RefreshAllPatientHoldTimes()
+        {
+            foreach (var patient in Patients.ToList())
+            {
+                patient.RefreshHoldTimeInfo(_pickupAlertThresholdMinutes);
+            }
+        }
+
+        public void RefreshPatientHoldTimeInfo(Patient? patient)
+        {
+            patient?.RefreshHoldTimeInfo(_pickupAlertThresholdMinutes);
+        }
+
+        private void PreparePatient(Patient? patient)
+        {
+            if (patient is null)
+            {
+                return;
+            }
+
+            patient.RefreshHoldTimeInfo(_pickupAlertThresholdMinutes);
         }
 
         public event Action<ChatMessageModel>? OnMessageReceived;
@@ -265,7 +351,10 @@ namespace Client.Services
             var patients = await GetPatientsAsync();
             Patients.Clear();
             foreach (var p in patients)
+            {
+                PreparePatient(p);
                 Patients.Add(p);
+            }
 
             await SyncServerConfigurationAsync();
         }
@@ -459,6 +548,7 @@ namespace Client.Services
             {
                 Dispatcher?.TryEnqueue(() =>
                 {
+                    PreparePatient(patient);
                     Patients.Add(patient);
                     OnNewPatient?.Invoke(patient);
                 });
@@ -479,6 +569,7 @@ namespace Client.Services
             {
                 Dispatcher?.TryEnqueue(() =>
                 {
+                    PreparePatient(patient);
                     var existing = Patients.FirstOrDefault(p => p.Id == patient.Id);
                     if (existing != null)
                     {


### PR DESCRIPTION
## Summary
- display patient wait time in minutes with a warning indicator when beyond the configured threshold
- refresh wait-time bindings on a timer and when local updates occur so values stay current
- expose a system setting for the pickup alert threshold and persist it in machine configuration

## Testing
- dotnet build *(fails: dotnet command not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e7e39164c483249233ea03784b2e6e