### PR TITLE
Fix pickup alert foreground binding

### DIFF
--- a/Client/Models/Patient.cs
+++ b/Client/Models/Patient.cs
@@ -12,6 +12,12 @@ namespace Client.Models
            ColorUtils.ToHex(
                ColorUtils.GetContrastingTextColor(
                    ColorUtils.FromHex(Colors)));
+
+        public string PickupAttentionForeground => RequiresPickupAttention
+            ? "#FFFF5555"
+            : ForegroundColor;
+
+        public string PickupAttentionFontWeight => RequiresPickupAttention ? "Bold" : "Normal";
         public string LastName { get; set; } = string.Empty;
         public string FirstName { get; set; } = string.Empty;
         public string Exams { get; set; } = string.Empty;
@@ -53,6 +59,8 @@ namespace Client.Models
             _pickupAlertThresholdMinutes = Math.Max(0, pickupAlertThresholdMinutes);
             OnPropertyChanged(nameof(TimeSinceHoldTimeFormatted));
             OnPropertyChanged(nameof(RequiresPickupAttention));
+            OnPropertyChanged(nameof(PickupAttentionForeground));
+            OnPropertyChanged(nameof(PickupAttentionFontWeight));
         }
 
         public string ToggleExamLabel => IsTaken

--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -287,8 +287,8 @@
                         <TextBlock Grid.Column="0" Text="{x:Bind Position}" Foreground="{x:Bind ForegroundColor}" Margin="0,0,8,0"/>
                         <TextBlock Grid.Column="1"
                                    Text="{x:Bind TimeSinceHoldTimeFormatted, Mode=OneWay}"
-                                   Foreground="{x:Bind RequiresPickupAttention ? \"#FFFF5555\" : ForegroundColor, Mode=OneWay}"
-                                   FontWeight="{x:Bind RequiresPickupAttention ? FontWeights.Bold : FontWeights.Normal, Mode=OneWay}"
+                                   Foreground="{x:Bind PickupAttentionForeground, Mode=OneWay}"
+                                   FontWeight="{x:Bind PickupAttentionFontWeight, Mode=OneWay}"
                                    HorizontalAlignment="Right"/>
                     </Grid>
                 </Grid>

--- a/Client/Pages/HistoryPage.xaml
+++ b/Client/Pages/HistoryPage.xaml
@@ -65,8 +65,8 @@
                         <TextBlock Grid.Column="0" Text="{x:Bind Position}" Foreground="{x:Bind ForegroundColor}" Margin="0,0,8,0"/>
                         <TextBlock Grid.Column="1"
                                    Text="{x:Bind TimeSinceHoldTimeFormatted, Mode=OneWay}"
-                                   Foreground="{x:Bind RequiresPickupAttention ? \"#FFFF5555\" : ForegroundColor, Mode=OneWay}"
-                                   FontWeight="{x:Bind RequiresPickupAttention ? FontWeights.Bold : FontWeights.Normal, Mode=OneWay}"
+                                   Foreground="{x:Bind PickupAttentionForeground, Mode=OneWay}"
+                                   FontWeight="{x:Bind PickupAttentionFontWeight, Mode=OneWay}"
                                    HorizontalAlignment="Right"/>
                     </Grid>
                 </Grid>
@@ -155,8 +155,8 @@
                         <TextBlock Grid.Column="0" Text="{x:Bind Position}" Foreground="{x:Bind ForegroundColor}" Margin="0,0,8,0"/>
                         <TextBlock Grid.Column="1"
                                    Text="{x:Bind TimeSinceHoldTimeFormatted, Mode=OneWay}"
-                                   Foreground="{x:Bind RequiresPickupAttention ? \"#FFFF5555\" : ForegroundColor, Mode=OneWay}"
-                                   FontWeight="{x:Bind RequiresPickupAttention ? FontWeights.Bold : FontWeights.Normal, Mode=OneWay}"
+                                   Foreground="{x:Bind PickupAttentionForeground, Mode=OneWay}"
+                                   FontWeight="{x:Bind PickupAttentionFontWeight, Mode=OneWay}"
                                    HorizontalAlignment="Right"/>
                     </Grid>
                 </Grid>


### PR DESCRIPTION
## Summary
- add a PickupAttentionForeground property on Patient to expose the alert color
- bind the pickup alert foregrounds in HistoryPage and ChatPage to the new property so the XAML parses correctly
- add a PickupAttentionFontWeight helper on Patient and bind HistoryPage and ChatPage to it so the alert text renders without invalid expressions

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e7ebe585948324aa38c5ae3d2971d3