### PR TITLE
Ensure dialogs follow app theme

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -88,6 +88,8 @@ namespace Client
                     XamlRoot = root.XamlRoot
                 };
 
+                ThemeHelper.ApplyDialogTheme(dialog);
+
                 var box = new TextBox();
                 dialog.Content = box;
                 var result = await dialog.ShowAsync();
@@ -110,6 +112,8 @@ namespace Client
                     PrimaryButtonText = "Valider",
                     XamlRoot = root.XamlRoot
                 };
+
+                ThemeHelper.ApplyDialogTheme(userDialog);
 
                 var userBox = new TextBox();
                 userDialog.Content = userBox;
@@ -377,6 +381,8 @@ namespace Client
                             CloseButtonText = "Fermer",
                             XamlRoot = root.XamlRoot
                         };
+
+                        ThemeHelper.ApplyDialogTheme(dialog);
 
                         await dialog.ShowAsync();
                     }

--- a/Client/Helpers/AppSettings.cs
+++ b/Client/Helpers/AppSettings.cs
@@ -63,7 +63,8 @@ namespace Client.Helpers
                 {
                     _settings = new();
                 }
-                if (EnsureAvatarSetting())
+
+                if (EnsureDefaultSettings())
                 {
                     Save();
                 }
@@ -74,29 +75,106 @@ namespace Client.Helpers
                 _settings = new();
             }
         }
-        private static bool EnsureAvatarSetting()
+
+        private static bool EnsureDefaultSettings()
         {
             if (string.IsNullOrWhiteSpace(App.UserName))
                 return false;
 
-            const string defaultAvatar = "ms-appx:///Assets/utilisateur.png";
+            var updated = false;
 
-            if (!_settings.TryGetValue("Avatar", out var value) || value is null)
-            {
-                _settings["Avatar"] = JsonValue.Create(defaultAvatar);
-                return true;
-            }
+            updated |= EnsureStringSetting("SelectedUser", "A Tous");
+            updated |= EnsureStringSetting("Avatar", "ms-appx:///Assets/utilisateur.png");
+            updated |= EnsureStringSetting("ChatDisplayStyle", "Modern");
+            updated |= EnsureStringSetting("AppTheme", "Dark");
 
-            if (value is JsonValue jsonValue)
+            updated |= EnsureColorsSetting();
+
+            return updated;
+        }
+
+        private static bool EnsureStringSetting(string key, string defaultValue)
+        {
+            if (_settings.TryGetValue(key, out var value) && value is JsonValue jsonValue)
             {
-                if (jsonValue.TryGetValue<string>(out var avatarValue))
+                if (jsonValue.TryGetValue<string>(out var text) && !string.IsNullOrWhiteSpace(text))
                 {
-                    if (!string.IsNullOrWhiteSpace(avatarValue))
-                        return false;
+                    return false;
                 }
             }
 
-            _settings["Avatar"] = JsonValue.Create(defaultAvatar);
+            _settings[key] = JsonValue.Create(defaultValue);
+            return true;
+        }
+
+        private static bool EnsureColorsSetting()
+        {
+            var defaultColors = new AppColorSettings
+            {
+                TitleBarColor = "#FF0078D7",
+                TextTitleBarColor = "#FFFFFFFF",
+                NavigationViewColor = "#FFE6F1FF",
+                TextNavigationViewColor = "#FF000000",
+                MyMessageColor = "#FFCCE5FF",
+                TextMyMessageColor = "#FF000000",
+                OtherMessageColor = "#FFD9F2DC",
+                TextOtherMessageColor = "#FF000000",
+                AppBackgroundColor = "#FFFFFFFF",
+                TextAppBackgroundColor = "#FF000000",
+                SystemAccentColorDark1 = "#FF0078D7"
+            };
+
+            try
+            {
+                if (_settings.TryGetValue("Colors", out var node) && node is not null)
+                {
+                    var current = node.Deserialize<AppColorSettings>() ?? new AppColorSettings();
+                    var changed = ApplyColorDefaults(current, defaultColors);
+                    if (!changed)
+                    {
+                        return false;
+                    }
+
+                    _settings["Colors"] = JsonSerializer.SerializeToNode(current);
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("[AppSettings] EnsureColorsSetting failed", ex, "CLI21");
+            }
+
+            _settings["Colors"] = JsonSerializer.SerializeToNode(defaultColors);
+            return true;
+        }
+
+        private static bool ApplyColorDefaults(AppColorSettings current, AppColorSettings defaults)
+        {
+            var updated = false;
+
+            updated |= EnsureColorValue(ref current.TitleBarColor, defaults.TitleBarColor);
+            updated |= EnsureColorValue(ref current.TextTitleBarColor, defaults.TextTitleBarColor);
+            updated |= EnsureColorValue(ref current.NavigationViewColor, defaults.NavigationViewColor);
+            updated |= EnsureColorValue(ref current.TextNavigationViewColor, defaults.TextNavigationViewColor);
+            updated |= EnsureColorValue(ref current.MyMessageColor, defaults.MyMessageColor);
+            updated |= EnsureColorValue(ref current.TextMyMessageColor, defaults.TextMyMessageColor);
+            updated |= EnsureColorValue(ref current.OtherMessageColor, defaults.OtherMessageColor);
+            updated |= EnsureColorValue(ref current.TextOtherMessageColor, defaults.TextOtherMessageColor);
+            updated |= EnsureColorValue(ref current.AppBackgroundColor, defaults.AppBackgroundColor);
+            updated |= EnsureColorValue(ref current.TextAppBackgroundColor, defaults.TextAppBackgroundColor);
+            updated |= EnsureColorValue(ref current.SystemAccentColorDark1, defaults.SystemAccentColorDark1);
+
+            return updated;
+        }
+
+        private static bool EnsureColorValue(ref string value, string defaultValue)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            value = defaultValue;
             return true;
         }
 

