### PR TITLE
Add more diagnostic error logging

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -40,7 +40,7 @@ namespace Client
                 }
                 catch (Exception ex)
                 {
-                    System.Diagnostics.Debug.WriteLine($"❌ Sync settings error: {ex.Message}");
+                    Logger.LogException("[App] SettingsChanged handler failed", ex, "CLI12");
                 }
             };
         }
@@ -244,7 +244,7 @@ namespace Client
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"❌ Toast error: {ex.Message}");
+                Logger.LogException("[App] ShowNotification failed", ex, "CLI13");
             }
         }
 
@@ -267,7 +267,7 @@ namespace Client
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"❌ Sync settings error: {ex.Message}");
+                Logger.LogException("[App] SyncUserSettingsAsync failed", ex, "CLI14");
             }
         }
 
@@ -289,7 +289,7 @@ namespace Client
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"❌ Sync missing settings error: {ex.Message}");
+                Logger.LogException("[App] DownloadMissingUserSettingsAsync failed", ex, "CLI15");
             }
         }
 
@@ -303,7 +303,10 @@ namespace Client
                 if (ChatService.Connection != null)
                     await ChatService.DisconnectAsync();
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Logger.LogException("[App] ChangeUserAsync.DisconnectAsync failed", ex, "CLI16");
+            }
 
             ChatService.ClearLocalData();
 
@@ -338,7 +341,10 @@ namespace Client
                 if (ChatService.Connection != null)
                     await ChatService.DisconnectAsync();
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Logger.LogException("LogoutAsync.DisconnectAsync failed", ex, "CLI09");
+            }
 
             ChatService.ClearLocalData();
         }
@@ -349,7 +355,7 @@ namespace Client
         {
             if (e.Exception is Exception ex)
             {
-                Logger.LogException("Unhandled UI exception", ex);
+                Logger.LogException("Unhandled UI exception", ex, "CLI01");
             }
             else
             {
@@ -386,7 +392,7 @@ namespace Client
         {
             if (e.ExceptionObject is Exception ex)
             {
-                Logger.LogException("AppDomain unhandled exception", ex);
+                Logger.LogException("AppDomain unhandled exception", ex, "CLI02");
             }
             else
             {
@@ -396,7 +402,7 @@ namespace Client
 
         private void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
         {
-            Logger.LogException("Unobserved task exception", e.Exception);
+            Logger.LogException("Unobserved task exception", e.Exception, "CLI03");
             e.SetObserved();
         }
     }

--- a/Client/Helpers/AppSettings.cs
+++ b/Client/Helpers/AppSettings.cs
@@ -68,8 +68,9 @@ namespace Client.Helpers
                     Save();
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                Logger.LogException("[AppSettings] Load failed", ex, "CLI17");
                 _settings = new();
             }
         }
@@ -122,7 +123,10 @@ namespace Client.Helpers
                     return value.Deserialize<T>() ?? new T();
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Logger.LogException("[AppSettings] GetObject failed", ex, "CLI18");
+            }
             return new T();
         }
 
@@ -147,8 +151,9 @@ namespace Client.Helpers
             {
                 return JsonSerializer.Serialize(_settings, new JsonSerializerOptions { WriteIndented = true });
             }
-            catch
+            catch (Exception ex)
             {
+                Logger.LogException("[AppSettings] Export failed", ex, "CLI19");
                 return string.Empty;
             }
         }
@@ -169,8 +174,9 @@ namespace Client.Helpers
                     Save();
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                Logger.LogException("[AppSettings] Import failed", ex, "CLI20");
             }
         }
 
@@ -188,6 +194,7 @@ namespace Client.Helpers
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"❌ Sauvegarde échouée : {ex.Message}");
+                Logger.LogException("[AppSettings] Save failed", ex, "CLI10");
             }
         }
 
@@ -207,7 +214,7 @@ namespace Client.Helpers
                 }
                 catch (Exception ex)
                 {
-                    Logger.LogException("[AppSettings] SettingsChanged handler failed", ex);
+                    Logger.LogException("[AppSettings] SettingsChanged handler failed", ex, "CLI04");
                 }
             }
         }
@@ -219,7 +226,10 @@ namespace Client.Helpers
                 if (File.Exists(FilePath))
                     File.Delete(FilePath);
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Logger.LogException("[AppSettings] DeleteSettingsFile failed", ex, "CLI11");
+            }
         }
     }
 }

