### PR TITLE
Ensure dialogs follow app theme

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -88,6 +88,8 @@ namespace Client
                     XamlRoot = root.XamlRoot
                 };
 
+                ThemeHelper.ApplyDialogTheme(dialog);
+
                 var box = new TextBox();
                 dialog.Content = box;
                 var result = await dialog.ShowAsync();
@@ -110,6 +112,8 @@ namespace Client
                     PrimaryButtonText = "Valider",
                     XamlRoot = root.XamlRoot
                 };
+
+                ThemeHelper.ApplyDialogTheme(userDialog);
 
                 var userBox = new TextBox();
                 userDialog.Content = userBox;
@@ -377,6 +381,8 @@ namespace Client
                             CloseButtonText = "Fermer",
                             XamlRoot = root.XamlRoot
                         };
+
+                        ThemeHelper.ApplyDialogTheme(dialog);
 
                         await dialog.ShowAsync();
                     }

--- a/Client/Helpers/ThemeHelper.cs
+++ b/Client/Helpers/ThemeHelper.cs
@@ -1,0 +1,41 @@
+using Client;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+
+namespace Client.Helpers
+{
+    public static class ThemeHelper
+    {
+        public static void ApplyDialogTheme(ContentDialog dialog)
+        {
+            if (dialog is null)
+            {
+                return;
+            }
+
+            if (Application.Current?.Resources is ResourceDictionary resources)
+            {
+                if (resources.TryGetValue("ApplicationPageBackgroundThemeBrush", out var background) && background is SolidColorBrush backgroundBrush)
+                {
+                    dialog.Background = backgroundBrush;
+                }
+
+                if (resources.TryGetValue("TextAppBackgroundColor", out var foreground) && foreground is SolidColorBrush foregroundBrush)
+                {
+                    dialog.Foreground = foregroundBrush;
+                }
+            }
+
+            if (App.MainWindow?.Content is FrameworkElement root)
+            {
+                dialog.RequestedTheme = root.ActualTheme switch
+                {
+                    ElementTheme.Dark => ElementTheme.Dark,
+                    ElementTheme.Light => ElementTheme.Light,
+                    _ => dialog.RequestedTheme
+                };
+            }
+        }
+    }
+}

--- a/Client/MainWindow.xaml.cs
+++ b/Client/MainWindow.xaml.cs
@@ -135,6 +135,8 @@ namespace Client
                 XamlRoot = this.Content.XamlRoot
             };
 
+            ThemeHelper.ApplyDialogTheme(dialog);
+
             var stack = new StackPanel { Spacing = 10 };
             var combo = new ComboBox { ItemsSource = users, PlaceholderText = "Utilisateur" };
             var newBox = new TextBox { PlaceholderText = "Nouvel utilisateur" };

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -665,6 +665,8 @@ namespace Client.Pages
                 XamlRoot = this.XamlRoot
             };
 
+            ThemeHelper.ApplyDialogTheme(dialog);
+
             var stack = new StackPanel { Spacing = 10 };
 
             var groupNameBox = new TextBox { PlaceholderText = "Nom du groupe" };
@@ -935,6 +937,8 @@ namespace Client.Pages
                     XamlRoot = (this.Content as FrameworkElement)?.XamlRoot
                 };
 
+                ThemeHelper.ApplyDialogTheme(dialog);
+
                 var result = await dialog.ShowAsync();
                 if (result == ContentDialogResult.Primary)
                 {
@@ -1165,6 +1169,8 @@ namespace Client.Pages
                 DefaultButton = ContentDialogButton.Primary,
                 XamlRoot = this.XamlRoot
             };
+
+            ThemeHelper.ApplyDialogTheme(dialog);
 
             var result = await dialog.ShowAsync();
 
@@ -1452,6 +1458,8 @@ namespace Client.Pages
                 XamlRoot = (this.Content as FrameworkElement)?.XamlRoot
             };
 
+            ThemeHelper.ApplyDialogTheme(dialog);
+
             await dialog.ShowAsync();
         }
 
@@ -1465,6 +1473,8 @@ namespace Client.Pages
                 CloseButtonText = "Fermer",
                 XamlRoot = (this.Content as FrameworkElement)?.XamlRoot
             };
