### PR TITLE
Allow configuring Access OLE DB provider

### DIFF
--- a/Client/Helpers/MachineConfig.cs
+++ b/Client/Helpers/MachineConfig.cs
@@ -31,6 +31,11 @@ namespace Client.Helpers
         public int PickupAlertThresholdMinutes { get; set; }
 
         /// <summary>
+        /// OLE DB provider to use when connecting to the Access database.
+        /// </summary>
+        public string AccessOleDbProvider { get; set; } = "Microsoft.ACE.OLEDB.12.0";
+
+        /// <summary>
         /// Local path to the Access system database (system.mdw).
         /// </summary>
         public string AccessWorkgroupPath { get; set; } = string.Empty;

--- a/Client/Pages/SystemPage.xaml
+++ b/Client/Pages/SystemPage.xaml
@@ -84,6 +84,8 @@
                                                         <TimePicker Time="{x:Bind AppointmentConfig.FoAfternoonLimit, Mode=TwoWay}" />
                                                 </StackPanel>
                                         </StackPanel>
+                                        <TextBlock Text="Fournisseur OLE DB" />
+                                        <TextBox Text="{x:Bind AccessOleDbProvider, Mode=TwoWay}" />
                                         <TextBlock Text="Chemin system.mdw (local)" />
                                         <TextBox Text="{x:Bind AccessWorkgroupPath, Mode=TwoWay}" />
                                         <TextBlock Text="Utilisateur Access" />

--- a/Client/Pages/SystemPage.xaml.cs
+++ b/Client/Pages/SystemPage.xaml.cs
@@ -31,6 +31,7 @@ namespace Client.Pages
         public bool ConnectLastUser { get; set; }
         public double PickupAlertThresholdMinutes { get; set; }
         public AppointmentSearchConfig AppointmentConfig { get; private set; } = new();
+        public string AccessOleDbProvider { get; set; } = string.Empty;
         public string AccessWorkgroupPath { get; set; } = string.Empty;
         public string AccessUserName { get; set; } = string.Empty;
         public string AccessPassword { get; set; } = string.Empty;
@@ -47,6 +48,7 @@ namespace Client.Pages
             ConnectLastUser = _config.ConnectLastUser;
             ShowSlashCommands = _config.ShowSlashCommands;
             PickupAlertThresholdMinutes = _config.PickupAlertThresholdMinutes;
+            AccessOleDbProvider = _config.AccessOleDbProvider;
             AccessWorkgroupPath = _config.AccessWorkgroupPath;
             AccessUserName = _config.AccessUserName;
             AccessPassword = _config.AccessPassword;
@@ -98,6 +100,7 @@ namespace Client.Pages
             _config.DefaultUser = DefaultUser;
             _config.ConnectLastUser = ConnectLastUser;
             _config.PickupAlertThresholdMinutes = (int)Math.Max(0, Math.Round(PickupAlertThresholdMinutes));
+            _config.AccessOleDbProvider = AccessOleDbProvider?.Trim() ?? string.Empty;
             _config.AccessWorkgroupPath = AccessWorkgroupPath?.Trim() ?? string.Empty;
             _config.AccessUserName = AccessUserName?.Trim() ?? string.Empty;
             _config.AccessPassword = AccessPassword ?? string.Empty;

--- a/Client/Services/AppointmentSearchService.cs
+++ b/Client/Services/AppointmentSearchService.cs
@@ -143,9 +143,13 @@ namespace Client.Services
 
         private string BuildConnectionString()
         {
+            var provider = string.IsNullOrWhiteSpace(_machineConfig.AccessOleDbProvider)
+                ? "Microsoft.ACE.OLEDB.12.0"
+                : _machineConfig.AccessOleDbProvider;
+
             var builder = new OleDbConnectionStringBuilder
             {
-                Provider = "Microsoft.ACE.OLEDB.12.0",
+                Provider = provider,
                 ["Data Source"] = _config.DatabasePath,
                 ["Persist Security Info"] = true
             };


### PR DESCRIPTION
## Summary
- add an Access OLE DB provider setting to the machine configuration and system page UI
- honor the configured provider when building the Access connection string for appointment searches

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f0f7bf941083248840c2b4f18e6226