### PR TITLE
Ensure default avatar uses relative paths

### DIFF
--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -251,8 +251,14 @@ namespace Client.Services
             {
                 var serverUri = new Uri(ServerAddress);
                 var uri = new Uri(avatar, UriKind.RelativeOrAbsolute);
-                if (uri.IsAbsoluteUri && uri.Host == serverUri.Host && uri.Port == serverUri.Port)
-                    return uri.PathAndQuery;
+                if (uri.IsAbsoluteUri)
+                {
+                    if (uri.Host == serverUri.Host && uri.Port == serverUri.Port)
+                        return uri.PathAndQuery;
+
+                    if (string.Equals(uri.Scheme, "ms-appx", StringComparison.OrdinalIgnoreCase))
+                        return uri.PathAndQuery;
+                }
             }
             catch
             {


### PR DESCRIPTION
## Summary
- ensure ms-appx avatar URIs are converted to relative paths before sending to the server
- keep previously supported behavior for same-host absolute avatar URLs

## Testing
- dotnet build *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e9f012b4e4832485e44a8fa8e5ec3f