### PR TITLE
Fix dark theme palette for chat client

### DIFF
--- a/Client/Helpers/AppSettings.cs
+++ b/Client/Helpers/AppSettings.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Client.Models;
 using Client;
+using Microsoft.UI.Xaml;
 using System.Text;
 
 namespace Client.Helpers
@@ -153,20 +154,10 @@ namespace Client.Helpers
 
         private static bool EnsureColorsSetting()
         {
-            var defaultColors = new AppColorSettings
-            {
-                TitleBarColor = "#FF0078D7",
-                TextTitleBarColor = "#FFFFFFFF",
-                NavigationViewColor = "#FFE6F1FF",
-                TextNavigationViewColor = "#FF000000",
-                MyMessageColor = "#FFCCE5FF",
-                TextMyMessageColor = "#FF000000",
-                OtherMessageColor = "#FFD9F2DC",
-                TextOtherMessageColor = "#FF000000",
-                AppBackgroundColor = "#FFFFFFFF",
-                TextAppBackgroundColor = "#FF000000",
-                SystemAccentColorDark1 = "#FF0078D7"
-            };
+            var theme = Get("AppTheme", "Dark");
+            var defaultColors = string.Equals(theme, nameof(ApplicationTheme.Light), StringComparison.OrdinalIgnoreCase)
+                ? AppColorPalettes.CreateLightPalette()
+                : AppColorPalettes.CreateDarkPalette();
 
             try
             {

--- a/Client/Models/AppColorPalettes.cs
+++ b/Client/Models/AppColorPalettes.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace Client.Models
+{
+    public static class AppColorPalettes
+    {
+        public static AppColorSettings CreateLightPalette()
+        {
+            return new AppColorSettings
+            {
+                TitleBarColor = "#FF0078D7",
+                TextTitleBarColor = "#FFFFFFFF",
+                NavigationViewColor = "#FFE6F1FF",
+                TextNavigationViewColor = "#FF000000",
+                MyMessageColor = "#FFCCE5FF",
+                TextMyMessageColor = "#FF000000",
+                OtherMessageColor = "#FFD9F2DC",
+                TextOtherMessageColor = "#FF000000",
+                AppBackgroundColor = "#FFFFFFFF",
+                TextAppBackgroundColor = "#FF000000",
+                SystemAccentColorDark1 = "#FF0078D7"
+            };
+        }
+
+        public static AppColorSettings CreateDarkPalette()
+        {
+            return new AppColorSettings
+            {
+                TitleBarColor = "#FF202020",
+                TextTitleBarColor = "#FFFFFFFF",
+                NavigationViewColor = "#FF1E1E1E",
+                TextNavigationViewColor = "#FFFFFFFF",
+                MyMessageColor = "#FF2F5D8C",
+                TextMyMessageColor = "#FFFFFFFF",
+                OtherMessageColor = "#FF2F6F4A",
+                TextOtherMessageColor = "#FFFFFFFF",
+                AppBackgroundColor = "#FF0F0F0F",
+                TextAppBackgroundColor = "#FFFFFFFF",
+                SystemAccentColorDark1 = "#FF0078D7"
+            };
+        }
+
+        public static bool AreEquivalent(AppColorSettings? first, AppColorSettings? second)
+        {
+            if (first is null || second is null)
+            {
+                return false;
+            }
+
+            return string.Equals(first.TitleBarColor, second.TitleBarColor, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(first.TextTitleBarColor, second.TextTitleBarColor, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(first.NavigationViewColor, second.NavigationViewColor, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(first.TextNavigationViewColor, second.TextNavigationViewColor, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(first.MyMessageColor, second.MyMessageColor, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(first.TextMyMessageColor, second.TextMyMessageColor, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(first.OtherMessageColor, second.OtherMessageColor, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(first.TextOtherMessageColor, second.TextOtherMessageColor, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(first.AppBackgroundColor, second.AppBackgroundColor, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(first.TextAppBackgroundColor, second.TextAppBackgroundColor, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(first.SystemAccentColorDark1, second.SystemAccentColorDark1, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/Client/Pages/AppearanceSettingsPage.xaml.cs
+++ b/Client/Pages/AppearanceSettingsPage.xaml.cs
@@ -24,15 +24,7 @@ namespace Client.Pages
             Debug.WriteLine($"[AppearanceSettingsPage] ViewModel instance: {ViewModelSettings.GetHashCode()}");
 
             currentSettings = AppSettings.GetObject<AppColorSettings>("Colors");
-
-            if (FindName("TitleBarAccentPicker") is ColorPicker tb)
-                tb.Color = ColorUtils.FromHex(currentSettings.TitleBarColor);
-            if (FindName("NavPicker") is ColorPicker np)
-                np.Color = ColorUtils.FromHex(currentSettings.NavigationViewColor);
-            if (FindName("MyBubblePicker") is ColorPicker mb)
-                mb.Color = ColorUtils.FromHex(currentSettings.MyMessageColor);
-            if (FindName("OtherBubblePicker") is ColorPicker ob)
-                ob.Color = ColorUtils.FromHex(currentSettings.OtherMessageColor);
+            RefreshColorPreview();
             if (FindName("ThemeCombo") is ComboBox theme)
             {
                 theme.SelectedIndex = ViewModelSettings.AppTheme switch
@@ -145,7 +137,26 @@ namespace Client.Pages
             if (ThemeCombo.SelectedItem is ComboBoxItem item && item.Tag is string theme)
             {
                 ViewModelSettings.AppTheme = theme;
+                currentSettings = AppSettings.GetObject<AppColorSettings>("Colors");
+                RefreshColorPreview();
             }
+        }
+
+        private void RefreshColorPreview()
+        {
+            if (FindName("TitleBarAccentPicker") is ColorPicker tb)
+                tb.Color = ColorUtils.FromHex(currentSettings.TitleBarColor);
+            if (FindName("NavPicker") is ColorPicker np)
+                np.Color = ColorUtils.FromHex(currentSettings.NavigationViewColor);
+            if (FindName("MyBubblePicker") is ColorPicker mb)
+                mb.Color = ColorUtils.FromHex(currentSettings.MyMessageColor);
+            if (FindName("OtherBubblePicker") is ColorPicker ob)
+                ob.Color = ColorUtils.FromHex(currentSettings.OtherMessageColor);
+
+            TitleBarZone.Background = new SolidColorBrush(ColorUtils.FromHex(currentSettings.TitleBarColor));
+            NavZone.Background = new SolidColorBrush(ColorUtils.FromHex(currentSettings.NavigationViewColor));
+            MyMessageZone.Background = new SolidColorBrush(ColorUtils.FromHex(currentSettings.MyMessageColor));
+            OtherMessageZone.Background = new SolidColorBrush(ColorUtils.FromHex(currentSettings.OtherMessageColor));
         }
 
         private void SaveSettings_Click(object sender, RoutedEventArgs e)
@@ -171,6 +182,8 @@ namespace Client.Pages
             var otherColor = ColorUtils.FromHex(colors.OtherMessageColor);
             var textOtherColor = ColorUtils.FromHex(colors.TextOtherMessageColor);
             var accentDark1 = ColorUtils.FromHex(colors.SystemAccentColorDark1);
+            var appBackgroundColor = ColorUtils.FromHex(colors.AppBackgroundColor);
+            var textAppBackgroundColor = ColorUtils.FromHex(colors.TextAppBackgroundColor);
 
             UpdateResourceBrush("TitleBarColor", titleColor);
             UpdateResourceBrush("TextTitleBarColor", textColorTitleBar);
@@ -183,6 +196,8 @@ namespace Client.Pages
             UpdateResourceBrush("OtherMessageColor", otherColor);
             UpdateResourceBrush("TextOtherMessageColor", textOtherColor);
             UpdateResourceBrush("SystemAccentColorDark1", accentDark1);
+            UpdateResourceBrush("ApplicationPageBackgroundThemeBrush", appBackgroundColor);
+            UpdateResourceBrush("TextAppBackgroundColor", textAppBackgroundColor);
 
             ApplyNavigationColors(colors, nav);
 

--- a/Client/ViewModel/SettingsViewModel.cs
+++ b/Client/ViewModel/SettingsViewModel.cs
@@ -6,6 +6,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Client.Helpers;
 using Client.Models;
+using Client.Pages;
 using System.Runtime.Versioning;
 
 namespace Client.ViewModel
@@ -575,18 +576,53 @@ namespace Client.ViewModel
 
         private static void ApplyTheme(string theme)
         {
-            if (Enum.TryParse<ApplicationTheme>(theme, out var appTheme))
+            if (!Enum.TryParse<ApplicationTheme>(theme, out var appTheme))
             {
-                //Application.Current.RequestedTheme = appTheme;
-
-                if (App.MainWindow?.Content is FrameworkElement root)
-                {
-                    root.RequestedTheme =
-                        appTheme == ApplicationTheme.Dark ?
-                        ElementTheme.Dark :
-                        ElementTheme.Light;
-                }
+                return;
             }
+
+            var colors = EnsureThemePalette(appTheme);
+
+            Grid? titleBar = null;
+            NavigationView? nav = null;
+            TextBlock? titleText = null;
+
+            if (App.MainWindow?.Content is FrameworkElement root)
+            {
+                root.RequestedTheme = appTheme == ApplicationTheme.Dark
+                    ? ElementTheme.Dark
+                    : ElementTheme.Light;
+
+                titleBar = root.FindName("AppTitleBar") as Grid;
+                nav = root.FindName("nvSample") as NavigationView;
+                titleText = root.FindName("TitleBarTextBlock") as TextBlock;
+            }
+
+            AppearanceSettingsPage.ApplyColors(colors, titleBar, nav, titleText);
+        }
+
+        private static AppColorSettings EnsureThemePalette(ApplicationTheme appTheme)
+        {
+            var colors = AppSettings.GetObject<AppColorSettings>("Colors") ?? new AppColorSettings();
+            var targetPalette = appTheme == ApplicationTheme.Dark
+                ? AppColorPalettes.CreateDarkPalette()
+                : AppColorPalettes.CreateLightPalette();
+            var oppositePalette = appTheme == ApplicationTheme.Dark
+                ? AppColorPalettes.CreateLightPalette()
+                : AppColorPalettes.CreateDarkPalette();
+
+            if (AppColorPalettes.AreEquivalent(colors, targetPalette))
+            {
+                return colors;
+            }
+
+            if (AppColorPalettes.AreEquivalent(colors, oppositePalette))
+            {
+                AppSettings.SetObject("Colors", targetPalette);
+                return targetPalette;
+            }
+
+            return colors;
         }
 
         private void OnPropertyChanged(string propertyName)


### PR DESCRIPTION
## Summary
- add dedicated light and dark color palettes and use the active theme when seeding default chat colors
- apply the appropriate palette when the user switches themes so navigation, message bubbles, and backgrounds stay legible
- refresh the appearance preview after theme changes and update shared resources, including the page background brush

## Testing
- dotnet build WebApplication1.sln *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebb53174748324960a40321613557f