### PR TITLE
Fix pickup alert foreground binding

### DIFF
--- a/Client/Models/Patient.cs
+++ b/Client/Models/Patient.cs
@@ -12,6 +12,10 @@ namespace Client.Models
            ColorUtils.ToHex(
                ColorUtils.GetContrastingTextColor(
                    ColorUtils.FromHex(Colors)));
+
+        public string PickupAttentionForeground => RequiresPickupAttention
+            ? "#FFFF5555"
+            : ForegroundColor;
         public string LastName { get; set; } = string.Empty;
         public string FirstName { get; set; } = string.Empty;
         public string Exams { get; set; } = string.Empty;
@@ -53,6 +57,7 @@ namespace Client.Models
             _pickupAlertThresholdMinutes = Math.Max(0, pickupAlertThresholdMinutes);
             OnPropertyChanged(nameof(TimeSinceHoldTimeFormatted));
             OnPropertyChanged(nameof(RequiresPickupAttention));
+            OnPropertyChanged(nameof(PickupAttentionForeground));
         }
 
         public string ToggleExamLabel => IsTaken

--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -287,7 +287,7 @@
                         <TextBlock Grid.Column="0" Text="{x:Bind Position}" Foreground="{x:Bind ForegroundColor}" Margin="0,0,8,0"/>
                         <TextBlock Grid.Column="1"
                                    Text="{x:Bind TimeSinceHoldTimeFormatted, Mode=OneWay}"
-                                   Foreground="{x:Bind RequiresPickupAttention ? \"#FFFF5555\" : ForegroundColor, Mode=OneWay}"
+                                   Foreground="{x:Bind PickupAttentionForeground, Mode=OneWay}"
                                    FontWeight="{x:Bind RequiresPickupAttention ? FontWeights.Bold : FontWeights.Normal, Mode=OneWay}"
                                    HorizontalAlignment="Right"/>
                     </Grid>

--- a/Client/Pages/HistoryPage.xaml
+++ b/Client/Pages/HistoryPage.xaml
@@ -65,7 +65,7 @@
                         <TextBlock Grid.Column="0" Text="{x:Bind Position}" Foreground="{x:Bind ForegroundColor}" Margin="0,0,8,0"/>
                         <TextBlock Grid.Column="1"
                                    Text="{x:Bind TimeSinceHoldTimeFormatted, Mode=OneWay}"
-                                   Foreground="{x:Bind RequiresPickupAttention ? \"#FFFF5555\" : ForegroundColor, Mode=OneWay}"
+                                   Foreground="{x:Bind PickupAttentionForeground, Mode=OneWay}"
                                    FontWeight="{x:Bind RequiresPickupAttention ? FontWeights.Bold : FontWeights.Normal, Mode=OneWay}"
                                    HorizontalAlignment="Right"/>
                     </Grid>
@@ -155,7 +155,7 @@
                         <TextBlock Grid.Column="0" Text="{x:Bind Position}" Foreground="{x:Bind ForegroundColor}" Margin="0,0,8,0"/>
                         <TextBlock Grid.Column="1"
                                    Text="{x:Bind TimeSinceHoldTimeFormatted, Mode=OneWay}"
-                                   Foreground="{x:Bind RequiresPickupAttention ? \"#FFFF5555\" : ForegroundColor, Mode=OneWay}"
+                                   Foreground="{x:Bind PickupAttentionForeground, Mode=OneWay}"
                                    FontWeight="{x:Bind RequiresPickupAttention ? FontWeights.Bold : FontWeights.Normal, Mode=OneWay}"
                                    HorizontalAlignment="Right"/>
                     </Grid>


### PR DESCRIPTION
## Summary
- add a PickupAttentionForeground property on Patient to expose the alert color
- bind the pickup alert foregrounds in HistoryPage and ChatPage to the new property so the XAML parses correctly

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e7ebe585948324aa38c5ae3d2971d3