### PR TITLE
Add appointment search interface and shared scheduling config

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Data.OleDb" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Page Update="Pages\SystemPage.xaml">

--- a/Client/Helpers/MachineConfig.cs
+++ b/Client/Helpers/MachineConfig.cs
@@ -30,6 +30,21 @@ namespace Client.Helpers
         /// </summary>
         public int PickupAlertThresholdMinutes { get; set; }
 
+        /// <summary>
+        /// Local path to the Access system database (system.mdw).
+        /// </summary>
+        public string AccessWorkgroupPath { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Optional user name for the Access workgroup.
+        /// </summary>
+        public string AccessUserName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Optional password for the Access workgroup.
+        /// </summary>
+        public string AccessPassword { get; set; } = string.Empty;
+
         public static string FilePath =>
             Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                 "EyeChat", "machine.json");

--- a/Client/MainWindow.xaml
+++ b/Client/MainWindow.xaml
@@ -85,6 +85,7 @@
             <NavigationView.MenuItems>
                 <NavigationViewItem Content="Chat" Tag="ChatPage" Icon="LeaveChat" />
                 <NavigationViewItem Content="Historique" Tag="HistoryPage" Icon="People" />
+                <NavigationViewItem Content="Recherche RDV" Tag="AppointmentSearchPage" Icon="CalendarDay" />
             </NavigationView.MenuItems>
             <Frame x:Name="contentFrame" Padding="-2" />
         </NavigationView>

--- a/Client/MainWindow.xaml.cs
+++ b/Client/MainWindow.xaml.cs
@@ -64,6 +64,7 @@ namespace Client
                 {
                     "ChatPage" => typeof(Pages.ChatPage),
                     "HistoryPage" => typeof(Pages.HistoryPage),
+                    "AppointmentSearchPage" => typeof(Pages.AppointmentSearchPage),
                     _ => null
                 };
                 if (pageType != null && contentFrame.CurrentSourcePageType != pageType)

--- a/Client/Models/AppointmentSearchConfig.cs
+++ b/Client/Models/AppointmentSearchConfig.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Client.Models
+{
+    public class AppointmentSearchConfig
+    {
+        public string DatabasePath { get; set; } = string.Empty;
+        public string TableName { get; set; } = "Ag_rdv";
+        public string DateColumn { get; set; } = "DateRdv";
+        public string TimeColumn { get; set; } = "Heure";
+        public string ColorColumn { get; set; } = "Marque";
+        public int SlotLengthMinutes { get; set; } = 15;
+        public int MaxAppointmentsPerSlot { get; set; } = 3;
+        public int OverloadExtraAppointments { get; set; } = 1;
+        public TimeSpan MorningStart { get; set; } = TimeSpan.FromHours(8);
+        public TimeSpan MorningEnd { get; set; } = TimeSpan.FromHours(11.5);
+        public TimeSpan AfternoonStart { get; set; } = TimeSpan.FromHours(13);
+        public TimeSpan AfternoonEnd { get; set; } = TimeSpan.FromHours(18);
+        public TimeSpan FoMorningLimit { get; set; } = TimeSpan.FromHours(10);
+        public TimeSpan FoAfternoonLimit { get; set; } = TimeSpan.FromHours(16.5);
+
+        public bool IsValid()
+        {
+            return !string.IsNullOrWhiteSpace(DatabasePath)
+                && !string.IsNullOrWhiteSpace(TableName)
+                && !string.IsNullOrWhiteSpace(DateColumn)
+                && !string.IsNullOrWhiteSpace(TimeColumn)
+                && !string.IsNullOrWhiteSpace(ColorColumn)
+                && SlotLengthMinutes > 0
+                && MaxAppointmentsPerSlot > 0;
+        }
+    }
+}

--- a/Client/Models/AppointmentSlotInfo.cs
+++ b/Client/Models/AppointmentSlotInfo.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Client.Models
+{
+    public class AppointmentSlotInfo
+    {
+        public DateTime SlotStart { get; set; }
+        public int ExistingAppointments { get; set; }
+        public IReadOnlyDictionary<int, int> ColorCounts { get; set; } = new Dictionary<int, int>();
+        public bool UsesOverloadCapacity { get; set; }
+        public bool RedRelaxationApplied { get; set; }
+
+        public string DisplayDate => SlotStart.ToString("dddd dd/MM/yyyy HH:mm");
+
+        public string Summary
+        {
+            get
+            {
+                if (ColorCounts.Count == 0)
+                {
+                    return "Aucun rendez-vous";
+                }
+
+                var parts = ColorCounts
+                    .OrderBy(p => p.Key)
+                    .Select(p => $"{GetColorName(p.Key)}: {p.Value}");
+                return string.Join(", ", parts);
+            }
+        }
+
+        private static string GetColorName(int value) => value switch
+        {
+            0 => "Noir",
+            255 => "Rouge",
+            33023 => "Orange",
+            16711935 => "Rose",
+            65280 => "Vert",
+            _ => $"Couleur {value}"
+        };
+    }
+}