--- a/Client/Helpers/ThemeHelper.cs
+++ b/Client/Helpers/ThemeHelper.cs
@@ -1,0 +1,41 @@
+using Client;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+
+namespace Client.Helpers
+{
+    public static class ThemeHelper
+    {
+        public static void ApplyDialogTheme(ContentDialog dialog)
+        {
+            if (dialog is null)
+            {
+                return;
+            }
+
+            if (Application.Current?.Resources is ResourceDictionary resources)
+            {
+                if (resources.TryGetValue("ApplicationPageBackgroundThemeBrush", out var background) && background is SolidColorBrush backgroundBrush)
+                {
+                    dialog.Background = backgroundBrush;
+                }
+
+                if (resources.TryGetValue("TextAppBackgroundColor", out var foreground) && foreground is SolidColorBrush foregroundBrush)
+                {
+                    dialog.Foreground = foregroundBrush;
+                }
+            }
+
+            if (App.MainWindow?.Content is FrameworkElement root)
+            {
+                dialog.RequestedTheme = root.ActualTheme switch
+                {
+                    ElementTheme.Dark => ElementTheme.Dark,
+                    ElementTheme.Light => ElementTheme.Light,
+                    _ => dialog.RequestedTheme
+                };
+            }
+        }
+    }
+}

--- a/Client/MainWindow.xaml.cs
+++ b/Client/MainWindow.xaml.cs
@@ -135,6 +135,8 @@ namespace Client
                 XamlRoot = this.Content.XamlRoot
             };
 
+            ThemeHelper.ApplyDialogTheme(dialog);
+
             var stack = new StackPanel { Spacing = 10 };
             var combo = new ComboBox { ItemsSource = users, PlaceholderText = "Utilisateur" };
             var newBox = new TextBox { PlaceholderText = "Nouvel utilisateur" };

--- a/Client/Models/AppColorSettings.cs
+++ b/Client/Models/AppColorSettings.cs
@@ -3,7 +3,7 @@ namespace Client.Models
     public class AppColorSettings
     {
         public string TitleBarColor { get; set; } = "#FF0078D7";
-        public string TextTitleBarColor { get; set; } = "#FF000000";
+        public string TextTitleBarColor { get; set; } = "#FFFFFFFF";
         public string NavigationViewColor { get; set; } = "#FFE6F1FF";
         public string TextNavigationViewColor { get; set; } = "#FF000000";
         public string MyMessageColor { get; set; } = "#FFCCE5FF";
@@ -14,6 +14,6 @@ namespace Client.Models
         public string AppBackgroundColor { get; set; } = "#FFFFFFFF";
         public string TextAppBackgroundColor { get; set; } = "#FF000000";
 
-        public string SystemAccentColorDark1 { get; set; } = "#FF5F9EA0"; // CadetBlue
+        public string SystemAccentColorDark1 { get; set; } = "#FF0078D7";
     }
 }

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -665,6 +665,8 @@ namespace Client.Pages
                 XamlRoot = this.XamlRoot
             };
 
+            ThemeHelper.ApplyDialogTheme(dialog);
+
             var stack = new StackPanel { Spacing = 10 };
 
             var groupNameBox = new TextBox { PlaceholderText = "Nom du groupe" };
@@ -935,6 +937,8 @@ namespace Client.Pages
                     XamlRoot = (this.Content as FrameworkElement)?.XamlRoot
                 };
 
+                ThemeHelper.ApplyDialogTheme(dialog);
+
                 var result = await dialog.ShowAsync();
                 if (result == ContentDialogResult.Primary)
                 {
@@ -1165,6 +1169,8 @@ namespace Client.Pages
                 DefaultButton = ContentDialogButton.Primary,
                 XamlRoot = this.XamlRoot
             };
+
+            ThemeHelper.ApplyDialogTheme(dialog);
 
             var result = await dialog.ShowAsync();
 