--- a/Client/Helpers/ConnectionConfig.cs
+++ b/Client/Helpers/ConnectionConfig.cs
@@ -23,8 +23,9 @@ namespace Client.Helpers
                     return JsonConvert.DeserializeObject<ConnectionConfig>(json) ?? new ConnectionConfig();
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                Logger.LogException("[ConnectionConfig] Load failed", ex, "CLI26");
             }
             return new ConnectionConfig();
         }
@@ -37,8 +38,9 @@ namespace Client.Helpers
                 var json = JsonConvert.SerializeObject(config, Formatting.Indented);
                 File.WriteAllText(FilePath, json);
             }
-            catch
+            catch (Exception ex)
             {
+                Logger.LogException("[ConnectionConfig] Save failed", ex, "CLI27");
             }
         }
     }

--- a/Client/Helpers/Logger.cs
+++ b/Client/Helpers/Logger.cs
@@ -34,10 +34,13 @@ namespace Client.Helpers
             }
         }
 
-        public static void LogException(string context, Exception exception)
+        public static void LogException(string context, Exception exception, string? errorCode = null)
         {
             var builder = new StringBuilder();
-            builder.AppendLine(context);
+            var header = string.IsNullOrWhiteSpace(errorCode)
+                ? context
+                : $"[{errorCode}] {context}";
+            builder.AppendLine(header);
             builder.AppendLine(exception.ToString());
             Log(builder.ToString());
         }

--- a/Client/Helpers/MachineConfig.cs
+++ b/Client/Helpers/MachineConfig.cs
@@ -45,8 +45,9 @@ namespace Client.Helpers
                     return JsonConvert.DeserializeObject<MachineConfig>(json) ?? new MachineConfig();
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                Logger.LogException("[MachineConfig] Load failed", ex, "CLI21");
             }
             return new MachineConfig();
         }
@@ -59,8 +60,9 @@ namespace Client.Helpers
                 var json = JsonConvert.SerializeObject(config, Formatting.Indented);
                 File.WriteAllText(FilePath, json);
             }
-            catch
+            catch (Exception ex)
             {
+                Logger.LogException("[MachineConfig] Save failed", ex, "CLI22");
             }
         }
     }

--- a/Client/Helpers/NetworkScanner.cs
+++ b/Client/Helpers/NetworkScanner.cs
@@ -59,8 +59,9 @@ namespace Client.Helpers
                         if (response.IsSuccessStatusCode)
                             Interlocked.CompareExchange(ref found, $"http://{ip}:{port}", null);
                     }
-                    catch
+                    catch (Exception ex)
                     {
+                        Logger.LogException("[NetworkScanner] Probe failed", ex, "CLI23");
                     }
                 });
 

--- a/Client/Helpers/RoomList.cs
+++ b/Client/Helpers/RoomList.cs
@@ -23,8 +23,9 @@ namespace Client.Helpers
                            ?? new ObservableCollection<string>();
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                Logger.LogException("[RoomList] Load failed", ex, "CLI24");
             }
             return new ObservableCollection<string>();
         }
@@ -37,8 +38,9 @@ namespace Client.Helpers
                 var json = JsonConvert.SerializeObject(rooms, Formatting.Indented);
                 File.WriteAllText(FilePath, json);
             }
-            catch
+            catch (Exception ex)
             {
+                Logger.LogException("[RoomList] Save failed", ex, "CLI25");
             }
         }
     }

--- a/Client/Models/ExamOption.cs
+++ b/Client/Models/ExamOption.cs
@@ -207,7 +207,7 @@ namespace Client.Models
             }
             catch (Exception ex)
             {
-                Logger.LogException("ExamOption.Load failed", ex);
+                Logger.LogException("ExamOption.Load failed", ex, "CLI05");
             }
             return new ObservableCollection<ExamOption>();
         }
@@ -232,7 +232,7 @@ namespace Client.Models
             }
             catch (Exception ex)
             {
-                Logger.LogException("ExamOption.Save failed", ex);
+                Logger.LogException("ExamOption.Save failed", ex, "CLI06");
             }
         }
 

--- a/Client/Pages/UserSettingsPage.xaml.cs
+++ b/Client/Pages/UserSettingsPage.xaml.cs
@@ -145,7 +145,7 @@ namespace Client.Pages
             }
             catch (Exception ex)
             {
-                Logger.LogException("UserSettingsPage.RefreshExamOptionsAsync failed", ex);
+                Logger.LogException("UserSettingsPage.RefreshExamOptionsAsync failed", ex, "CLI07");
             }
         }
 

