### PR TITLE
Fix settings file naming and dialog theming

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -1,5 +1,6 @@
 using Microsoft.UI.Xaml;
 using System;
+using System.Collections.Generic;
 using Client.Services;
 using Microsoft.Windows.AppNotifications;
 using Microsoft.Windows.AppNotifications.Builder;
@@ -103,6 +104,30 @@ namespace Client
             var appFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat");
             Directory.CreateDirectory(appFolder);
             var settingsFiles = Directory.GetFiles(appFolder, "*_settings.json");
+            var validSettingsFiles = new List<string>();
+
+            foreach (var file in settingsFiles)
+            {
+                var rawName = Path.GetFileNameWithoutExtension(file)?.Replace("_settings", string.Empty) ?? string.Empty;
+                var sanitized = AppSettings.SanitizeUserNameForFile(rawName);
+                if (string.IsNullOrWhiteSpace(sanitized))
+                {
+                    try
+                    {
+                        File.Delete(file);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogException($"[App] Impossible de supprimer le fichier de paramètres invalide '{file}'", ex, "CLI24");
+                    }
+
+                    continue;
+                }
+
+                validSettingsFiles.Add(file);
+            }
+
+            settingsFiles = validSettingsFiles.ToArray();
 
             if (settingsFiles.Length == 0)
             {
@@ -143,7 +168,11 @@ namespace Client
                    ? machine.LastUser
                    : machine.DefaultUser;
                 if (string.IsNullOrWhiteSpace(username))
-                    username = Path.GetFileNameWithoutExtension(settingsFiles[0]).Replace("_settings", "");
+                {
+                    var fromFile = Path.GetFileNameWithoutExtension(settingsFiles[0])?
+                        .Replace("_settings", string.Empty) ?? string.Empty;
+                    username = AppSettings.SanitizeUserNameForFile(fromFile);
+                }
 
                 App.UserName = username;
                 AppSettings.Reload();
@@ -282,12 +311,20 @@ namespace Client
                 var appFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat");
                 Directory.CreateDirectory(appFolder);
                 var localUsers = Directory.GetFiles(appFolder, "*_settings.json")
-                    .Select(f => Path.GetFileNameWithoutExtension(f).Replace("_settings", ""))
+                    .Select(f => Path.GetFileNameWithoutExtension(f)?.Replace("_settings", string.Empty) ?? string.Empty)
+                    .Select(AppSettings.SanitizeUserNameForFile)
+                    .Where(name => !string.IsNullOrWhiteSpace(name))
                     .ToList();
                 var missing = await ChatService.GetMissingUserSettingsAsync(localUsers);
                 foreach (var kvp in missing)
                 {
-                    var path = Path.Combine(appFolder, $"{kvp.Key}_settings.json");
+                    var sanitized = AppSettings.SanitizeUserNameForFile(kvp.Key ?? string.Empty);
+                    if (string.IsNullOrWhiteSpace(sanitized))
+                    {
+                        continue;
+                    }
+
+                    var path = Path.Combine(appFolder, $"{sanitized}_settings.json");
                     File.WriteAllText(path, kvp.Value);
                 }
             }

--- a/Client/Helpers/AppSettings.cs
+++ b/Client/Helpers/AppSettings.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Client.Models;
 using Client;
