### PR TITLE
Restore light theme resources

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -219,7 +219,11 @@ namespace Client
 
             }
 
-            AppearanceSettingsPage.ApplyColors(colors, titleBar, nav, titleText);
+            var targetTheme = root.RequestedTheme is ElementTheme.Default
+                ? root.ActualTheme
+                : root.RequestedTheme;
+
+            AppearanceSettingsPage.ApplyColors(colors, titleBar, nav, titleText, targetTheme);
         }
 
         private void ChatService_OnMessageReceived(ChatMessageModel chat)

--- a/Client/Pages/AppearanceSettingsPage.xaml.cs
+++ b/Client/Pages/AppearanceSettingsPage.xaml.cs
@@ -43,17 +43,20 @@ namespace Client.Pages
             currentSettings.TextTitleBarColor = ColorUtils.ToHex(textColorTitleBar);
             currentSettings.SystemAccentColorDark1 = ColorUtils.ToHex(args.NewColor);
             AppSettings.SetObject("Colors", currentSettings);
-            UpdateResourceBrush("TextTitleBarColor", textColorTitleBar);
-            UpdateResourceBrush("SystemAccentColorDark1", args.NewColor);
-            UpdateResourceBrush("AccentColor", args.NewColor);
-            UpdateResourceBrush("SystemControlHighlightAccentBrush", args.NewColor);
+
+            var theme = GetCurrentTheme();
+
+            UpdateResourceBrush("TextTitleBarColor", textColorTitleBar, theme);
+            UpdateResourceBrush("SystemAccentColorDark1", args.NewColor, theme);
+            UpdateResourceBrush("AccentColor", args.NewColor, theme);
+            UpdateResourceBrush("SystemControlHighlightAccentBrush", args.NewColor, theme);
             if (App.MainWindow.Content is FrameworkElement root)
             {
                 var titleBar = root.FindName("AppTitleBar") as Grid;
                 var nav = root.FindName("nvSample") as NavigationView;
                 var titleText = root.FindName("TitleBarTextBlock") as TextBlock;
                 TitleBarZone.Background = new SolidColorBrush(ColorUtils.FromHex(currentSettings.TitleBarColor));
-                ApplyColors(currentSettings, titleBar, nav, titleText);
+                ApplyColors(currentSettings, titleBar, nav, titleText, theme);
             }
         }
 
@@ -63,28 +66,29 @@ namespace Client.Pages
             var textNavColor = ColorUtils.GetContrastingTextColor(args.NewColor);
             currentSettings.TextNavigationViewColor = ColorUtils.ToHex(textNavColor);
             AppSettings.SetObject("Colors", currentSettings);
+            var theme = GetCurrentTheme();
             if (App.MainWindow.Content is FrameworkElement root)
             {
                 var nav = root.FindName("nvSample") as NavigationView;
                 NavZone.Background = new SolidColorBrush(ColorUtils.FromHex(currentSettings.NavigationViewColor));
-                ApplyNavigationColors(currentSettings, nav);
+                ApplyNavigationColors(currentSettings, nav, theme);
             }
         }
 