--- a/Client/ViewModel/SettingsViewModel.cs
+++ b/Client/ViewModel/SettingsViewModel.cs
@@ -482,7 +482,7 @@ namespace Client.ViewModel
             }
             catch (Exception ex)
             {
-                Logger.LogException("[SettingsViewModel] ValidateExamSelectionsInternal failed", ex);
+                Logger.LogException("[SettingsViewModel] ValidateExamSelectionsInternal failed", ex, "CLI08");
             }
         }
 

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text.Json;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -8,6 +7,7 @@ using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using System;
+using Microsoft.Extensions.Logging;
 
 namespace ChatServeur
 {
@@ -118,14 +118,16 @@ namespace ChatServeur
 
         private readonly ChatDbContext _db;
         private readonly IWebHostEnvironment _env;
+        private readonly ILogger<ChatHub> _logger;
 
-        public ChatHub(ChatDbContext db, IWebHostEnvironment env)
+        public ChatHub(ChatDbContext db, IWebHostEnvironment env, ILogger<ChatHub> logger)
         {
             _db = db;
             _env = env;
+            _logger = logger;
         }
 
-        private static string ToRelativeAvatar(string avatar)
+        private string ToRelativeAvatar(string avatar)
         {
             if (string.IsNullOrWhiteSpace(avatar))
                 return avatar;
@@ -141,8 +143,9 @@ namespace ChatServeur
                     return uri.PathAndQuery;
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "SER10: Failed to normalize avatar path {Avatar}.", avatar);
             }
             return avatar;
         }
@@ -229,7 +232,7 @@ namespace ChatServeur
                 if (string.IsNullOrWhiteSpace(avatar))
                     avatar = "/Assets/utilisateur.png";
                 EnsureUsersLoaded();
-                Console.WriteLine($"[SERVER] RegisterUser : {username}");
+                _logger.LogInformation("RegisterUser invoked for {Username}.", username);
 
                 var rooms = new List<string>();
                 if (AllUsers.TryGetValue(username, out var existing) && existing.Rooms.Any())
@@ -299,7 +302,7 @@ namespace ChatServeur
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[SERVER ERROR] RegisterUser : {ex.Message}");
+                _logger.LogError(ex, "SER11: Failed to register user {Username}.", username);
                 throw;
             }
         }
@@ -346,7 +349,7 @@ namespace ChatServeur
                 await Clients.Group(destinataire).SendAsync("ReceiveMessage", message.Id, sender, room, destinataire, content, avatar, timestamp);
                 await Clients.Caller.SendAsync("ReceiveMessage", message.Id, sender, room, destinataire, content, avatar, timestamp);
             }
-            Console.WriteLine($"[SERVER] Message sent from {sender} to {destinataire} in room {room}: {content}");
+            _logger.LogInformation("Message sent from {Sender} to {Recipient} in room {Room}.", sender, destinataire, room);
         }
 
         public async Task GenerateSampleMessages()
@@ -949,8 +952,9 @@ namespace ChatServeur
             {
                 return JsonSerializer.Deserialize<List<ExamOption>>(config.ExamOptionsJson) ?? new List<ExamOption>();
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "SER12: Failed to deserialize exam options configuration.");
                 return new List<ExamOption>();
             }
         }
@@ -964,8 +968,9 @@ namespace ChatServeur
             {
                 return JsonSerializer.Deserialize<List<string>>(config.RoomsJson) ?? new List<string>();
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "SER13: Failed to deserialize rooms configuration.");
                 return new List<string>();
             }
         }
@@ -992,8 +997,9 @@ namespace ChatServeur
             {
                 return JsonSerializer.Deserialize<ReminderConfig>(cfg.ReminderJson) ?? new ReminderConfig();
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "SER14: Failed to deserialize reminder configuration.");
                 return new ReminderConfig();
             }
         }

--- a/Serveur/Program.cs
+++ b/Serveur/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using ChatServeur;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Hosting.WindowsServices;
+using Microsoft.Extensions.Logging;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -34,6 +35,7 @@ builder.Services.AddHostedService<ReminderService>();
 builder.WebHost.UseUrls("http://0.0.0.0:5000");
 
 var app = builder.Build();