+using System.Text;
 
 namespace Client.Helpers
 {
@@ -14,10 +15,46 @@ namespace Client.Helpers
 
         public static event Action? SettingsChanged;
 
-        private static string FilePath =>
-              Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        private static readonly HashSet<char> InvalidFileNameCharacters = new(Path.GetInvalidFileNameChars());
+
+        private static string? GetSettingsFilePath()
+        {
+            var username = App.UserName;
+            if (string.IsNullOrWhiteSpace(username))
+            {
+                return null;
+            }
+
+            var sanitized = SanitizeUserNameForFile(username);
+            if (string.IsNullOrWhiteSpace(sanitized))
+            {
+                return null;
+            }
+
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                 "EyeChat",
-                $"{(App.UserName)}_settings.json");
+                $"{sanitized}_settings.json");
+        }
+
+        internal static string SanitizeUserNameForFile(string? username)
+        {
+            if (string.IsNullOrWhiteSpace(username))
+            {
+                return string.Empty;
+            }
+
+            var builder = new StringBuilder(username.Length);
+            foreach (var character in username.Trim())
+            {
+                if (!InvalidFileNameCharacters.Contains(character))
+                {
+                    builder.Append(character);
+                }
+            }
+
+            return builder.ToString();
+        }
 
         private static UserInfo? _currentUser;
         public static UserInfo? CurrentSelectedUser