@@ -1452,6 +1458,8 @@ namespace Client.Pages
                 XamlRoot = (this.Content as FrameworkElement)?.XamlRoot
             };
 
+            ThemeHelper.ApplyDialogTheme(dialog);
+
             await dialog.ShowAsync();
         }
 
@@ -1465,6 +1473,8 @@ namespace Client.Pages
                 CloseButtonText = "Fermer",
                 XamlRoot = (this.Content as FrameworkElement)?.XamlRoot
             };
+
+            ThemeHelper.ApplyDialogTheme(dialog);
 
             var stack = new StackPanel { Spacing = 10 };
             var roomBox = new ComboBox { ItemsSource = groups.Keys.ToList(), PlaceholderText = "Salle" };

--- a/Client/Pages/ExamRoomPage.xaml.cs
+++ b/Client/Pages/ExamRoomPage.xaml.cs
@@ -448,6 +448,8 @@ namespace Client.Pages
                 XamlRoot = this.XamlRoot
             };
 
+            ThemeHelper.ApplyDialogTheme(dialog);
+
             await dialog.ShowAsync();
         }
 
@@ -469,6 +471,8 @@ namespace Client.Pages
                     CloseButtonText = "Annuler",
                     XamlRoot = this.XamlRoot
                 };
+
+                ThemeHelper.ApplyDialogTheme(dialog);
 
                 var box = new TextBox { Text = room };
                 dialog.Content = box;

--- a/Client/Pages/HistoryPage.xaml.cs
+++ b/Client/Pages/HistoryPage.xaml.cs
@@ -173,6 +173,8 @@ namespace Client.Pages
                     XamlRoot = (this.Content as FrameworkElement)?.XamlRoot
                 };
 
+                ThemeHelper.ApplyDialogTheme(dialog);
+
                 var result = await dialog.ShowAsync();
                 if (result == ContentDialogResult.Primary)
                 {

--- a/Client/Pages/SystemPage.xaml.cs
+++ b/Client/Pages/SystemPage.xaml.cs
@@ -105,6 +105,8 @@ namespace Client.Pages
                 XamlRoot = xamlRoot
             };
 
+            ThemeHelper.ApplyDialogTheme(dialog);
+
             dialog.PrimaryButtonClick += async (s, args) =>
             {
                 var trimmed = nameBox.Text.Trim();
@@ -300,6 +302,8 @@ namespace Client.Pages
                     XamlRoot = xamlRoot
                 };
 
+                ThemeHelper.ApplyDialogTheme(dialog);
+
                 var result = await dialog.ShowAsync();
                 if (result != ContentDialogResult.Primary)
                     return false;
@@ -330,6 +334,8 @@ namespace Client.Pages
                 XamlRoot = xamlRoot
             };
 
+            ThemeHelper.ApplyDialogTheme(dialog);
+
             var result = await dialog.ShowAsync();
             return result == ContentDialogResult.Primary;
         }
@@ -343,6 +349,8 @@ namespace Client.Pages
                 CloseButtonText = "Fermer",
                 XamlRoot = xamlRoot
             };
+
+            ThemeHelper.ApplyDialogTheme(dialog);
 
             await dialog.ShowAsync();
         }

--- a/Client/Pages/UserSettingsPage.xaml.cs
+++ b/Client/Pages/UserSettingsPage.xaml.cs
@@ -226,6 +226,8 @@ namespace Client.Pages
                 XamlRoot = this.XamlRoot
             };
 
+            ThemeHelper.ApplyDialogTheme(dialog);
+
             var grid = new GridView
             {
                 ItemsSource = _defaultAvatars,

--- a/Client/Services/HotKeyService.cs
+++ b/Client/Services/HotKeyService.cs
@@ -197,6 +197,8 @@ namespace Client.Services
                 XamlRoot = xamlRoot,
             };
 
+            ThemeHelper.ApplyDialogTheme(dialog);
+
             var grid = new Grid { ColumnSpacing = 10, RowSpacing = 4 };
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
@@ -378,6 +380,8 @@ namespace Client.Services
                 XamlRoot = xamlRoot,
             };
 
+            ThemeHelper.ApplyDialogTheme(dialog);
+
             var grid = new Grid { ColumnSpacing = 10, RowSpacing = 4 };
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
@@ -483,6 +487,8 @@ namespace Client.Services
                 },
                 XamlRoot = xamlRoot,
             };
+
+            ThemeHelper.ApplyDialogTheme(dialog);
             await dialog.ShowAsync();
         }
         public static async Task DeclarePatientAsync(string examIdentifier, string patientName)


### PR DESCRIPTION
## Summary
- add a ThemeHelper to apply the application theme brushes to ContentDialogs
- call the helper from every programmatic dialog so light and dark themes are respected
- initialize new user settings files with the default avatar, theme, and appearance color values so dialogs pick up the expected brushes

## Testing
- dotnet build Client/Client.csproj *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eb9ef01e8c8324b8c83f9f555cb837