### PR TITLE
Fix appointment search page bindings

### DIFF
--- a/Client/Helpers/BooleanToVisibilityConverter.cs
+++ b/Client/Helpers/BooleanToVisibilityConverter.cs
@@ -1,0 +1,34 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+
+namespace Client.Helpers
+{
+    public sealed class BooleanToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            if (value is bool boolean)
+            {
+                return boolean ? Visibility.Visible : Visibility.Collapsed;
+            }
+
+            if (value is bool?)
+            {
+                var nullable = (bool?)value;
+                return nullable == true ? Visibility.Visible : Visibility.Collapsed;
+            }
+
+            return Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            if (value is Visibility visibility)
+            {
+                return visibility == Visibility.Visible;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Client/Pages/AppointmentSearchPage.xaml
+++ b/Client/Pages/AppointmentSearchPage.xaml
@@ -3,9 +3,10 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:models="using:Client.Models"
+    xmlns:helpers="using:Client.Helpers"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
     <Page.Resources>
-        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <helpers:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     </Page.Resources>
     <ScrollViewer>
         <StackPanel Padding="20" Spacing="16">
@@ -55,7 +56,10 @@
                                 <TextBlock Text="{x:Bind DisplayDate}" FontWeight="SemiBold" />
                                 <TextBlock Text="{x:Bind Summary}" />
                                 <StackPanel Orientation="Horizontal" Spacing="12">
-                                    <TextBlock Text="{x:Bind ExistingAppointments, Mode=OneWay, StringFormat='RDV existants: {0}'}" />
+                                    <TextBlock>
+                                        <Run Text="RDV existants : " />
+                                        <Run Text="{x:Bind ExistingAppointments, Mode=OneWay}" />
+                                    </TextBlock>
                                     <TextBlock Text="Overload en cours" Visibility="{x:Bind UsesOverloadCapacity, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                     <TextBlock Text="Tolérance rouge" Visibility="{x:Bind RedRelaxationApplied, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                 </StackPanel>

--- a/Client/Services/AppointmentSearchService.cs
+++ b/Client/Services/AppointmentSearchService.cs
@@ -60,7 +60,7 @@ namespace Client.Services
                         cancellationToken.ThrowIfCancellationRequested();
 
                     groupedAppointments.TryGetValue(slotDateTime, out var colorsForSlot);
-                    var colorList = colorsForSlot ?? Array.Empty<int>();
+                    var colorList = colorsForSlot ?? new List<int>();
                     var currentCount = colorList.Count;
 
                     if (!IsSlotAllowed(colorList, currentCount, baseLimit, overloadLimit, canClimb))


### PR DESCRIPTION
## Summary
- add a reusable BooleanToVisibilityConverter for WinUI bindings
- update appointment search XAML to use the converter and inline formatting compatible with x:Bind
- fix appointment search service slot lookup to avoid null-coalescing type mismatches

## Testing
- dotnet build WebApplication1.sln *(fails: dotnet CLI is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f0d51c9b988324923ade400e7d4d29