@@ -52,10 +89,17 @@ namespace Client.Helpers
         {
             try
             {
-                Directory.CreateDirectory(Path.GetDirectoryName(FilePath)!);
-                if (File.Exists(FilePath))
+                var filePath = GetSettingsFilePath();
+                if (string.IsNullOrEmpty(filePath))
                 {
-                    var json = File.ReadAllText(FilePath);
+                    _settings = new();
+                    return;
+                }
+
+                Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+                if (File.Exists(filePath))
+                {
+                    var json = File.ReadAllText(filePath);
                     _settings = JsonSerializer.Deserialize<Dictionary<string, JsonNode?>>(json)
                                 ?? new();
                 }
@@ -273,19 +317,20 @@ namespace Client.Helpers
 
         private static void Save()
         {
-            if (string.IsNullOrWhiteSpace(App.UserName))
-            {
-                return;
-            }
-
             try
             {
-                Directory.CreateDirectory(Path.GetDirectoryName(FilePath)!);
+                var filePath = GetSettingsFilePath();
+                if (string.IsNullOrEmpty(filePath))
+                {
+                    return;
+                }
+
+                Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
                 var json = JsonSerializer.Serialize(_settings, new JsonSerializerOptions
                 {
                     WriteIndented = true
                 });
-                File.WriteAllText(FilePath, json);
+                File.WriteAllText(filePath, json);
             }
             catch (Exception ex)
             {
@@ -319,8 +364,14 @@ namespace Client.Helpers
         {
             try
             {
-                if (File.Exists(FilePath))
-                    File.Delete(FilePath);
+                var filePath = GetSettingsFilePath();
+                if (string.IsNullOrEmpty(filePath))
+                {
+                    return;
+                }
+
+                if (File.Exists(filePath))
+                    File.Delete(filePath);
             }
             catch (Exception ex)
             {

--- a/Client/Helpers/ThemeHelper.cs
+++ b/Client/Helpers/ThemeHelper.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using Client.Models;
 
 namespace Client.Helpers
 {
@@ -24,7 +25,9 @@ namespace Client.Helpers
                 return;
             }
 
-            if (Application.Current?.Resources is ResourceDictionary resources)
+            var appliedCustomColors = TryApplyCustomDialogColors(dialog);
+
+            if (!appliedCustomColors && Application.Current?.Resources is ResourceDictionary resources)
             {
                 if (resources.TryGetValue("ApplicationPageBackgroundThemeBrush", out var background) && background is SolidColorBrush backgroundBrush)
                 {
@@ -58,6 +61,34 @@ namespace Client.Helpers
                 dialog.RequestedTheme = appTheme == ApplicationTheme.Dark
                     ? ElementTheme.Dark
                     : ElementTheme.Light;
+            }
+        }
+
+        private static bool TryApplyCustomDialogColors(ContentDialog dialog)
+        {
+            try
+            {
+                var colors = AppSettings.GetObject<AppColorSettings>("Colors");
+                var applied = false;
+
+                if (!string.IsNullOrWhiteSpace(colors.AppBackgroundColor))
+                {
+                    dialog.Background = new SolidColorBrush(ColorUtils.FromHex(colors.AppBackgroundColor));
+                    applied = true;
+                }
+
+                if (!string.IsNullOrWhiteSpace(colors.TextAppBackgroundColor))
+                {
+                    dialog.Foreground = new SolidColorBrush(ColorUtils.FromHex(colors.TextAppBackgroundColor));
+                    applied = true;
+                }
+
+                return applied;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("[ThemeHelper] Applying custom dialog colors failed", ex, "CLI23");
+                return false;
             }
         }
     }

--- a/Client/MainWindow.xaml.cs
+++ b/Client/MainWindow.xaml.cs
@@ -125,7 +125,12 @@ namespace Client
             var appFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat");
             Directory.CreateDirectory(appFolder);
             var settingsFiles = Directory.GetFiles(appFolder, "*_settings.json");
-            var users = settingsFiles.Select(f => Path.GetFileNameWithoutExtension(f).Replace("_settings", "")).ToList();
+            var users = settingsFiles
+                .Select(f => Path.GetFileNameWithoutExtension(f)?.Replace("_settings", string.Empty) ?? string.Empty)
+                .Select(AppSettings.SanitizeUserNameForFile)
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
 
             var dialog = new ContentDialog
             {

--- a/Client/Pages/SystemPage.xaml.cs
+++ b/Client/Pages/SystemPage.xaml.cs
@@ -424,6 +424,7 @@ namespace Client.Pages
                 return Directory
                     .GetFiles(folder, "*_settings.json")
                     .Select(file => Path.GetFileName(file).Replace("_settings.json", string.Empty).Trim())
+                    .Select(AppSettings.SanitizeUserNameForFile)
                     .Where(name => !string.IsNullOrWhiteSpace(name))
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -124,7 +124,7 @@ namespace Client.Services
 
         private static string GetUserSettingsFilePath(string username)
         {
-            var safeName = (username ?? string.Empty).Trim();
+            var safeName = AppSettings.SanitizeUserNameForFile(username ?? string.Empty);
             if (string.IsNullOrEmpty(safeName))
                 throw new ArgumentException("Le nom d'utilisateur est invalide.", nameof(username));
 
@@ -609,10 +609,18 @@ namespace Client.Services
                     {
                         var appFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat");
                         Directory.CreateDirectory(appFolder);
-                        var path = Path.Combine(appFolder, $"{username}_settings.json");
+                        var sanitized = AppSettings.SanitizeUserNameForFile(username);
+                        if (string.IsNullOrWhiteSpace(sanitized))
+                        {
+                            return;
+                        }
+
+                        var path = Path.Combine(appFolder, $"{sanitized}_settings.json");
                         File.WriteAllText(path, json);
 
-                        if (username == App.UserName)
+                        var currentUser = AppSettings.SanitizeUserNameForFile(App.UserName);
+                        if (!string.IsNullOrWhiteSpace(currentUser) &&
+                            sanitized.Equals(currentUser, StringComparison.OrdinalIgnoreCase))
                         {
                             AppSettings.Import(json);
                             if (App.MainWindow?.Content is FrameworkElement root)
@@ -994,8 +1002,8 @@ namespace Client.Services
                 if (string.IsNullOrWhiteSpace(user.Username))
                     continue;
 
-                var safeName = user.Username.Trim();
-                if (safeName.Length == 0)
+                var safeName = AppSettings.SanitizeUserNameForFile(user.Username);
+                if (string.IsNullOrWhiteSpace(safeName))
                     continue;
 
                 var settingsPath = Path.Combine(folder, $"{safeName}_settings.json");


### PR DESCRIPTION
## Summary
- sanitize usernames before creating or loading local *_settings.json files and ignore invalid entries
- delete stray settings files without a username and ensure user lists only include valid accounts
- apply the saved color palette to content dialogs so they remain readable when the dark theme is active

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ebb10bf91083248d3483f570131689