### PR TITLE
Default client to x86 runtime and improve Access provider fallback

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -7,6 +7,8 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <PlatformTarget Condition="'$(PlatformTarget)' == ''">x86</PlatformTarget>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-x86</RuntimeIdentifier>
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>

--- a/Client/Services/AppointmentSearchService.cs
+++ b/Client/Services/AppointmentSearchService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.OleDb;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -173,6 +174,11 @@ namespace Client.Services
                 message += $" Fournisseurs testés : {string.Join(", ", triedProviders)}.";
             }
 
+            if (Environment.Is64BitProcess && IsMdbDatabase())
+            {
+                message += " La base de données cible est un fichier .mdb. Le fournisseur Microsoft Jet intégré à Windows n'est disponible que pour les applications 32 bits : lancez la version x86 du client pour éviter d'installer un fournisseur supplémentaire.";
+            }
+
             throw new InvalidOperationException(message, lastProviderError);
         }
 
@@ -187,16 +193,34 @@ namespace Client.Services
                     yield return configured;
             }
 
-            foreach (var fallback in new[]
-                     {
-                         "Microsoft.ACE.OLEDB.16.0",
-                         "Microsoft.ACE.OLEDB.12.0",
-                         "Microsoft.Jet.OLEDB.4.0"
-                     })
+            foreach (var fallback in EnumerateFallbackProviders())
             {
                 if (yielded.Add(fallback))
                     yield return fallback;
             }
+        }
+
+        private IEnumerable<string> EnumerateFallbackProviders()
+        {
+            if (IsMdbDatabase())
+            {
+                yield return "Microsoft.Jet.OLEDB.4.0";
+            }
+
+            yield return "Microsoft.ACE.OLEDB.16.0";
+            yield return "Microsoft.ACE.OLEDB.12.0";
+
+            if (!IsMdbDatabase())
+            {
+                yield return "Microsoft.Jet.OLEDB.4.0";
+            }
+        }
+
+        private bool IsMdbDatabase()
+        {
+            var extension = Path.GetExtension(_config.DatabasePath);
+            return !string.IsNullOrWhiteSpace(extension)
+                   && extension.Equals(".mdb", StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool IsProviderNotRegistered(Exception exception)


### PR DESCRIPTION
## Summary
- default the WinUI client build to the x86 runtime identifier when no explicit platform is supplied
- refine Access provider selection by prioritising Jet for .mdb databases and add guidance when running in 64-bit

## Testing
- `dotnet build Client/Client.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f0fbecc224832497ff8a74b88a8321