--- a/Client/Pages/AppointmentSearchPage.xaml
+++ b/Client/Pages/AppointmentSearchPage.xaml
@@ -1,0 +1,69 @@
+<Page
+    x:Class="Client.Pages.AppointmentSearchPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:models="using:Client.Models"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Page.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+    </Page.Resources>
+    <ScrollViewer>
+        <StackPanel Padding="20" Spacing="16">
+            <TextBlock Text="Recherche de rendez-vous" FontSize="24" FontWeight="Bold" />
+
+            <StackPanel Orientation="Horizontal" Spacing="12" HorizontalAlignment="Stretch">
+                <StackPanel Width="220" Spacing="8">
+                    <TextBlock Text="Horizon" FontWeight="SemiBold" />
+                    <ComboBox x:Name="HorizonCombo" SelectedIndex="0" SelectionChanged="HorizonCombo_SelectionChanged">
+                        <ComboBoxItem Content="Dans 1 mois" Tag="1" />
+                        <ComboBoxItem Content="Dans 2 mois" Tag="2" />
+                        <ComboBoxItem Content="Dans 4 mois" Tag="4" />
+                        <ComboBoxItem Content="Dans 8 mois" Tag="8" />
+                        <ComboBoxItem Content="Personnalisé" Tag="custom" />
+                    </ComboBox>
+                </StackPanel>
+                <StackPanel Width="260" Spacing="8">
+                    <TextBlock Text="Date de référence" FontWeight="SemiBold" />
+                    <CalendarDatePicker x:Name="ReferenceDatePicker" DateChanged="ReferenceDatePicker_DateChanged" />
+                </StackPanel>
+                <StackPanel Width="220" Spacing="8">
+                    <TextBlock Text="Mode" FontWeight="SemiBold" />
+                    <ComboBox x:Name="ModeCombo" SelectedIndex="0">
+                        <ComboBoxItem Content="Autour" Tag="Around" />
+                        <ComboBoxItem Content="À partir" Tag="From" />
+                    </ComboBox>
+                </StackPanel>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal" Spacing="12">
+                <ToggleSwitch x:Name="ClimbToggle" Header="Peut monter" IsOn="True"/>
+                <ToggleSwitch x:Name="FoToggle" Header="FO" />
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal" Spacing="12">
+                <Button x:Name="SearchButton" Content="Chercher" Click="Search_Click" />
+                <Button x:Name="SearchOverloadButton" Content="Chercher (overload)" Click="SearchOverload_Click" />
+            </StackPanel>
+
+            <TextBlock x:Name="StatusText" TextWrapping="Wrap" />
+
+            <ListView x:Name="ResultsList" ItemsSource="{x:Bind Results}" SelectionMode="None">
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="models:AppointmentSlotInfo">
+                        <Border CornerRadius="6" Padding="12" Margin="0,6" Background="{ThemeResource NavigationViewColor}">
+                            <StackPanel Spacing="4">
+                                <TextBlock Text="{x:Bind DisplayDate}" FontWeight="SemiBold" />
+                                <TextBlock Text="{x:Bind Summary}" />
+                                <StackPanel Orientation="Horizontal" Spacing="12">
+                                    <TextBlock Text="{x:Bind ExistingAppointments, Mode=OneWay, StringFormat='RDV existants: {0}'}" />
+                                    <TextBlock Text="Overload en cours" Visibility="{x:Bind UsesOverloadCapacity, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    <TextBlock Text="Tolérance rouge" Visibility="{x:Bind RedRelaxationApplied, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/Client/Pages/AppointmentSearchPage.xaml.cs
+++ b/Client/Pages/AppointmentSearchPage.xaml.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Client.Helpers;
+using Client.Models;
+using Client.Services;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Client.Pages
+{
+    public sealed partial class AppointmentSearchPage : Page
+    {
+        private AppointmentSearchConfig? _config;
+        private MachineConfig _machineConfig = MachineConfig.Load();
+        private CancellationTokenSource? _searchToken;
+        private bool _suppressHorizonUpdate;
+
+        public ObservableCollection<AppointmentSlotInfo> Results { get; } = new();
+
+        public AppointmentSearchPage()
+        {
+            InitializeComponent();
+            Loaded += AppointmentSearchPage_Loaded;
+            Unloaded += AppointmentSearchPage_Unloaded;
+        }
+
+        private async void AppointmentSearchPage_Loaded(object sender, RoutedEventArgs e)
+        {
+            await LoadConfigAsync();
+            if (ReferenceDatePicker.Date is null)
+            {
+                ReferenceDatePicker.Date = DateTimeOffset.Now.AddMonths(1);
+            }
+        }
+
+        private void AppointmentSearchPage_Unloaded(object sender, RoutedEventArgs e)
+        {
+            _searchToken?.Cancel();
+            _searchToken?.Dispose();
+            _searchToken = null;
+        }
+
+        private async Task LoadConfigAsync()
+        {
+            try
+            {
+                var cfg = await App.ChatService.GetAppointmentSearchConfigAsync();
+                _config = cfg ?? new AppointmentSearchConfig();
+                if (!_config.IsValid())
+                {
+                    StatusText.Text = "Configuration incomplète. Veuillez vérifier les paramètres système.";
+                }
+                else
+                {
+                    StatusText.Text = string.Empty;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("[AppointmentSearch] LoadConfig", ex, "CLI41");
+                StatusText.Text = "Impossible de charger la configuration (voir les journaux).";
+            }
+        }
+
+        private async Task RunSearchAsync(bool allowOverload)
+        {
+            if (_config == null || !_config.IsValid())
+            {
+                await ShowDialogAsync("Configuration manquante", "Les paramètres de connexion à la base Access ne sont pas définis.");
+                return;
+            }
+
+            if (ReferenceDatePicker.Date is null)
+            {
+                await ShowDialogAsync("Date manquante", "Veuillez sélectionner une date de référence.");
+                return;
+            }
+
+            _machineConfig = MachineConfig.Load();
+
+            _searchToken?.Cancel();
+            _searchToken?.Dispose();
+            _searchToken = new CancellationTokenSource();
+
+            var anchorDate = ReferenceDatePicker.Date.Value.Date;
+            var mode = GetSelectedMode();
+            var canClimb = ClimbToggle.IsOn;
+            var isFo = FoToggle.IsOn;
+            var token = _searchToken.Token;
+
+            ToggleInputs(false);
+            StatusText.Text = "Recherche en cours...";
+            Results.Clear();
+
+            try
+            {
+                var service = new AppointmentSearchService(_config, _machineConfig);
+                var slots = await service.FindAvailableSlotsAsync(anchorDate, mode, canClimb, isFo, allowOverload, token);
+                foreach (var slot in slots)
+                {
+                    Results.Add(slot);
+                }
+
+                StatusText.Text = slots.Any()
+                    ? $"{slots.Count} créneaux disponibles."
+                    : "Aucun créneau ne respecte les contraintes.";
+            }
+            catch (OperationCanceledException)
+            {
+                StatusText.Text = "Recherche annulée.";
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("[AppointmentSearch] RunSearch", ex, "CLI42");
+                StatusText.Text = "Erreur pendant la recherche (voir les journaux).";
+                await ShowDialogAsync("Erreur", ex.Message);
+            }
+            finally
+            {
+                ToggleInputs(true);
+            }
+        }
+
+        private void ToggleInputs(bool isEnabled)
+        {
+            HorizonCombo.IsEnabled = isEnabled;
+            ReferenceDatePicker.IsEnabled = isEnabled;
+            ModeCombo.IsEnabled = isEnabled;
+            ClimbToggle.IsEnabled = isEnabled;
+            FoToggle.IsEnabled = isEnabled;
+            SearchButton.IsEnabled = isEnabled;
+            SearchOverloadButton.IsEnabled = isEnabled;
+        }
+
+        private SearchMode GetSelectedMode()
+        {
+            if (ModeCombo.SelectedItem is ComboBoxItem item && item.Tag is string tag)
+            {
+                if (Enum.TryParse<SearchMode>(tag, out var mode))
+                {
+                    return mode;
+                }
+            }
+            return SearchMode.Around;
+        }
+
+        private void HorizonCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (HorizonCombo.SelectedItem is ComboBoxItem item && item.Tag is string tag)
+            {
+                if (tag.Equals("custom", StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+
+                if (int.TryParse(tag, out var months))
+                {
+                    _suppressHorizonUpdate = true;
+                    ReferenceDatePicker.Date = DateTimeOffset.Now.AddMonths(months);
+                    _suppressHorizonUpdate = false;
+                }
+            }
+        }
+
+        private void ReferenceDatePicker_DateChanged(CalendarDatePicker sender, CalendarDatePickerDateChangedEventArgs args)
+        {
+            if (_suppressHorizonUpdate)
+                return;
+
+            if (args.NewDate != null && HorizonCombo.SelectedItem is ComboBoxItem item && item.Tag is string tag && !tag.Equals("custom", StringComparison.OrdinalIgnoreCase))
+            {
+                HorizonCombo.SelectedIndex = HorizonCombo.Items.Count - 1;
+            }
+        }
+
+        private async Task ShowDialogAsync(string title, string message)
+        {
+            if (Content is not FrameworkElement root)
+                return;
+
+            var dialog = new ContentDialog
+            {
+                Title = title,
+                Content = new TextBlock { Text = message, TextWrapping = TextWrapping.Wrap },
+                CloseButtonText = "Fermer",
+                XamlRoot = root.XamlRoot
+            };
+
+            await dialog.ShowAsync();
+        }
+
+        private async void Search_Click(object sender, RoutedEventArgs e)
+        {
+            await RunSearchAsync(false);
+        }
+
+        private async void SearchOverload_Click(object sender, RoutedEventArgs e)
+        {
+            await RunSearchAsync(true);
+        }
+    }
+}

--- a/Client/Pages/SystemPage.xaml
+++ b/Client/Pages/SystemPage.xaml
@@ -25,6 +25,71 @@
                                             SmallChange="1"
                                             SpinButtonPlacementMode="Compact"/>
                                         <TextBlock Text="Mettre 0 pour désactiver l'alerte." FontStyle="Italic" Opacity="0.7"/>
+                                        <TextBlock Text="Paramètres recherche RDV" FontSize="18" FontWeight="Bold" Margin="0,16,0,0"/>
+                                        <TextBlock Text="Chemin base Access (partagé)" />
+                                        <TextBox Text="{x:Bind AppointmentConfig.DatabasePath, Mode=TwoWay}" />
+                                        <TextBlock Text="Nom de la table" />
+                                        <TextBox Text="{x:Bind AppointmentConfig.TableName, Mode=TwoWay}" />
+                                        <StackPanel Orientation="Horizontal" Spacing="10">
+                                                <StackPanel Width="200">
+                                                        <TextBlock Text="Colonne date" />
+                                                        <TextBox Text="{x:Bind AppointmentConfig.DateColumn, Mode=TwoWay}" />
+                                                </StackPanel>
+                                                <StackPanel Width="200">
+                                                        <TextBlock Text="Colonne heure" />
+                                                        <TextBox Text="{x:Bind AppointmentConfig.TimeColumn, Mode=TwoWay}" />
+                                                </StackPanel>
+                                                <StackPanel Width="200">
+                                                        <TextBlock Text="Colonne couleur" />
+                                                        <TextBox Text="{x:Bind AppointmentConfig.ColorColumn, Mode=TwoWay}" />
+                                                </StackPanel>
+                                        </StackPanel>
+                                        <StackPanel Orientation="Horizontal" Spacing="10">
+                                                <StackPanel Width="200">
+                                                        <TextBlock Text="RDV max/¼ h" />
+                                                        <NumberBox Value="{x:Bind AppointmentConfig.MaxAppointmentsPerSlot, Mode=TwoWay}" Minimum="1" SmallChange="1"/>
+                                                </StackPanel>
+                                                <StackPanel Width="200">
+                                                        <TextBlock Text="Overload supplémentaire" />
+                                                        <NumberBox Value="{x:Bind AppointmentConfig.OverloadExtraAppointments, Mode=TwoWay}" Minimum="1" SmallChange="1"/>
+                                                </StackPanel>
+                                        </StackPanel>
+                                        <TextBlock Text="Horaires de travail" FontWeight="SemiBold"/>
+                                        <StackPanel Orientation="Horizontal" Spacing="10">
+                                                <StackPanel Width="200">
+                                                        <TextBlock Text="Début matin" />
+                                                        <TimePicker Time="{x:Bind AppointmentConfig.MorningStart, Mode=TwoWay}" />
+                                                </StackPanel>
+                                                <StackPanel Width="200">
+                                                        <TextBlock Text="Fin matin" />
+                                                        <TimePicker Time="{x:Bind AppointmentConfig.MorningEnd, Mode=TwoWay}" />
+                                                </StackPanel>
+                                                <StackPanel Width="200">
+                                                        <TextBlock Text="Début après-midi" />
+                                                        <TimePicker Time="{x:Bind AppointmentConfig.AfternoonStart, Mode=TwoWay}" />
+                                                </StackPanel>
+                                                <StackPanel Width="200">
+                                                        <TextBlock Text="Fin après-midi" />
+                                                        <TimePicker Time="{x:Bind AppointmentConfig.AfternoonEnd, Mode=TwoWay}" />
+                                                </StackPanel>
+                                        </StackPanel>
+                                        <TextBlock Text="Limites FO" FontWeight="SemiBold"/>
+                                        <StackPanel Orientation="Horizontal" Spacing="10">
+                                                <StackPanel Width="200">
+                                                        <TextBlock Text="FO matin" />
+                                                        <TimePicker Time="{x:Bind AppointmentConfig.FoMorningLimit, Mode=TwoWay}" />
+                                                </StackPanel>
+                                                <StackPanel Width="200">
+                                                        <TextBlock Text="FO après-midi" />
+                                                        <TimePicker Time="{x:Bind AppointmentConfig.FoAfternoonLimit, Mode=TwoWay}" />
+                                                </StackPanel>
+                                        </StackPanel>
+                                        <TextBlock Text="Chemin system.mdw (local)" />
+                                        <TextBox Text="{x:Bind AccessWorkgroupPath, Mode=TwoWay}" />
+                                        <TextBlock Text="Utilisateur Access" />
+                                        <TextBox Text="{x:Bind AccessUserName, Mode=TwoWay}" />
+                                        <TextBlock Text="Mot de passe Access" />
+                                        <PasswordBox x:Name="AccessPasswordBox" PasswordChanged="AccessPasswordBox_PasswordChanged" />
                                         <TextBlock Text="Utilisateur par défaut"/>
                                         <ComboBox
                                             x:Name="UsersComboBox"

--- a/Client/Pages/SystemPage.xaml.cs
+++ b/Client/Pages/SystemPage.xaml.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Client.Dialogs;
 using Client.Helpers;
+using Client.Models;
 
 namespace Client.Pages
 {
@@ -29,6 +30,10 @@ namespace Client.Pages
         public string DefaultUser { get; set; } = string.Empty;
         public bool ConnectLastUser { get; set; }
         public double PickupAlertThresholdMinutes { get; set; }
+        public AppointmentSearchConfig AppointmentConfig { get; private set; } = new();
+        public string AccessWorkgroupPath { get; set; } = string.Empty;
+        public string AccessUserName { get; set; } = string.Empty;
+        public string AccessPassword { get; set; } = string.Empty;
 
         public SystemPage()
         {
@@ -42,19 +47,40 @@ namespace Client.Pages
             ConnectLastUser = _config.ConnectLastUser;
             ShowSlashCommands = _config.ShowSlashCommands;
             PickupAlertThresholdMinutes = _config.PickupAlertThresholdMinutes;
+            AccessWorkgroupPath = _config.AccessWorkgroupPath;
+            AccessUserName = _config.AccessUserName;
+            AccessPassword = _config.AccessPassword;
+            AppointmentConfig = new AppointmentSearchConfig();
 
             var initialUsers = LoadUsernamesFromSettingsFiles();
             UpdateUsersCollection(initialUsers);
 
             DataContext = this;
             PickupAlertBox.Value = PickupAlertThresholdMinutes;
+            AccessPasswordBox.Password = AccessPassword;
             Loaded += SystemPage_Loaded;
         }
 
         private async void SystemPage_Loaded(object sender, RoutedEventArgs e)
         {
             _isLoaded = true;
+            AccessPasswordBox.Password = AccessPassword;
+            await LoadAppointmentConfigAsync();
             await RefreshLocalUserListAsync();
+        }
+
+        private async Task LoadAppointmentConfigAsync()
+        {
+            try
+            {
+                var cfg = await App.ChatService.GetAppointmentSearchConfigAsync();
+                AppointmentConfig = cfg ?? new AppointmentSearchConfig();
+                this.Bindings.Update();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("[SystemPage] Failed to load appointment config", ex, "CLI43");
+            }
         }
 
         private void Back_Click(object sender, RoutedEventArgs e)
@@ -72,12 +98,36 @@ namespace Client.Pages
             _config.DefaultUser = DefaultUser;
             _config.ConnectLastUser = ConnectLastUser;
             _config.PickupAlertThresholdMinutes = (int)Math.Max(0, Math.Round(PickupAlertThresholdMinutes));
+            _config.AccessWorkgroupPath = AccessWorkgroupPath?.Trim() ?? string.Empty;
+            _config.AccessUserName = AccessUserName?.Trim() ?? string.Empty;
+            _config.AccessPassword = AccessPassword ?? string.Empty;
             PickupAlertThresholdMinutes = _config.PickupAlertThresholdMinutes;
             PickupAlertBox.Value = PickupAlertThresholdMinutes;
             MachineConfig.Save(_config);
             App.ChatService.RoomName = RoomName;
             await App.ChatService.UpdateRoomNameAsync(RoomName);
             App.ChatService.PickupAlertThresholdMinutes = _config.PickupAlertThresholdMinutes;
+            AccessPasswordBox.Password = AccessPassword;
+
+            try
+            {
+                await App.ChatService.SaveAppointmentSearchConfigAsync(AppointmentConfig);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("[SystemPage] Failed to save appointment config", ex, "CLI44");
+            }
+        }
+
+        private void AccessPasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
+        {
+            if (!_isLoaded)
+                return;
+
+            if (sender is PasswordBox box)
+            {
+                AccessPassword = box.Password;
+            }
         }
 
         private async void RenameRoom_Click(object sender, RoutedEventArgs e)

--- a/Client/Services/AppointmentSearchService.cs
+++ b/Client/Services/AppointmentSearchService.cs
@@ -1,0 +1,344 @@
+using System;
+using System.Collections.Generic;
+using System.Data.OleDb;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Client.Helpers;
+using Client.Models;
+
+namespace Client.Services
+{
+    public class AppointmentSearchService
+    {
+        private readonly AppointmentSearchConfig _config;
+        private readonly MachineConfig _machineConfig;
+
+        public AppointmentSearchService(AppointmentSearchConfig config, MachineConfig machineConfig)
+        {
+            _config = config;
+            _machineConfig = machineConfig;
+        }
+
+        public async Task<IReadOnlyList<AppointmentSlotInfo>> FindAvailableSlotsAsync(
+            DateTime anchorDate,
+            SearchMode mode,
+            bool canClimb,
+            bool isFo,
+            bool allowOverload,
+            CancellationToken cancellationToken)
+        {
+            if (!_config.IsValid())
+            {
+                throw new InvalidOperationException("La configuration de recherche des rendez-vous est incomplète.");
+            }
+
+            var (startDate, endDate) = GetSearchRange(anchorDate, mode);
+            var existingAppointments = await LoadExistingAppointmentsAsync(startDate, endDate, cancellationToken).ConfigureAwait(false);
+            var groupedAppointments = GroupAppointments(existingAppointments);
+
+            var slots = new List<AppointmentSlotInfo>();
+            var baseLimit = Math.Max(1, _config.MaxAppointmentsPerSlot);
+            var overloadLimit = allowOverload
+                ? baseLimit + Math.Max(1, _config.OverloadExtraAppointments)
+                : baseLimit;
+
+            var slotLength = TimeSpan.FromMinutes(Math.Max(1, _config.SlotLengthMinutes));
+            for (var date = startDate.Date; date <= endDate.Date; date = date.AddDays(1))
+            {
+                foreach (var slotTime in EnumerateDailySlots(slotLength))
+                {
+                    var slotDateTime = date + slotTime;
+                    if (slotDateTime < startDate || slotDateTime > endDate)
+                        continue;
+
+                    if (!IsWithinWorkingHours(slotTime, isFo))
+                        continue;
+
+                    if (cancellationToken.IsCancellationRequested)
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                    groupedAppointments.TryGetValue(slotDateTime, out var colorsForSlot);
+                    var colorList = colorsForSlot ?? Array.Empty<int>();
+                    var currentCount = colorList.Count;
+
+                    if (!IsSlotAllowed(colorList, currentCount, baseLimit, overloadLimit, canClimb))
+                        continue;
+
+                    var redRelaxation = currentCount >= baseLimit && colorList.Contains(255);
+                    var overloadUsed = allowOverload && currentCount >= baseLimit;
+
+                    slots.Add(new AppointmentSlotInfo
+                    {
+                        SlotStart = slotDateTime,
+                        ExistingAppointments = currentCount,
+                        ColorCounts = colorList
+                            .GroupBy(c => c)
+                            .ToDictionary(g => g.Key, g => g.Count()),
+                        UsesOverloadCapacity = overloadUsed,
+                        RedRelaxationApplied = redRelaxation
+                    });
+                }
+            }
+
+            return slots
+                .OrderBy(s => s.SlotStart)
+                .ToList();
+        }
+
+        private (DateTime start, DateTime end) GetSearchRange(DateTime anchor, SearchMode mode)
+        {
+            var start = anchor;
+            var end = anchor;
+            if (mode == SearchMode.Around)
+            {
+                start = anchor.Date.AddDays(-7);
+                end = anchor.Date.AddDays(14).AddHours(23).AddMinutes(59);
+            }
+            else
+            {
+                start = anchor.Date;
+                end = anchor.Date.AddDays(21).AddHours(23).AddMinutes(59);
+            }
+
+            return (start, end);
+        }
+
+        private async Task<List<AppointmentEntry>> LoadExistingAppointmentsAsync(
+            DateTime start,
+            DateTime end,
+            CancellationToken cancellationToken)
+        {
+            var entries = new List<AppointmentEntry>();
+            var connectionString = BuildConnectionString();
+            await using var connection = new OleDbConnection(connectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = $"SELECT [{_config.DateColumn}], [{_config.TimeColumn}], [{_config.ColorColumn}] FROM [{_config.TableName}] WHERE [{_config.DateColumn}] BETWEEN ? AND ?";
+            command.Parameters.Add(new OleDbParameter("@start", OleDbType.Date) { Value = start.Date });
+            command.Parameters.Add(new OleDbParameter("@end", OleDbType.Date) { Value = end.Date });
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var dateValue = reader.GetValue(0);
+                var timeValue = reader.GetValue(1);
+                var colorValue = reader.GetValue(2);
+
+                if (!TryGetDate(dateValue, out var date))
+                    continue;
+                if (!TryGetTime(timeValue, out var time))
+                    continue;
+
+                var slotDateTime = date.Date + time;
+                slotDateTime = NormalizeToSlot(slotDateTime);
+                var colorCode = ConvertToColor(colorValue);
+                entries.Add(new AppointmentEntry(slotDateTime, colorCode));
+            }
+
+            return entries;
+        }
+
+        private string BuildConnectionString()
+        {
+            var builder = new OleDbConnectionStringBuilder
+            {
+                Provider = "Microsoft.ACE.OLEDB.12.0",
+                ["Data Source"] = _config.DatabasePath,
+                ["Persist Security Info"] = true
+            };
+
+            if (!string.IsNullOrWhiteSpace(_machineConfig.AccessWorkgroupPath))
+            {
+                builder["Jet OLEDB:System Database"] = _machineConfig.AccessWorkgroupPath;
+            }
+
+            if (!string.IsNullOrWhiteSpace(_machineConfig.AccessUserName))
+            {
+                builder["User ID"] = _machineConfig.AccessUserName;
+            }
+
+            if (!string.IsNullOrWhiteSpace(_machineConfig.AccessPassword))
+            {
+                builder["Password"] = _machineConfig.AccessPassword;
+            }
+
+            return builder.ConnectionString;
+        }
+
+        private Dictionary<DateTime, List<int>> GroupAppointments(IEnumerable<AppointmentEntry> entries)
+        {
+            var dict = new Dictionary<DateTime, List<int>>();
+            foreach (var entry in entries)
+            {
+                if (!dict.TryGetValue(entry.SlotStart, out var list))
+                {
+                    list = new List<int>();
+                    dict[entry.SlotStart] = list;
+                }
+                list.Add(entry.ColorCode);
+            }
+            return dict;
+        }
+
+        private IEnumerable<TimeSpan> EnumerateDailySlots(TimeSpan slotLength)
+        {
+            foreach (var slot in EnumerateRange(_config.MorningStart, _config.MorningEnd, slotLength))
+                yield return slot;
+            foreach (var slot in EnumerateRange(_config.AfternoonStart, _config.AfternoonEnd, slotLength))
+                yield return slot;
+        }
+
+        private static IEnumerable<TimeSpan> EnumerateRange(TimeSpan start, TimeSpan end, TimeSpan step)
+        {
+            if (step <= TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(step));
+
+            for (var current = start; current < end; current += step)
+                yield return current;
+        }
+
+        private bool IsWithinWorkingHours(TimeSpan time, bool isFo)
+        {
+            var inMorning = time >= _config.MorningStart && time < _config.MorningEnd;
+            var inAfternoon = time >= _config.AfternoonStart && time < _config.AfternoonEnd;
+            if (!inMorning && !inAfternoon)
+                return false;
+
+            if (isFo)
+            {
+                if (inMorning && time > _config.FoMorningLimit)
+                    return false;
+                if (inAfternoon && time > _config.FoAfternoonLimit)
+                    return false;
+            }
+
+            return true;
+        }
+
+        private bool IsSlotAllowed(IReadOnlyCollection<int> colors, int currentCount, int baseLimit, int overloadLimit, bool canClimb)
+        {
+            if (!canClimb)
+            {
+                var pinkCount = colors.Count(c => c == 16711935);
+                if (pinkCount >= 1)
+                    return false;
+            }
+
+            var overloadAllowed = overloadLimit > baseLimit;
+            if (currentCount < baseLimit)
+                return true;
+
+            var hasRed = colors.Contains(255);
+
+            if (currentCount == baseLimit)
+            {
+                if (hasRed)
+                    return true;
+                if (overloadAllowed)
+                    return true;
+                return false;
+            }
+
+            if (!overloadAllowed)
+                return false;
+
+            if (currentCount < overloadLimit)
+                return true;
+
+            if (currentCount == overloadLimit && hasRed)
+                return true;
+
+            return false;
+        }
+
+        private DateTime NormalizeToSlot(DateTime value)
+        {
+            var slotMinutes = Math.Max(1, _config.SlotLengthMinutes);
+            var minutes = value.Minute - (value.Minute % slotMinutes);
+            return new DateTime(value.Year, value.Month, value.Day, value.Hour, minutes, 0);
+        }
+
+        private static bool TryGetDate(object? value, out DateTime date)
+        {
+            if (value is DateTime dt)
+            {
+                date = dt;
+                return true;
+            }
+
+            if (value is string s && DateTime.TryParse(s, CultureInfo.CurrentCulture, DateTimeStyles.AssumeLocal, out dt))
+            {
+                date = dt;
+                return true;
+            }
+
+            date = default;
+            return false;
+        }
+
+        private static bool TryGetTime(object? value, out TimeSpan time)
+        {
+            if (value is TimeSpan ts)
+            {
+                time = ts;
+                return true;
+            }
+
+            if (value is DateTime dt)
+            {
+                time = dt.TimeOfDay;
+                return true;
+            }
+
+            if (value is string s && TimeSpan.TryParse(s, CultureInfo.CurrentCulture, out ts))
+            {
+                time = ts;
+                return true;
+            }
+
+            time = default;
+            return false;
+        }
+
+        private static int ConvertToColor(object? value)
+        {
+            try
+            {
+                if (value == null || value == DBNull.Value)
+                    return 0;
+
+                if (value is int i)
+                    return i;
+
+                if (value is short s)
+                    return s;
+
+                if (value is long l)
+                    return (int)l;
+
+                if (value is byte b)
+                    return b;
+
+                if (value is string str && int.TryParse(str, NumberStyles.Integer, CultureInfo.InvariantCulture, out i))
+                    return i;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("[AppointmentSearch] ConvertToColor failed", ex, "CLI40");
+            }
+
+            return 0;
+        }
+
+        private readonly record struct AppointmentEntry(DateTime SlotStart, int ColorCode);
+    }
+
+    public enum SearchMode
+    {
+        Around,
+        From
+    }
+}

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -30,6 +30,7 @@ namespace Client.Services
         private DispatcherQueue? _dispatcher;
         private DispatcherQueueTimer? _holdTimeUpdateTimer;
         private int _pickupAlertThresholdMinutes;
+        public AppointmentSearchConfig? AppointmentConfig { get; private set; }
 
         public DispatcherQueue? Dispatcher
         {
@@ -1316,6 +1317,51 @@ namespace Client.Services
             {
                 Debug.WriteLine($"Erreur récupération rappel : {ex.Message}");
                 return null;
+            }
+        }
+
+        public async Task SaveAppointmentSearchConfigAsync(AppointmentSearchConfig config)
+        {
+            AppointmentConfig = config;
+
+            if (!TryGetActiveConnection(out var connection))
+            {
+                var connected = await TryReconnectAsync();
+                if (!connected || !TryGetActiveConnection(out connection))
+                {
+                    Debug.WriteLine("Impossible d'envoyer la configuration RDV : connexion SignalR non établie.");
+                    return;
+                }
+            }
+
+            try
+            {
+                await connection.InvokeAsync("SaveAppointmentSearchConfig", config);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur envoi configuration RDV : {ex.Message}");
+            }
+        }
+
+        public async Task<AppointmentSearchConfig?> GetAppointmentSearchConfigAsync()
+        {
+            if (!TryGetActiveConnection(out var connection))
+            {
+                var connected = await TryReconnectAsync();
+                if (!connected || !TryGetActiveConnection(out connection))
+                    return AppointmentConfig;
+            }
+
+            try
+            {
+                AppointmentConfig = await connection.InvokeAsync<AppointmentSearchConfig>("GetAppointmentSearchConfig");
+                return AppointmentConfig;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Erreur récupération configuration RDV : {ex.Message}");
+                return AppointmentConfig;
             }
         }
         public async Task<List<ExamOption>> GetExamOptionsAsync()

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -1004,6 +1004,35 @@ namespace ChatServeur
             }
         }
 
+        public async Task SaveAppointmentSearchConfig(AppointmentSearchConfig config)
+        {
+            var json = JsonSerializer.Serialize(config);
+            var cfg = await _db.ServerConfigs.SingleOrDefaultAsync();
+            if (cfg == null)
+            {
+                cfg = new ServerConfig();
+                _db.ServerConfigs.Add(cfg);
+            }
+            cfg.AppointmentSearchJson = json;
+            await _db.SaveChangesAsync();
+        }
+
+        public async Task<AppointmentSearchConfig> GetAppointmentSearchConfig()
+        {
+            var cfg = await _db.ServerConfigs.SingleOrDefaultAsync();
+            if (cfg == null || string.IsNullOrEmpty(cfg.AppointmentSearchJson))
+                return new AppointmentSearchConfig();
+            try
+            {
+                return JsonSerializer.Deserialize<AppointmentSearchConfig>(cfg.AppointmentSearchJson) ?? new AppointmentSearchConfig();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "SER16: Failed to deserialize appointment search configuration.");
+                return new AppointmentSearchConfig();
+            }
+        }
+
         public async Task DeclarePatient(Patient patient)
         {
             patient.IsArchived = false;

--- a/Serveur/Models/AppointmentSearchConfig.cs
+++ b/Serveur/Models/AppointmentSearchConfig.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace ChatServeur
+{
+    public class AppointmentSearchConfig
+    {
+        public string DatabasePath { get; set; } = string.Empty;
+        public string TableName { get; set; } = "Ag_rdv";
+        public string DateColumn { get; set; } = "DateRdv";
+        public string TimeColumn { get; set; } = "Heure";
+        public string ColorColumn { get; set; } = "Marque";
+        public int SlotLengthMinutes { get; set; } = 15;
+        public int MaxAppointmentsPerSlot { get; set; } = 3;
+        public int OverloadExtraAppointments { get; set; } = 1;
+        public TimeSpan MorningStart { get; set; } = TimeSpan.FromHours(8);
+        public TimeSpan MorningEnd { get; set; } = TimeSpan.FromHours(11.5);
+        public TimeSpan AfternoonStart { get; set; } = TimeSpan.FromHours(13);
+        public TimeSpan AfternoonEnd { get; set; } = TimeSpan.FromHours(18);
+        public TimeSpan FoMorningLimit { get; set; } = TimeSpan.FromHours(10);
+        public TimeSpan FoAfternoonLimit { get; set; } = TimeSpan.FromHours(16.5);
+    }
+}

--- a/Serveur/Models/ServerConfig.cs
+++ b/Serveur/Models/ServerConfig.cs
@@ -6,5 +6,6 @@ namespace ChatServeur
         public string ExamOptionsJson { get; set; } = string.Empty;
         public string RoomsJson { get; set; } = string.Empty;
         public string ReminderJson { get; set; } = string.Empty;
+        public string AppointmentSearchJson { get; set; } = string.Empty;
     }
 }

