### PR TITLE
Handle dark theme dialog styling and avoid empty settings file

### DIFF
--- a/Client/Helpers/AppSettings.cs
+++ b/Client/Helpers/AppSettings.cs
@@ -273,6 +273,11 @@ namespace Client.Helpers
 
         private static void Save()
         {
+            if (string.IsNullOrWhiteSpace(App.UserName))
+            {
+                return;
+            }
+
             try
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(FilePath)!);

--- a/Client/Helpers/ThemeHelper.cs
+++ b/Client/Helpers/ThemeHelper.cs
@@ -1,4 +1,6 @@
+using System;
 using Client;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
@@ -11,6 +13,14 @@ namespace Client.Helpers
         {
             if (dialog is null)
             {
+                return;
+            }
+
+            var dispatcher = dialog.DispatcherQueue ?? App.MainWindow?.DispatcherQueue;
+
+            if (dispatcher is DispatcherQueue queue && !queue.HasThreadAccess)
+            {
+                queue.TryEnqueue(() => ApplyDialogTheme(dialog));
                 return;
             }
 
@@ -29,12 +39,25 @@ namespace Client.Helpers
 
             if (App.MainWindow?.Content is FrameworkElement root)
             {
-                dialog.RequestedTheme = root.ActualTheme switch
+                dialog.XamlRoot ??= root.XamlRoot;
+
+                var theme = root.RequestedTheme != ElementTheme.Default
+                    ? root.RequestedTheme
+                    : root.ActualTheme;
+
+                if (theme is ElementTheme.Dark or ElementTheme.Light)
                 {
-                    ElementTheme.Dark => ElementTheme.Dark,
-                    ElementTheme.Light => ElementTheme.Light,
-                    _ => dialog.RequestedTheme
-                };
+                    dialog.RequestedTheme = theme;
+                    return;
+                }
+            }
+
+            var themeSetting = AppSettings.Get("AppTheme", "Dark");
+            if (Enum.TryParse<ApplicationTheme>(themeSetting, out var appTheme))
+            {
+                dialog.RequestedTheme = appTheme == ApplicationTheme.Dark
+                    ? ElementTheme.Dark
+                    : ElementTheme.Light;
             }
         }
     }


### PR DESCRIPTION
## Summary
- guard dialog theming helper so it reruns on the UI dispatcher when invoked off-thread and respects the active theme or saved preference when the root theme is unavailable
- prevent AppSettings from persisting an orphan `_settings.json` file while no user is selected

## Testing
- Not Run (environment does not provide the required tooling)

------
https://chatgpt.com/codex/tasks/task_e_68eba984be50832480dd5136a8520e12