+
+            ThemeHelper.ApplyDialogTheme(dialog);
 
             var stack = new StackPanel { Spacing = 10 };
             var roomBox = new ComboBox { ItemsSource = groups.Keys.ToList(), PlaceholderText = "Salle" };

--- a/Client/Pages/ExamRoomPage.xaml.cs
+++ b/Client/Pages/ExamRoomPage.xaml.cs
@@ -448,6 +448,8 @@ namespace Client.Pages
                 XamlRoot = this.XamlRoot
             };
 
+            ThemeHelper.ApplyDialogTheme(dialog);
+
             await dialog.ShowAsync();
         }
 
@@ -469,6 +471,8 @@ namespace Client.Pages
                     CloseButtonText = "Annuler",
                     XamlRoot = this.XamlRoot
                 };
+
+                ThemeHelper.ApplyDialogTheme(dialog);
 
                 var box = new TextBox { Text = room };
                 dialog.Content = box;

--- a/Client/Pages/HistoryPage.xaml.cs
+++ b/Client/Pages/HistoryPage.xaml.cs
@@ -173,6 +173,8 @@ namespace Client.Pages
                     XamlRoot = (this.Content as FrameworkElement)?.XamlRoot
                 };
 
+                ThemeHelper.ApplyDialogTheme(dialog);
+
                 var result = await dialog.ShowAsync();
                 if (result == ContentDialogResult.Primary)
                 {

--- a/Client/Pages/SystemPage.xaml.cs
+++ b/Client/Pages/SystemPage.xaml.cs
@@ -105,6 +105,8 @@ namespace Client.Pages
                 XamlRoot = xamlRoot
             };
 
+            ThemeHelper.ApplyDialogTheme(dialog);
+
             dialog.PrimaryButtonClick += async (s, args) =>
             {
                 var trimmed = nameBox.Text.Trim();
@@ -300,6 +302,8 @@ namespace Client.Pages
                     XamlRoot = xamlRoot
                 };
 
+                ThemeHelper.ApplyDialogTheme(dialog);
+
                 var result = await dialog.ShowAsync();
                 if (result != ContentDialogResult.Primary)
                     return false;
@@ -330,6 +334,8 @@ namespace Client.Pages
                 XamlRoot = xamlRoot
             };
 
+            ThemeHelper.ApplyDialogTheme(dialog);
+
             var result = await dialog.ShowAsync();
             return result == ContentDialogResult.Primary;
         }
@@ -343,6 +349,8 @@ namespace Client.Pages
                 CloseButtonText = "Fermer",
                 XamlRoot = xamlRoot
             };
+
+            ThemeHelper.ApplyDialogTheme(dialog);
 
             await dialog.ShowAsync();
         }

--- a/Client/Pages/UserSettingsPage.xaml.cs
+++ b/Client/Pages/UserSettingsPage.xaml.cs
@@ -226,6 +226,8 @@ namespace Client.Pages
                 XamlRoot = this.XamlRoot
             };
 
+            ThemeHelper.ApplyDialogTheme(dialog);
+
             var grid = new GridView
             {
                 ItemsSource = _defaultAvatars,

--- a/Client/Services/HotKeyService.cs
+++ b/Client/Services/HotKeyService.cs
@@ -197,6 +197,8 @@ namespace Client.Services
                 XamlRoot = xamlRoot,
             };
 
+            ThemeHelper.ApplyDialogTheme(dialog);
+
             var grid = new Grid { ColumnSpacing = 10, RowSpacing = 4 };
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
@@ -378,6 +380,8 @@ namespace Client.Services
                 XamlRoot = xamlRoot,
             };
 
+            ThemeHelper.ApplyDialogTheme(dialog);
+
             var grid = new Grid { ColumnSpacing = 10, RowSpacing = 4 };
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
@@ -483,6 +487,8 @@ namespace Client.Services
                 },
                 XamlRoot = xamlRoot,
             };
+
+            ThemeHelper.ApplyDialogTheme(dialog);
             await dialog.ShowAsync();
         }
         public static async Task DeclarePatientAsync(string examIdentifier, string patientName)


### PR DESCRIPTION
## Summary
- add a ThemeHelper to apply the application theme brushes to ContentDialogs
- call the helper from every programmatic dialog so light and dark themes are respected

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eb9ef01e8c8324b8c83f9f555cb837