### PR TITLE
Ensure chat auto-scroll waits for layout updates

### DIFF
--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -794,10 +794,21 @@ namespace Client.Pages
                 return;
             }
 
-            if (!TryScrollToLastMessageCore())
+            _pendingScrollToLastMessage = true;
+
+            if (TryScrollToLastMessageCore())
             {
-                _pendingScrollToLastMessage = true;
+                _pendingScrollToLastMessage = false;
+                return;
             }
+
+            DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, () =>
+            {
+                if (TryScrollToLastMessageCore())
+                {
+                    _pendingScrollToLastMessage = false;
+                }
+            });
         }
 
         private void MessagesList_LayoutUpdated(object? sender, object e)


### PR DESCRIPTION
## Summary
- keep the pending scroll flag active until the scroll attempt succeeds
- enqueue a follow-up scroll attempt at low priority to let the layout update before retrying

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ea319a01748324b0976c954f49a49c