-        private static void ApplyNavigationColors(AppColorSettings colors, NavigationView? nav = null)
+        private static void ApplyNavigationColors(AppColorSettings colors, NavigationView? nav = null, ElementTheme? theme = null)
         {
             var navColor = ColorUtils.FromHex(colors.NavigationViewColor);
             var textNavColor = ColorUtils.FromHex(colors.TextNavigationViewColor);
             var pointerNavColor = ColorUtils.GetContrastingTextColor(textNavColor);
 
-            UpdateResourceBrush("NavigationViewColor", navColor);
-            UpdateResourceBrush("NavigationViewItemForeground", textNavColor);
-            UpdateResourceBrush("NavigationViewItemForegroundSelected", textNavColor);
-            UpdateResourceBrush("NavigationViewItemIconForeground", textNavColor);
-            UpdateResourceBrush("NavigationViewItemIconForegroundSelected", textNavColor);
-            UpdateResourceBrush("NavigationViewItemForegroundPointerOver", pointerNavColor);
-            UpdateResourceBrush("NavigationViewItemIconForegroundPointerOver", pointerNavColor);
-            UpdateResourceBrush("PivotHeaderForeground", textNavColor);
+            UpdateResourceBrush("NavigationViewColor", navColor, theme);
+            UpdateResourceBrush("NavigationViewItemForeground", textNavColor, theme);
+            UpdateResourceBrush("NavigationViewItemForegroundSelected", textNavColor, theme);
+            UpdateResourceBrush("NavigationViewItemIconForeground", textNavColor, theme);
+            UpdateResourceBrush("NavigationViewItemIconForegroundSelected", textNavColor, theme);
+            UpdateResourceBrush("NavigationViewItemForegroundPointerOver", pointerNavColor, theme);
+            UpdateResourceBrush("NavigationViewItemIconForegroundPointerOver", pointerNavColor, theme);
+            UpdateResourceBrush("PivotHeaderForeground", textNavColor, theme);
 
             nav?.DispatcherQueue.TryEnqueue(() =>
             {
@@ -106,13 +110,14 @@ namespace Client.Pages
             var textColor = ColorUtils.GetContrastingTextColor(args.NewColor);
             currentSettings.TextMyMessageColor = ColorUtils.ToHex(textColor);
             AppSettings.SetObject("Colors", currentSettings);
+            var theme = GetCurrentTheme();
             if (App.MainWindow.Content is FrameworkElement root)
             {
                 var titleBar = root.FindName("AppTitleBar") as Grid;
                 var nav = root.FindName("nvSample") as NavigationView;
                 var titleText = root.FindName("TitleBarTextBlock") as TextBlock;
                 MyMessageZone.Background = new SolidColorBrush(ColorUtils.FromHex(currentSettings.MyMessageColor));
-                ApplyColors(currentSettings, titleBar, nav, titleText);
+                ApplyColors(currentSettings, titleBar, nav, titleText, theme);
             }
         }
 
@@ -122,13 +127,14 @@ namespace Client.Pages
             var textColor = ColorUtils.GetContrastingTextColor(args.NewColor);
             currentSettings.TextOtherMessageColor = ColorUtils.ToHex(textColor);
             AppSettings.SetObject("Colors", currentSettings);
+            var theme = GetCurrentTheme();
             if (App.MainWindow.Content is FrameworkElement root)
             {
                 var titleBar = root.FindName("AppTitleBar") as Grid;
                 var nav = root.FindName("nvSample") as NavigationView;
                 var titleText = root.FindName("TitleBarTextBlock") as TextBlock;
                 OtherMessageZone.Background = new SolidColorBrush(ColorUtils.FromHex(currentSettings.OtherMessageColor));
-                ApplyColors(currentSettings, titleBar, nav, titleText);
+                ApplyColors(currentSettings, titleBar, nav, titleText, theme);
             }
         }
 
@@ -162,16 +168,22 @@ namespace Client.Pages
         private void SaveSettings_Click(object sender, RoutedEventArgs e)
         {
             AppSettings.SetObject("Colors", currentSettings);
+            var theme = GetCurrentTheme();
             if (App.MainWindow.Content is FrameworkElement root)
             {
                 var titleBar = root.FindName("AppTitleBar") as Grid;
                 var nav = root.FindName("nvSample") as NavigationView;
                 var titleText = root.FindName("TitleBarTextBlock") as TextBlock;
-                ApplyColors(currentSettings, titleBar, nav, titleText);
+                ApplyColors(currentSettings, titleBar, nav, titleText, theme);
             }
         }
 
-        public static void ApplyColors(AppColorSettings colors, Grid? titleBar = null, NavigationView? nav = null, TextBlock? titleTextBlock = null)
+        public static void ApplyColors(
+            AppColorSettings colors,
+            Grid? titleBar = null,
+            NavigationView? nav = null,
+            TextBlock? titleTextBlock = null,
+            ElementTheme? theme = null)
         {
             var titleColor = ColorUtils.FromHex(colors.TitleBarColor);
             var textColorTitleBar = ColorUtils.FromHex(colors.TextTitleBarColor);
@@ -185,42 +197,92 @@ namespace Client.Pages
             var appBackgroundColor = ColorUtils.FromHex(colors.AppBackgroundColor);
             var textAppBackgroundColor = ColorUtils.FromHex(colors.TextAppBackgroundColor);
 
-            UpdateResourceBrush("TitleBarColor", titleColor);
-            UpdateResourceBrush("TextTitleBarColor", textColorTitleBar);
-            UpdateResourceBrush("SystemAccentColor", titleColor);
-            UpdateResourceBrush("AccentColor", titleColor);
-            UpdateResourceBrush("SystemAccentColorLight3", navColor);
-            UpdateResourceBrush("SystemControlHighlightAccentBrush", titleColor);
-            UpdateResourceBrush("MyMessageColor", myColor);
-            UpdateResourceBrush("TextMyMessageColor", textMyColor);
-            UpdateResourceBrush("OtherMessageColor", otherColor);
-            UpdateResourceBrush("TextOtherMessageColor", textOtherColor);
-            UpdateResourceBrush("SystemAccentColorDark1", accentDark1);
-            UpdateResourceBrush("ApplicationPageBackgroundThemeBrush", appBackgroundColor);
-            UpdateResourceBrush("TextAppBackgroundColor", textAppBackgroundColor);
+            var targetTheme = theme ?? GetCurrentTheme();
 
-            ApplyNavigationColors(colors, nav);
+            UpdateResourceBrush("TitleBarColor", titleColor, targetTheme);
+            UpdateResourceBrush("TextTitleBarColor", textColorTitleBar, targetTheme);
+            UpdateResourceBrush("SystemAccentColor", titleColor, targetTheme);
+            UpdateResourceBrush("AccentColor", titleColor, targetTheme);
+            UpdateResourceBrush("SystemAccentColorLight3", navColor, targetTheme);
+            UpdateResourceBrush("SystemControlHighlightAccentBrush", titleColor, targetTheme);
+            UpdateResourceBrush("MyMessageColor", myColor, targetTheme);
+            UpdateResourceBrush("TextMyMessageColor", textMyColor, targetTheme);
+            UpdateResourceBrush("OtherMessageColor", otherColor, targetTheme);
+            UpdateResourceBrush("TextOtherMessageColor", textOtherColor, targetTheme);
+            UpdateResourceBrush("SystemAccentColorDark1", accentDark1, targetTheme);
+            UpdateResourceBrush("ApplicationPageBackgroundThemeBrush", appBackgroundColor, targetTheme);
+            UpdateResourceBrush("TextAppBackgroundColor", textAppBackgroundColor, targetTheme);
+
+            ApplyNavigationColors(colors, nav, targetTheme);
 
             titleBar?.DispatcherQueue.TryEnqueue(() => titleBar.Background = new SolidColorBrush(titleColor));
 
             titleTextBlock?.DispatcherQueue.TryEnqueue(() => titleTextBlock.Foreground = new SolidColorBrush(textColorTitleBar));
         }
 
-        private static void UpdateResourceBrush(string key, Windows.UI.Color color)
+        private static void UpdateResourceBrush(string key, Windows.UI.Color color, ElementTheme? theme = null)
         {
             var resources = Application.Current.Resources;
-            if (resources[key] is SolidColorBrush brush)
+            if (theme is ElementTheme.Dark or ElementTheme.Light)
             {
-                brush.Color = color;
+                var themeKey = theme.ToString();
+                if (themeKey is not null && resources.ThemeDictionaries.TryGetValue(themeKey, out var themeResources)
+                    && themeResources is ResourceDictionary themeDictionary)
+                {
+                    if (TryUpdateResource(themeDictionary, key, color))
+                    {
+                        return;
+                    }
+                }
             }
-            else if (resources[key] is Windows.UI.Color)
+
+            TryUpdateResource(resources, key, color, allowAdd: true);
+        }
+
+        private static bool TryUpdateResource(ResourceDictionary dictionary, string key, Windows.UI.Color color, bool allowAdd = false)
+        {
+            if (dictionary.TryGetValue(key, out var value))
             {
-                resources[key] = color;
+                switch (value)
+                {
+                    case SolidColorBrush brush:
+                        brush.Color = color;
+                        return true;
+                    case Windows.UI.Color:
+                        dictionary[key] = color;
+                        return true;
+                    default:
+                        dictionary[key] = new SolidColorBrush(color);
+                        return true;
+                }
             }
-            else
+
+            if (allowAdd)
             {
-                resources[key] = new SolidColorBrush(color);
+                dictionary[key] = new SolidColorBrush(color);
+                return true;
             }
+
+            return false;
+        }
+
+        private static ElementTheme? GetCurrentTheme()
+        {
+            if (App.MainWindow?.Content is FrameworkElement root)
+            {
+                var theme = root.RequestedTheme;
+                if (theme == ElementTheme.Default)
+                {
+                    theme = root.ActualTheme;
+                }
+
+                if (theme is ElementTheme.Dark or ElementTheme.Light)
+                {
+                    return theme;
+                }
+            }
+
+            return null;
         }
 
         private void Back_Click(object sender, RoutedEventArgs e)

--- a/Client/ViewModel/SettingsViewModel.cs
+++ b/Client/ViewModel/SettingsViewModel.cs
@@ -598,7 +598,11 @@ namespace Client.ViewModel
                 titleText = root.FindName("TitleBarTextBlock") as TextBlock;
             }
 
-            AppearanceSettingsPage.ApplyColors(colors, titleBar, nav, titleText);
+            var theme = appTheme == ApplicationTheme.Dark
+                ? ElementTheme.Dark
+                : ElementTheme.Light;
+
+            AppearanceSettingsPage.ApplyColors(colors, titleBar, nav, titleText, theme);
         }
 
         private static AppColorSettings EnsureThemePalette(ApplicationTheme appTheme)


### PR DESCRIPTION
## Summary
- update appearance settings helpers to adjust resource dictionaries per active theme
- ensure theme application passes the active theme so light mode keeps its light palette

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebcd71ea148324ad9d59993806cc25