--- a/Serveur/Program.cs
+++ b/Serveur/Program.cs
@@ -68,6 +68,7 @@ using (var scope = app.Services.CreateScope())
     EnsurePatientLogsTable(db, logger);
     EnsureUserSettingsTable(db, logger);
     EnsureReminderColumn(db, logger);
+    EnsureAppointmentSearchColumn(db, logger);
     EnsureKnownUsersTable(db, logger);
     CleanupKnownUsers(db, logger);
     if (!db.ServerConfigs.Any())
@@ -271,6 +272,42 @@ void EnsureReminderColumn(ChatDbContext db, ILogger logger)
     catch (Exception ex)
     {
         logger.LogError(ex, "SER07: Failed to ensure ServerConfigs table contains ReminderJson column.");
+        throw;
+    }
+    finally
+    {
+        connection.Close();
+    }
+}
+
+void EnsureAppointmentSearchColumn(ChatDbContext db, ILogger logger)
+{
+    var connection = db.Database.GetDbConnection();
+    connection.Open();
+    try
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "PRAGMA table_info('ServerConfigs')";
+        using var reader = cmd.ExecuteReader();
+        bool exists = false;
+        while (reader.Read())
+        {
+            if (string.Equals(reader.GetString(1), "AppointmentSearchJson", StringComparison.OrdinalIgnoreCase))
+            {
+                exists = true;
+                break;
+            }
+        }
+        reader.Close();
+        if (!exists)
+        {
+            cmd.CommandText = "ALTER TABLE ServerConfigs ADD COLUMN AppointmentSearchJson TEXT NOT NULL DEFAULT ''";
+            cmd.ExecuteNonQuery();
+        }
+    }
+    catch (Exception ex)
+    {
+        logger.LogError(ex, "SER15: Failed to ensure ServerConfigs table contains AppointmentSearchJson column.");
         throw;
     }
     finally


### PR DESCRIPTION
## Summary
- add a dedicated appointment search page with filters, quarter-hour constraints, and visual cues for overload and red-slot tolerance
- allow configuring Access connection settings and scheduling limits from the system page, persisting local workgroup credentials and synchronizing shared rules via the server
- extend the server hub, configuration storage, and client SignalR service to store and distribute the appointment search configuration

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f0ccb08d508324b49057edabce8b87