+var logger = app.Logger;
 
 if (!app.Environment.IsDevelopment())
 {
@@ -50,15 +52,24 @@ app.UseAuthorization();
 using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<ChatDbContext>();
-    db.Database.EnsureCreated();
-    EnsurePatientsTable(db);
-    EnsureArchivedColumn(db);
-    EnsureIsDeletedColumn(db);
-    EnsurePatientLogsTable(db);
-    EnsureUserSettingsTable(db);
-    EnsureReminderColumn(db);
-    EnsureKnownUsersTable(db);
-    CleanupKnownUsers(db);
+    try
+    {
+        db.Database.EnsureCreated();
+    }
+    catch (Exception ex)
+    {
+        logger.LogError(ex, "SER00: Failed to ensure SQLite database is created.");
+        throw;
+    }
+
+    EnsurePatientsTable(db, logger);
+    EnsureArchivedColumn(db, logger);
+    EnsureIsDeletedColumn(db, logger);
+    EnsurePatientLogsTable(db, logger);
+    EnsureUserSettingsTable(db, logger);
+    EnsureReminderColumn(db, logger);
+    EnsureKnownUsersTable(db, logger);
+    CleanupKnownUsers(db, logger);
     if (!db.ServerConfigs.Any())
     {
         db.ServerConfigs.Add(new ServerConfig());
@@ -66,13 +77,13 @@ using (var scope = app.Services.CreateScope())
     }
 }
 
-void EnsureArchivedColumn(ChatDbContext db)
+void EnsureArchivedColumn(ChatDbContext db, ILogger logger)
 {
     var connection = db.Database.GetDbConnection();
     connection.Open();
     try
     {
-        if (!TableExists(connection, "Patients"))
+        if (!TableExists(connection, "Patients", logger))
         {
             return;
         }
@@ -96,19 +107,24 @@ void EnsureArchivedColumn(ChatDbContext db)
             cmd.ExecuteNonQuery();
         }
     }
+    catch (Exception ex)
+    {
+        logger.LogError(ex, "SER02: Failed to ensure Patients table contains IsArchived column.");
+        throw;
+    }
     finally
     {
         connection.Close();
     }
 }
 
-void EnsurePatientsTable(ChatDbContext db)
+void EnsurePatientsTable(ChatDbContext db, ILogger logger)
 {
     var connection = db.Database.GetDbConnection();
     connection.Open();
     try
     {
-        if (TableExists(connection, "Patients"))
+        if (TableExists(connection, "Patients", logger))
         {
             return;
         }
@@ -134,25 +150,38 @@ void EnsurePatientsTable(ChatDbContext db)
         )";
         cmd.ExecuteNonQuery();
     }
+    catch (Exception ex)
+    {
+        logger.LogError(ex, "SER01: Failed to create Patients table.");
+        throw;
+    }
     finally
     {
         connection.Close();
     }
 }
 
-bool TableExists(System.Data.Common.DbConnection connection, string tableName)
+bool TableExists(System.Data.Common.DbConnection connection, string tableName, ILogger logger)
 {
-    using var cmd = connection.CreateCommand();
-    cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name=$name";
-    var parameter = cmd.CreateParameter();
-    parameter.ParameterName = "$name";
-    parameter.Value = tableName;
-    cmd.Parameters.Add(parameter);
-    var result = cmd.ExecuteScalar();
-    return result != null;
+    try
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name=$name";
+        var parameter = cmd.CreateParameter();
+        parameter.ParameterName = "$name";
+        parameter.Value = tableName;
+        cmd.Parameters.Add(parameter);
+        var result = cmd.ExecuteScalar();
+        return result != null;
+    }
+    catch (Exception ex)
+    {
+        logger.LogError(ex, "SER03: Failed to check existence of table {TableName}.", tableName);
+        throw;
+    }
 }
 
-void EnsureIsDeletedColumn(ChatDbContext db)
+void EnsureIsDeletedColumn(ChatDbContext db, ILogger logger)
 {
     var connection = db.Database.GetDbConnection();
     connection.Open();
@@ -177,13 +206,18 @@ void EnsureIsDeletedColumn(ChatDbContext db)
             cmd.ExecuteNonQuery();
         }
     }
+    catch (Exception ex)
+    {
+        logger.LogError(ex, "SER04: Failed to ensure Messages table contains IsDeleted column.");
+        throw;
+    }
     finally
     {
         connection.Close();
     }
 }
 
-void EnsureUserSettingsTable(ChatDbContext db)
+void EnsureUserSettingsTable(ChatDbContext db, ILogger logger)
 {
     var connection = db.Database.GetDbConnection();
     connection.Open();
@@ -198,13 +232,18 @@ void EnsureUserSettingsTable(ChatDbContext db)
             cmd.ExecuteNonQuery();
         }
     }
+    catch (Exception ex)
+    {
+        logger.LogError(ex, "SER06: Failed to ensure UserSettings table exists.");
+        throw;
+    }
     finally
     {
         connection.Close();
     }
 }
 
