### PR TITLE
Adjust excluded day detection for partial-day markers

### DIFF
--- a/Client/Services/AppointmentSearchService.cs
+++ b/Client/Services/AppointmentSearchService.cs
@@ -291,9 +291,10 @@ namespace Client.Services
 
         private HashSet<DateTime> BuildExcludedDateSet(IEnumerable<AppointmentEntry> excludedEntries)
         {
-            var excludedDates = new HashSet<DateTime>();
             var releaseMonths = Math.Max(0, _config.ExcludedDayReleaseMonths);
             var releaseThreshold = releaseMonths > 0 ? DateTime.Today.AddMonths(releaseMonths) : (DateTime?)null;
+
+            var dayStates = new Dictionary<DateTime, (bool Morning, bool Afternoon)>();
 
             foreach (var entry in excludedEntries)
             {
@@ -301,7 +302,25 @@ namespace Client.Services
                 if (releaseThreshold.HasValue && date <= releaseThreshold.Value)
                     continue;
 
-                excludedDates.Add(date);
+                if (!dayStates.TryGetValue(date, out var state))
+                {
+                    state = (false, false);
+                }
+
+                var time = entry.SlotStart.TimeOfDay;
+                if (time < _config.AfternoonStart)
+                    state.Morning = true;
+                if (time >= _config.AfternoonStart)
+                    state.Afternoon = true;
+
+                dayStates[date] = state;
+            }
+
+            var excludedDates = new HashSet<DateTime>();
+            foreach (var (date, state) in dayStates)
+            {
+                if (state.Morning && state.Afternoon)
+                    excludedDates.Add(date);
             }
 
             return excludedDates;


### PR DESCRIPTION
## Summary
- update the excluded day calculation so that a day is skipped only when ~$0$ markers cover both morning and afternoon slots

## Testing
- dotnet build *(fails: `dotnet` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f10705249883249704595a2978a9b5