### PR TITLE
Allow configuring release of ~$0$ days

### DIFF
--- a/Client/Models/AppointmentSearchConfig.cs
+++ b/Client/Models/AppointmentSearchConfig.cs
@@ -18,6 +18,7 @@ namespace Client.Models
         public TimeSpan AfternoonEnd { get; set; } = TimeSpan.FromHours(18);
         public TimeSpan FoMorningLimit { get; set; } = TimeSpan.FromHours(10);
         public TimeSpan FoAfternoonLimit { get; set; } = TimeSpan.FromHours(16.5);
+        public int ExcludedDayReleaseMonths { get; set; } = 3;
 
         public bool IsValid()
         {

--- a/Client/Pages/SystemPage.xaml
+++ b/Client/Pages/SystemPage.xaml
@@ -53,7 +53,12 @@
                                                         <TextBlock Text="Overload supplémentaire" />
                                                         <NumberBox Value="{x:Bind AppointmentConfig.OverloadExtraAppointments, Mode=TwoWay}" Minimum="1" SmallChange="1"/>
                                                 </StackPanel>
+                                                <StackPanel Width="200">
+                                                        <TextBlock Text="Ouverture jours ~$0$ (mois)" />
+                                                        <NumberBox Value="{x:Bind AppointmentConfig.ExcludedDayReleaseMonths, Mode=TwoWay}" Minimum="0" SmallChange="1"/>
+                                                </StackPanel>
                                         </StackPanel>
+                                        <TextBlock Text="Mettre 0 pour conserver le blocage complet des jours contenant ~$0$." FontStyle="Italic" Opacity="0.7"/>
                                         <TextBlock Text="Horaires de travail" FontWeight="SemiBold"/>
                                         <StackPanel Orientation="Horizontal" Spacing="10">
                                                 <StackPanel Width="200">

--- a/Client/Services/AppointmentSearchService.cs
+++ b/Client/Services/AppointmentSearchService.cs
@@ -37,10 +37,7 @@ namespace Client.Services
 
             var (startDate, endDate) = GetSearchRange(anchorDate, mode);
             var existingAppointments = await LoadExistingAppointmentsAsync(startDate, endDate, cancellationToken).ConfigureAwait(false);
-            var excludedDates = existingAppointments
-                .Where(e => e.IsExcludedDayMarker)
-                .Select(e => e.SlotStart.Date)
-                .ToHashSet();
+            var excludedDates = BuildExcludedDateSet(existingAppointments.Where(e => e.IsExcludedDayMarker));
             var groupedAppointments = GroupAppointments(existingAppointments.Where(e => !e.IsExcludedDayMarker));
 
             var slots = new List<AppointmentSlotInfo>();
@@ -290,6 +287,24 @@ namespace Client.Services
                 list.Add(entry.ColorCode);
             }
             return dict;
+        }
+
+        private HashSet<DateTime> BuildExcludedDateSet(IEnumerable<AppointmentEntry> excludedEntries)
+        {
+            var excludedDates = new HashSet<DateTime>();
+            var releaseMonths = Math.Max(0, _config.ExcludedDayReleaseMonths);
+            var releaseThreshold = releaseMonths > 0 ? DateTime.Today.AddMonths(releaseMonths) : (DateTime?)null;
+
+            foreach (var entry in excludedEntries)
+            {
+                var date = entry.SlotStart.Date;
+                if (releaseThreshold.HasValue && date <= releaseThreshold.Value)
+                    continue;
+
+                excludedDates.Add(date);
+            }
+
+            return excludedDates;
         }
 
         private IEnumerable<TimeSpan> EnumerateDailySlots(TimeSpan slotLength)

--- a/Serveur/Models/AppointmentSearchConfig.cs
+++ b/Serveur/Models/AppointmentSearchConfig.cs
@@ -18,5 +18,6 @@ namespace ChatServeur
         public TimeSpan AfternoonEnd { get; set; } = TimeSpan.FromHours(18);
         public TimeSpan FoMorningLimit { get; set; } = TimeSpan.FromHours(10);
         public TimeSpan FoAfternoonLimit { get; set; } = TimeSpan.FromHours(16.5);
+        public int ExcludedDayReleaseMonths { get; set; } = 3;
     }
 }


### PR DESCRIPTION
## Summary
- add a configurable release window for days flagged with `~$0$`
- expose the new setting in the system page and adjust the appointment search logic to honour it

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f1036836a4832491bdb2b45ee36a41