-void EnsureReminderColumn(ChatDbContext db)
+void EnsureReminderColumn(ChatDbContext db, ILogger logger)
 {
     var connection = db.Database.GetDbConnection();
     connection.Open();
@@ -229,13 +268,18 @@ void EnsureReminderColumn(ChatDbContext db)
             cmd.ExecuteNonQuery();
         }
     }
+    catch (Exception ex)
+    {
+        logger.LogError(ex, "SER07: Failed to ensure ServerConfigs table contains ReminderJson column.");
+        throw;
+    }
     finally
     {
         connection.Close();
     }
 }
 
-void EnsurePatientLogsTable(ChatDbContext db)
+void EnsurePatientLogsTable(ChatDbContext db, ILogger logger)
 {
     var connection = db.Database.GetDbConnection();
     connection.Open();
@@ -250,19 +294,24 @@ void EnsurePatientLogsTable(ChatDbContext db)
             cmd.ExecuteNonQuery();
         }
     }
+    catch (Exception ex)
+    {
+        logger.LogError(ex, "SER05: Failed to ensure PatientLogs table exists.");
+        throw;
+    }
     finally
     {
         connection.Close();
     }
 }
 
-void EnsureKnownUsersTable(ChatDbContext db)
+void EnsureKnownUsersTable(ChatDbContext db, ILogger logger)
 {
     var connection = db.Database.GetDbConnection();
     connection.Open();
     try
     {
-        if (TableExists(connection, "KnownUsers"))
+        if (TableExists(connection, "KnownUsers", logger))
         {
             return;
         }
@@ -281,13 +330,18 @@ void EnsureKnownUsersTable(ChatDbContext db)
         )";
         cmd.ExecuteNonQuery();
     }
+    catch (Exception ex)
+    {
+        logger.LogError(ex, "SER08: Failed to ensure KnownUsers table exists.");
+        throw;
+    }
     finally
     {
         connection.Close();
     }
 }
 
-void CleanupKnownUsers(ChatDbContext db)
+void CleanupKnownUsers(ChatDbContext db, ILogger logger)
 {
     var connection = db.Database.GetDbConnection();
     connection.Open();
@@ -296,6 +350,11 @@ void CleanupKnownUsers(ChatDbContext db)
         using var cmd = connection.CreateCommand();
         cmd.CommandText = "DELETE FROM KnownUsers WHERE (Username IS NULL OR Username = '') AND (DisplayName IS NULL OR DisplayName = '')";
         cmd.ExecuteNonQuery();
+    }
+    catch (Exception ex)
+    {
+        logger.LogError(ex, "SER09: Failed to cleanup KnownUsers table.");
+        throw;
     }
     finally
     {

--- a/Serveur/ReminderService.cs
+++ b/Serveur/ReminderService.cs
@@ -31,7 +31,7 @@ namespace ChatServeur
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Erreur service rappels");
+                    _logger.LogError(ex, "SER15: Reminder service loop failed.");
                 }
 
                 var now = DateTime.Now;
@@ -53,8 +53,9 @@ namespace ChatServeur
             {
                 reminder = JsonSerializer.Deserialize<ReminderConfig>(config.ReminderJson);
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "SER16: Failed to deserialize reminder configuration payload.");
                 return;
             }
             if (reminder == null || !reminder.IsEnabled)
@@ -87,8 +88,24 @@ namespace ChatServeur
                                 IsDeleted = false
                             };
                             db.Messages.Add(message);
-                            await db.SaveChangesAsync();
-                            await _hub.Clients.All.SendAsync("ReceiveMessage", message.Id, message.Sender, message.Room, message.Destinataire, message.Content, message.Avatar, message.Timestamp);
+                            try
+                            {
+                                await db.SaveChangesAsync();
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogError(ex, "SER17: Failed to persist reminder message {Key}.", key);
+                                continue;
+                            }
+
+                            try
+                            {
+                                await _hub.Clients.All.SendAsync("ReceiveMessage", message.Id, message.Sender, message.Room, message.Destinataire, message.Content, message.Avatar, message.Timestamp);
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogError(ex, "SER18: Failed to broadcast reminder message {Key}.", key);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- add CLI-coded error logging around client configuration, network scan, and user switching flows
- add CLI-coded logging for configuration persistence helpers to capture file IO issues
- add SER-coded logging when reminder persistence or broadcast fails on the server

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68eb4aee60188324b633ed59aeb48a3c