### PR TITLE
Normalize color defaults to fix light theme regression

### DIFF
--- a/Client/Models/AppColorSettings.cs
+++ b/Client/Models/AppColorSettings.cs
@@ -2,18 +2,99 @@ namespace Client.Models
 {
     public class AppColorSettings
     {
-        public string TitleBarColor { get; set; } = "#FF0078D7";
-        public string TextTitleBarColor { get; set; } = "#FFFFFFFF";
-        public string NavigationViewColor { get; set; } = "#FFE6F1FF";
-        public string TextNavigationViewColor { get; set; } = "#FF000000";
-        public string MyMessageColor { get; set; } = "#FFCCE5FF";
-        public string TextMyMessageColor { get; set; } = "#FF000000";
-        public string OtherMessageColor { get; set; } = "#FFD9F2DC";
-        public string TextOtherMessageColor { get; set; } = "#FF000000";
+        private const string DefaultTitleBarColor = "#FF0078D7";
+        private const string DefaultTextTitleBarColor = "#FFFFFFFF";
+        private const string DefaultNavigationViewColor = "#FFE6F1FF";
+        private const string DefaultTextNavigationViewColor = "#FF000000";
+        private const string DefaultMyMessageColor = "#FFCCE5FF";
+        private const string DefaultTextMyMessageColor = "#FF000000";
+        private const string DefaultOtherMessageColor = "#FFD9F2DC";
+        private const string DefaultTextOtherMessageColor = "#FF000000";
+        private const string DefaultAppBackgroundColor = "#FFFFFFFF";
+        private const string DefaultTextAppBackgroundColor = "#FF000000";
+        private const string DefaultSystemAccentColorDark1 = "#FF0078D7";
 
-        public string AppBackgroundColor { get; set; } = "#FFFFFFFF";
-        public string TextAppBackgroundColor { get; set; } = "#FF000000";
+        private string _titleBarColor = DefaultTitleBarColor;
+        private string _textTitleBarColor = DefaultTextTitleBarColor;
+        private string _navigationViewColor = DefaultNavigationViewColor;
+        private string _textNavigationViewColor = DefaultTextNavigationViewColor;
+        private string _myMessageColor = DefaultMyMessageColor;
+        private string _textMyMessageColor = DefaultTextMyMessageColor;
+        private string _otherMessageColor = DefaultOtherMessageColor;
+        private string _textOtherMessageColor = DefaultTextOtherMessageColor;
+        private string _appBackgroundColor = DefaultAppBackgroundColor;
+        private string _textAppBackgroundColor = DefaultTextAppBackgroundColor;
+        private string _systemAccentColorDark1 = DefaultSystemAccentColorDark1;
 
-        public string SystemAccentColorDark1 { get; set; } = "#FF0078D7";
+        public string TitleBarColor
+        {
+            get => Normalize(_titleBarColor, DefaultTitleBarColor);
+            set => _titleBarColor = Normalize(value, DefaultTitleBarColor);
+        }
+
+        public string TextTitleBarColor
+        {
+            get => Normalize(_textTitleBarColor, DefaultTextTitleBarColor);
+            set => _textTitleBarColor = Normalize(value, DefaultTextTitleBarColor);
+        }
+
+        public string NavigationViewColor
+        {
+            get => Normalize(_navigationViewColor, DefaultNavigationViewColor);
+            set => _navigationViewColor = Normalize(value, DefaultNavigationViewColor);
+        }
+
+        public string TextNavigationViewColor
+        {
+            get => Normalize(_textNavigationViewColor, DefaultTextNavigationViewColor);
+            set => _textNavigationViewColor = Normalize(value, DefaultTextNavigationViewColor);
+        }
+
+        public string MyMessageColor
+        {
+            get => Normalize(_myMessageColor, DefaultMyMessageColor);
+            set => _myMessageColor = Normalize(value, DefaultMyMessageColor);
+        }
+
+        public string TextMyMessageColor
+        {
+            get => Normalize(_textMyMessageColor, DefaultTextMyMessageColor);
+            set => _textMyMessageColor = Normalize(value, DefaultTextMyMessageColor);
+        }
+
+        public string OtherMessageColor
+        {
+            get => Normalize(_otherMessageColor, DefaultOtherMessageColor);
+            set => _otherMessageColor = Normalize(value, DefaultOtherMessageColor);
+        }
+
+        public string TextOtherMessageColor
+        {
+            get => Normalize(_textOtherMessageColor, DefaultTextOtherMessageColor);
+            set => _textOtherMessageColor = Normalize(value, DefaultTextOtherMessageColor);
+        }
+
+        public string AppBackgroundColor
+        {
+            get => Normalize(_appBackgroundColor, DefaultAppBackgroundColor);
+            set => _appBackgroundColor = Normalize(value, DefaultAppBackgroundColor);
+        }
+
+        public string TextAppBackgroundColor
+        {
+            get => Normalize(_textAppBackgroundColor, DefaultTextAppBackgroundColor);
+            set => _textAppBackgroundColor = Normalize(value, DefaultTextAppBackgroundColor);
+        }
+
+        public string SystemAccentColorDark1
+        {
+            get => Normalize(_systemAccentColorDark1, DefaultSystemAccentColorDark1);
+            set => _systemAccentColorDark1 = Normalize(value, DefaultSystemAccentColorDark1);
+        }
+
+        private static string Normalize(string? value, string fallback)
+        {
+            return string.IsNullOrWhiteSpace(value) ? fallback : value;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- normalize every color property in `AppColorSettings` so empty or null values fall back to safe defaults
- protect the light theme from loading invalid brushes when persisted settings are missing recent fields

## Testing
- `dotnet build Client/Client.csproj` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebbac48a388324bc848313051b9cbc