### PR TITLE
Fetch French school holidays dynamically by zone

### DIFF
--- a/Client/Models/AppointmentSearchFilters.cs
+++ b/Client/Models/AppointmentSearchFilters.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Client.Models
+{
+    public class AppointmentSearchFilters
+    {
+        public int PersonCount { get; set; } = 1;
+        public DayOfWeek? PreferredDay { get; set; }
+        public TimeOfDayPreference TimePreference { get; set; } = TimeOfDayPreference.Any;
+        public SchoolHolidayFilter HolidayFilter { get; set; } = SchoolHolidayFilter.Any;
+        public SchoolHolidayZone HolidayZone { get; set; } = SchoolHolidayZone.Any;
+
+        public AppointmentSearchFilters Clone() => new()
+        {
+            PersonCount = PersonCount,
+            PreferredDay = PreferredDay,
+            TimePreference = TimePreference,
+            HolidayFilter = HolidayFilter,
+            HolidayZone = HolidayZone
+        };
+    }
+
+    public enum TimeOfDayPreference
+    {
+        Any,
+        Morning,
+        Afternoon
+    }
+
+    public enum SchoolHolidayFilter
+    {
+        Any,
+        OnlyDuring,
+        Exclude
+    }
+
+    public enum SchoolHolidayZone
+    {
+        Any,
+        ZoneA,
+        ZoneB,
+        ZoneC
+    }
+}

--- a/Client/Models/AppointmentSearchResult.cs
+++ b/Client/Models/AppointmentSearchResult.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Client.Models
+{
+    public class AppointmentSearchResult
+    {
+        public AppointmentSearchResult(
+            int personCount,
+            IReadOnlyList<AppointmentResultSlot> slots,
+            CombinationQuality quality,
+            TimeSpan totalSpan)
+        {
+            PersonCount = personCount;
+            Slots = slots;
+            Quality = quality;
+            TotalSpan = totalSpan;
+        }
+
+        public int PersonCount { get; }
+        public IReadOnlyList<AppointmentResultSlot> Slots { get; }
+        public CombinationQuality Quality { get; }
+        public TimeSpan TotalSpan { get; }
+
+        public DateTime Day => Slots.Count > 0 ? Slots[0].Slot.SlotStart.Date : DateTime.MinValue;
+
+        public bool UsesOverload => Slots.Any(s => s.Slot.UsesOverloadCapacity);
+
+        public bool UsesRedRelaxation => Slots.Any(s => s.Slot.RedRelaxationApplied);
+
+        public string Header
+        {
+            get
+            {
+                var culture = CultureInfo.CurrentCulture;
+                var textInfo = culture.TextInfo;
+                var dayText = Day.ToString("dddd dd/MM/yyyy", culture);
+                var duration = TotalSpan <= TimeSpan.Zero
+                    ? "durée totale <1min"
+                    : $"durée totale {FormatDuration(TotalSpan)}";
+                return $"{textInfo.ToTitleCase(dayText)} - {PersonCount} personne{(PersonCount > 1 ? "s" : string.Empty)} ({duration})";
+            }
+        }
+
+        public string Detail
+        {
+            get
+            {
+                var slotDescriptions = Slots
+                    .Select(slot => slot.ToDescription())
+                    .ToList();
+                return string.Join(" • ", slotDescriptions);
+            }
+        }
+
+        private static string FormatDuration(TimeSpan value)
+        {
+            if (value.TotalMinutes < 1)
+            {
+                return "<1min";
+            }
+
+            var parts = new List<string>();
+            if (value.Hours > 0)
+            {
+                parts.Add(value.Hours == 1 ? "1h" : $"{value.Hours}h");
+            }
+
+            var minutes = value.Minutes + (value.Seconds >= 30 ? 1 : 0);
+            if (minutes > 0)
+            {
+                parts.Add($"{minutes}min");
+            }
+
+            return parts.Count == 0 ? "<1min" : string.Join(" ", parts);
+        }
+    }
+
+    public class AppointmentResultSlot
+    {
+        public AppointmentResultSlot(AppointmentSlotInfo slot, int personCount)
+        {
+            Slot = slot;
+            PersonCount = personCount;
+        }
+
+        public AppointmentSlotInfo Slot { get; }
+        public int PersonCount { get; }
+
+        public string TimeLabel => Slot.TimeLabel;
+
+        public string PersonSummary => PersonCount > 1
+            ? $"{PersonCount} personnes"
+            : "1 personne";
+
+        public string ExistingSummary => $"RDV existants : {Slot.ExistingAppointments}";
+
+        public string RemainingCapacity => PersonCount >= Slot.AvailableCapacity
+            ? "Capacité utilisée"
+            : $"Capacité restante : {Slot.AvailableCapacity - PersonCount}";
+
+        public string SlotSummary => Slot.Summary;
+
+        public string ToDescription()
+        {
+            var parts = new List<string>
+            {
+                $"{TimeLabel} ({PersonSummary})"
+            };
+
+            if (Slot.UsesOverloadCapacity)
+            {
+                parts.Add("overload");
+            }
+
+            if (Slot.RedRelaxationApplied)
+            {
+                parts.Add("tolérance rouge");
+            }
+
+            return string.Join(" - ", parts);
+        }
+    }
+
+    public enum CombinationQuality
+    {
+        Strict = 0,
+        Relaxed = 1,
+        Fallback = 2
+    }
+}

--- a/Client/Models/AppointmentSlotInfo.cs
+++ b/Client/Models/AppointmentSlotInfo.cs
@@ -11,6 +11,8 @@ namespace Client.Models
         public IReadOnlyDictionary<int, int> ColorCounts { get; set; } = new Dictionary<int, int>();
         public bool UsesOverloadCapacity { get; set; }
         public bool RedRelaxationApplied { get; set; }
+        public int AvailableCapacity { get; set; }
+        public SlotDayPart DayPart { get; set; }
 
         public string DisplayDate => SlotStart.ToString("dddd dd/MM/yyyy HH:mm");
 
@@ -30,6 +32,12 @@ namespace Client.Models
             }
         }
 
+        public bool IsMorning => DayPart == SlotDayPart.Morning;
+
+        public bool IsAfternoon => DayPart == SlotDayPart.Afternoon;
+
+        public string TimeLabel => SlotStart.ToString("HH:mm");
+
         private static string GetColorName(int value) => value switch
         {
             0 => "Noir",
@@ -39,5 +47,11 @@ namespace Client.Models
             65280 => "Vert",
             _ => $"Couleur {value}"
         };
+    }
+
+    public enum SlotDayPart
+    {
+        Morning,
+        Afternoon
     }
 }

--- a/Client/Pages/AppointmentSearchPage.xaml
+++ b/Client/Pages/AppointmentSearchPage.xaml
@@ -41,27 +41,87 @@
                 <ToggleSwitch x:Name="FoToggle" Header="FO" />
             </StackPanel>
 
+            <StackPanel Orientation="Horizontal" Spacing="12" HorizontalAlignment="Stretch">
+                <StackPanel Width="180" Spacing="8">
+                    <TextBlock Text="Nombre de personnes" FontWeight="SemiBold" />
+                    <ComboBox x:Name="PersonCountCombo" SelectedIndex="0">
+                        <ComboBoxItem Content="1 personne" Tag="1" />
+                        <ComboBoxItem Content="2 personnes" Tag="2" />
+                        <ComboBoxItem Content="3 personnes" Tag="3" />
+                        <ComboBoxItem Content="4 personnes" Tag="4" />
+                    </ComboBox>
+                </StackPanel>
+                <StackPanel Width="180" Spacing="8">
+                    <TextBlock Text="Préférence de jour" FontWeight="SemiBold" />
+                    <ComboBox x:Name="DayPreferenceCombo" SelectedIndex="0">
+                        <ComboBoxItem Content="Peu importe" Tag="Any" />
+                        <ComboBoxItem Content="Lundi" Tag="Monday" />
+                        <ComboBoxItem Content="Mardi" Tag="Tuesday" />
+                        <ComboBoxItem Content="Mercredi" Tag="Wednesday" />
+                        <ComboBoxItem Content="Jeudi" Tag="Thursday" />
+                        <ComboBoxItem Content="Vendredi" Tag="Friday" />
+                    </ComboBox>
+                </StackPanel>
+                <StackPanel Width="180" Spacing="8">
+                    <TextBlock Text="Moment de la journée" FontWeight="SemiBold" />
+                    <ComboBox x:Name="DayPartCombo" SelectedIndex="0">
+                        <ComboBoxItem Content="Peu importe" Tag="Any" />
+                        <ComboBoxItem Content="Matin" Tag="Morning" />
+                        <ComboBoxItem Content="Après-midi" Tag="Afternoon" />
+                    </ComboBox>
+                </StackPanel>
+                <StackPanel Width="220" Spacing="8">
+                    <TextBlock Text="Vacances scolaires" FontWeight="SemiBold" />
+                    <ComboBox x:Name="HolidayCombo" SelectedIndex="0">
+                        <ComboBoxItem Content="Peu importe" Tag="Any" />
+                        <ComboBoxItem Content="Uniquement pendant" Tag="OnlyDuring" />
+                        <ComboBoxItem Content="Exclure" Tag="Exclude" />
+                    </ComboBox>
+                </StackPanel>
+                <StackPanel Width="180" Spacing="8">
+                    <TextBlock Text="Zone académique" FontWeight="SemiBold" />
+                    <ComboBox x:Name="HolidayZoneCombo" SelectedIndex="0">
+                        <ComboBoxItem Content="Toutes zones" Tag="Any" />
+                        <ComboBoxItem Content="Zone A" Tag="ZoneA" />
+                        <ComboBoxItem Content="Zone B" Tag="ZoneB" />
+                        <ComboBoxItem Content="Zone C" Tag="ZoneC" />
+                    </ComboBox>
+                </StackPanel>
+            </StackPanel>
+
             <StackPanel Orientation="Horizontal" Spacing="12">
                 <Button x:Name="SearchButton" Content="Chercher" Click="Search_Click" />
                 <Button x:Name="SearchOverloadButton" Content="Chercher (overload)" Click="SearchOverload_Click" />
+                <Button x:Name="SearchFurtherButton" Content="Chercher plus loin" Click="SearchFurther_Click" />
             </StackPanel>
 
             <TextBlock x:Name="StatusText" TextWrapping="Wrap" />
 
             <ListView x:Name="ResultsList" ItemsSource="{x:Bind Results}" SelectionMode="None">
                 <ListView.ItemTemplate>
-                    <DataTemplate x:DataType="models:AppointmentSlotInfo">
+                    <DataTemplate x:DataType="models:AppointmentSearchResult">
                         <Border CornerRadius="6" Padding="12" Margin="0,6" Background="{ThemeResource NavigationViewColor}">
-                            <StackPanel Spacing="4">
-                                <TextBlock Text="{x:Bind DisplayDate}" FontWeight="SemiBold" />
-                                <TextBlock Text="{x:Bind Summary}" />
+                            <StackPanel Spacing="8">
+                                <TextBlock Text="{x:Bind Header}" FontWeight="SemiBold" />
+                                <TextBlock Text="{x:Bind Detail}" TextWrapping="Wrap" />
+                                <ItemsControl ItemsSource="{x:Bind Slots}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate x:DataType="models:AppointmentResultSlot">
+                                            <StackPanel Margin="0,4,0,0" Spacing="2">
+                                                <TextBlock Text="{x:Bind TimeLabel}" FontWeight="SemiBold" />
+                                                <StackPanel Orientation="Horizontal" Spacing="12">
+                                                    <TextBlock Text="{x:Bind PersonSummary}" />
+                                                    <TextBlock Text="{x:Bind ExistingSummary}" />
+                                                    <TextBlock Text="{x:Bind RemainingCapacity}" />
+                                                </StackPanel>
+                                                <TextBlock Text="{x:Bind SlotSummary}" TextWrapping="Wrap" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
                                 <StackPanel Orientation="Horizontal" Spacing="12">
-                                    <TextBlock>
-                                        <Run Text="RDV existants : " />
-                                        <Run Text="{x:Bind ExistingAppointments, Mode=OneWay}" />
-                                    </TextBlock>
-                                    <TextBlock Text="Overload en cours" Visibility="{x:Bind UsesOverloadCapacity, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                                    <TextBlock Text="Tolérance rouge" Visibility="{x:Bind RedRelaxationApplied, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    <TextBlock Text="Overload en cours" Visibility="{x:Bind UsesOverload, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    <TextBlock Text="Tolérance rouge" Visibility="{x:Bind UsesRedRelaxation, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                 </StackPanel>
                             </StackPanel>
                         </Border>

--- a/Client/Pages/AppointmentSearchPage.xaml.cs
+++ b/Client/Pages/AppointmentSearchPage.xaml.cs
@@ -17,8 +17,10 @@ namespace Client.Pages
         private MachineConfig _machineConfig = MachineConfig.Load();
         private CancellationTokenSource? _searchToken;
         private bool _suppressHorizonUpdate;
+        private readonly ISchoolHolidayService _holidayService = new SchoolHolidayService();
+        private int _searchOffsetMonths;
 
-        public ObservableCollection<AppointmentSlotInfo> Results { get; } = new();
+        public ObservableCollection<AppointmentSearchResult> Results { get; } = new();
 
         public AppointmentSearchPage()
         {
@@ -65,7 +67,7 @@ namespace Client.Pages
             }
         }
 
-        private async Task RunSearchAsync(bool allowOverload)
+        private async Task RunSearchAsync(bool allowOverload, bool resetOffset)
         {
             if (_config == null || !_config.IsValid())
             {
@@ -81,6 +83,11 @@ namespace Client.Pages
 
             _machineConfig = MachineConfig.Load();
 
+            if (resetOffset)
+            {
+                _searchOffsetMonths = 0;
+            }
+
             _searchToken?.Cancel();
             _searchToken?.Dispose();
             _searchToken = new CancellationTokenSource();
@@ -90,6 +97,7 @@ namespace Client.Pages
             var canClimb = ClimbToggle.IsOn;
             var isFo = FoToggle.IsOn;
             var token = _searchToken.Token;
+            var filters = BuildFilters();
 
             ToggleInputs(false);
             StatusText.Text = "Recherche en cours...";
@@ -97,16 +105,26 @@ namespace Client.Pages
 
             try
             {
-                var service = new AppointmentSearchService(_config, _machineConfig);
-                var slots = await service.FindAvailableSlotsAsync(anchorDate, mode, canClimb, isFo, allowOverload, token);
-                foreach (var slot in slots)
+                var service = new AppointmentSearchService(_config, _machineConfig, _holidayService);
+                var slots = await service.FindAvailableSlotsAsync(anchorDate, mode, canClimb, isFo, allowOverload, filters, _searchOffsetMonths, token);
+                var groupedResults = AppointmentGroupBuilder.BuildResults(slots, filters);
+
+                foreach (var result in groupedResults)
                 {
-                    Results.Add(slot);
+                    Results.Add(result);
                 }
 
-                StatusText.Text = slots.Any()
-                    ? $"{slots.Count} créneaux disponibles."
-                    : "Aucun créneau ne respecte les contraintes.";
+                if (groupedResults.Any())
+                {
+                    var offsetText = _searchOffsetMonths > 0
+                        ? $" (recherche décalée de {_searchOffsetMonths} mois)"
+                        : string.Empty;
+                    StatusText.Text = $"{groupedResults.Count} proposition(s) trouvée(s){offsetText}.";
+                }
+                else
+                {
+                    StatusText.Text = "Aucun créneau ne respecte les contraintes.";
+                }
             }
             catch (OperationCanceledException)
             {
@@ -133,6 +151,12 @@ namespace Client.Pages
             FoToggle.IsEnabled = isEnabled;
             SearchButton.IsEnabled = isEnabled;
             SearchOverloadButton.IsEnabled = isEnabled;
+            PersonCountCombo.IsEnabled = isEnabled;
+            DayPreferenceCombo.IsEnabled = isEnabled;
+            DayPartCombo.IsEnabled = isEnabled;
+            HolidayCombo.IsEnabled = isEnabled;
+            HolidayZoneCombo.IsEnabled = isEnabled;
+            SearchFurtherButton.IsEnabled = isEnabled;
         }
 
         private SearchMode GetSelectedMode()
@@ -145,6 +169,82 @@ namespace Client.Pages
                 }
             }
             return SearchMode.Around;
+        }
+
+        private AppointmentSearchFilters BuildFilters()
+        {
+            var filters = new AppointmentSearchFilters
+            {
+                PersonCount = GetSelectedPersonCount(),
+                PreferredDay = GetPreferredDay(),
+                TimePreference = GetTimePreference(),
+                HolidayFilter = GetHolidayFilter(),
+                HolidayZone = GetHolidayZone()
+            };
+            return filters;
+        }
+
+        private int GetSelectedPersonCount()
+        {
+            if (PersonCountCombo.SelectedItem is ComboBoxItem item && item.Tag is string tag && int.TryParse(tag, out var count))
+            {
+                return Math.Clamp(count, 1, 4);
+            }
+
+            return 1;
+        }
+
+        private DayOfWeek? GetPreferredDay()
+        {
+            if (DayPreferenceCombo.SelectedItem is ComboBoxItem item && item.Tag is string tag)
+            {
+                if (string.Equals(tag, "Any", StringComparison.OrdinalIgnoreCase))
+                    return null;
+
+                if (Enum.TryParse<DayOfWeek>(tag, true, out var day))
+                    return day;
+            }
+
+            return null;
+        }
+
+        private TimeOfDayPreference GetTimePreference()
+        {
+            if (DayPartCombo.SelectedItem is ComboBoxItem item && item.Tag is string tag)
+            {
+                if (Enum.TryParse<TimeOfDayPreference>(tag, true, out var preference))
+                {
+                    return preference;
+                }
+            }
+
+            return TimeOfDayPreference.Any;
+        }
+
+        private SchoolHolidayFilter GetHolidayFilter()
+        {
+            if (HolidayCombo.SelectedItem is ComboBoxItem item && item.Tag is string tag)
+            {
+                if (Enum.TryParse<SchoolHolidayFilter>(tag, true, out var filter))
+                {
+                    return filter;
+                }
+            }
+
+            return SchoolHolidayFilter.Any;
+        }
+
+        private SchoolHolidayZone GetHolidayZone()
+        {
+            if (HolidayZoneCombo.SelectedItem is ComboBoxItem item && item.Tag is string tag)
+            {
+                if (Enum.TryParse<SchoolHolidayZone>(tag, true, out var zone))
+                {
+                    return zone;
+                }
+            }
+
+            return SchoolHolidayZone.Any;
         }
 
         private void HorizonCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -199,12 +299,18 @@ namespace Client.Pages
 
         private async void Search_Click(object sender, RoutedEventArgs e)
         {
-            await RunSearchAsync(false);
+            await RunSearchAsync(false, true);
         }
 
         private async void SearchOverload_Click(object sender, RoutedEventArgs e)
         {
-            await RunSearchAsync(true);
+            await RunSearchAsync(true, true);
+        }
+
+        private async void SearchFurther_Click(object sender, RoutedEventArgs e)
+        {
+            _searchOffsetMonths++;
+            await RunSearchAsync(false, false);
         }
     }
 }

--- a/Client/Services/AppointmentGroupBuilder.cs
+++ b/Client/Services/AppointmentGroupBuilder.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Client.Models;
+
+namespace Client.Services
+{
+    public static class AppointmentGroupBuilder
+    {
+        public static IReadOnlyList<AppointmentSearchResult> BuildResults(
+            IEnumerable<AppointmentSlotInfo> slots,
+            AppointmentSearchFilters filters)
+        {
+            var personCount = Math.Max(1, filters.PersonCount);
+            var orderedSlots = slots
+                .OrderBy(s => s.SlotStart)
+                .ToList();
+
+            if (personCount == 1)
+            {
+                return orderedSlots
+                    .Select(slot => new AppointmentSearchResult(
+                        1,
+                        new[] { new AppointmentResultSlot(slot, 1) },
+                        CombinationQuality.Strict,
+                        TimeSpan.Zero))
+                    .ToList();
+            }
+
+            var results = new List<AppointmentSearchResult>();
+            foreach (var dayGroup in orderedSlots.GroupBy(s => s.SlotStart.Date))
+            {
+                var generator = new CombinationGenerator(dayGroup.OrderBy(s => s.SlotStart).ToList(), personCount);
+                results.AddRange(generator.Generate());
+            }
+
+            if (results.Count == 0)
+                return results;
+
+            var bestQuality = results.Min(r => r.Quality);
+            return results
+                .Where(r => r.Quality == bestQuality)
+                .OrderBy(r => r.Day)
+                .ThenBy(r => r.TotalSpan)
+                .ThenBy(r => r.Slots.First().Slot.SlotStart)
+                .ToList();
+        }
+
+        private sealed class CombinationGenerator
+        {
+            private readonly List<AppointmentSlotInfo> _slots;
+            private readonly int _personCount;
+            private readonly List<AppointmentResultSlot> _current = new();
+            private readonly List<AppointmentSearchResult> _results = new();
+
+            public CombinationGenerator(List<AppointmentSlotInfo> slots, int personCount)
+            {
+                _slots = slots;
+                _personCount = personCount;
+            }
+
+            public IReadOnlyList<AppointmentSearchResult> Generate()
+            {
+                GenerateRecursive(0, _personCount);
+                return _results;
+            }
+
+            private void GenerateRecursive(int index, int remaining)
+            {
+                if (remaining == 0)
+                {
+                    EvaluateCurrent();
+                    return;
+                }
+
+                if (index >= _slots.Count)
+                {
+                    return;
+                }
+
+                var slot = _slots[index];
+                var maxTake = Math.Min(slot.AvailableCapacity, remaining);
+                for (var take = 0; take <= maxTake; take++)
+                {
+                    if (take > 0)
+                    {
+                        _current.Add(new AppointmentResultSlot(slot, take));
+                    }
+
+                    GenerateRecursive(index + 1, remaining - take);
+
+                    if (take > 0)
+                    {
+                        _current.RemoveAt(_current.Count - 1);
+                    }
+                }
+            }
+
+            private void EvaluateCurrent()
+            {
+                if (_current.Count == 0)
+                    return;
+
+                var times = new List<DateTime>();
+                var morningCount = 0;
+                var afternoonCount = 0;
+
+                foreach (var allocation in _current)
+                {
+                    for (var i = 0; i < allocation.PersonCount; i++)
+                    {
+                        times.Add(allocation.Slot.SlotStart);
+                    }
+
+                    if (allocation.Slot.IsMorning)
+                        morningCount += allocation.PersonCount;
+                    if (allocation.Slot.IsAfternoon)
+                        afternoonCount += allocation.PersonCount;
+                }
+
+                if (times.Count != _personCount)
+                    return;
+
+                times.Sort();
+
+                var totalSpan = times.Count > 1
+                    ? times.Last() - times.First()
+                    : TimeSpan.Zero;
+
+                var distinctTimes = times.Distinct().OrderBy(t => t).ToList();
+
+                var quality = EvaluateQuality(distinctTimes, morningCount, afternoonCount, totalSpan);
+                if (quality == null)
+                    return;
+
+                _results.Add(new AppointmentSearchResult(
+                    _personCount,
+                    _current.Select(slot => new AppointmentResultSlot(slot.Slot, slot.PersonCount)).ToList(),
+                    quality.Value,
+                    totalSpan));
+            }
+
+            private CombinationQuality? EvaluateQuality(
+                IReadOnlyList<DateTime> distinctTimes,
+                int morningCount,
+                int afternoonCount,
+                TimeSpan totalSpan)
+            {
+                var mixDayParts = morningCount > 0 && afternoonCount > 0;
+
+                if (_personCount == 2)
+                {
+                    if (mixDayParts)
+                        return null;
+
+                    var gap = distinctTimes.Count > 1
+                        ? distinctTimes[1] - distinctTimes[0]
+                        : TimeSpan.Zero;
+
+                    if (gap <= TimeSpan.FromHours(1) && totalSpan <= TimeSpan.FromHours(1))
+                        return CombinationQuality.Strict;
+
+                    if (totalSpan <= TimeSpan.FromHours(2))
+                        return CombinationQuality.Relaxed;
+
+                    return CombinationQuality.Fallback;
+                }
+
+                if (_personCount == 3)
+                {
+                    if (mixDayParts)
+                        return CombinationQuality.Fallback;
+
+                    var hasPair = _current.Any(s => s.PersonCount >= 2);
+                    var strict = totalSpan <= TimeSpan.FromMinutes(90)
+                                 && GapWithin(distinctTimes, 0, TimeSpan.FromHours(1))
+                                 && GapWithin(distinctTimes, 1, TimeSpan.FromMinutes(30));
+
+                    if (strict)
+                        return CombinationQuality.Strict;
+
+                    if (hasPair && totalSpan <= TimeSpan.FromHours(2))
+                        return CombinationQuality.Relaxed;
+
+                    if (totalSpan <= TimeSpan.FromHours(3))
+                        return CombinationQuality.Fallback;
+
+                    return null;
+                }
+
+                if (_personCount == 4)
+                {
+                    var hasValidMix = !mixDayParts || (morningCount >= 2 && afternoonCount >= 2);
+                    if (!hasValidMix)
+                        return null;
+
+                    var strict = totalSpan <= TimeSpan.FromHours(2)
+                                 && GapWithin(distinctTimes, 0, TimeSpan.FromHours(1))
+                                 && GapWithin(distinctTimes, 1, TimeSpan.FromMinutes(30))
+                                 && GapWithin(distinctTimes, 2, TimeSpan.FromMinutes(30));
+
+                    if (strict)
+                        return CombinationQuality.Strict;
+
+                    if (totalSpan <= TimeSpan.FromHours(2.5))
+                        return CombinationQuality.Relaxed;
+
+                    if (totalSpan <= TimeSpan.FromHours(3))
+                        return CombinationQuality.Fallback;
+
+                    return null;
+                }
+
+                return null;
+            }
+
+            private static bool GapWithin(IReadOnlyList<DateTime> times, int index, TimeSpan limit)
+            {
+                if (times.Count <= index + 1)
+                    return true;
+
+                var gap = times[index + 1] - times[index];
+                return gap <= limit;
+            }
+        }
+    }
+}

--- a/Client/Services/AppointmentSearchService.cs
+++ b/Client/Services/AppointmentSearchService.cs
@@ -15,11 +15,16 @@ namespace Client.Services
     {
         private readonly AppointmentSearchConfig _config;
         private readonly MachineConfig _machineConfig;
+        private readonly ISchoolHolidayService _holidayService;
 
-        public AppointmentSearchService(AppointmentSearchConfig config, MachineConfig machineConfig)
+        public AppointmentSearchService(
+            AppointmentSearchConfig config,
+            MachineConfig machineConfig,
+            ISchoolHolidayService holidayService)
         {
             _config = config;
             _machineConfig = machineConfig;
+            _holidayService = holidayService;
         }
 
         public async Task<IReadOnlyList<AppointmentSlotInfo>> FindAvailableSlotsAsync(
@@ -28,6 +33,8 @@ namespace Client.Services
             bool canClimb,
             bool isFo,
             bool allowOverload,
+            AppointmentSearchFilters filters,
+            int monthOffset,
             CancellationToken cancellationToken)
         {
             if (!_config.IsValid())
@@ -35,7 +42,9 @@ namespace Client.Services
                 throw new InvalidOperationException("La configuration de recherche des rendez-vous est incomplète.");
             }
 
-            var (startDate, endDate) = GetSearchRange(anchorDate, mode);
+            filters ??= new AppointmentSearchFilters();
+
+            var (startDate, endDate) = GetSearchRange(anchorDate.AddMonths(monthOffset), mode);
             var existingAppointments = await LoadExistingAppointmentsAsync(startDate, endDate, cancellationToken).ConfigureAwait(false);
             var excludedDates = BuildExcludedDateSet(existingAppointments.Where(e => e.IsExcludedDayMarker));
             var groupedAppointments = GroupAppointments(existingAppointments.Where(e => !e.IsExcludedDayMarker));
@@ -55,6 +64,18 @@ namespace Client.Services
                 if (excludedDates.Contains(date))
                     continue;
 
+                if (filters.PreferredDay.HasValue && filters.PreferredDay.Value != date.DayOfWeek)
+                    continue;
+
+                if (filters.HolidayFilter != SchoolHolidayFilter.Any)
+                {
+                    var isHoliday = _holidayService.IsSchoolHoliday(date, filters.HolidayZone);
+                    if (filters.HolidayFilter == SchoolHolidayFilter.OnlyDuring && !isHoliday)
+                        continue;
+                    if (filters.HolidayFilter == SchoolHolidayFilter.Exclude && isHoliday)
+                        continue;
+                }
+
                 foreach (var slotTime in EnumerateDailySlots(slotLength))
                 {
                     var slotDateTime = date + slotTime;
@@ -62,6 +83,15 @@ namespace Client.Services
                         continue;
 
                     if (!IsWithinWorkingHours(slotTime, isFo))
+                        continue;
+
+                    var dayPart = slotTime < _config.AfternoonStart
+                        ? SlotDayPart.Morning
+                        : SlotDayPart.Afternoon;
+
+                    if (filters.TimePreference == TimeOfDayPreference.Morning && dayPart != SlotDayPart.Morning)
+                        continue;
+                    if (filters.TimePreference == TimeOfDayPreference.Afternoon && dayPart != SlotDayPart.Afternoon)
                         continue;
 
                     if (cancellationToken.IsCancellationRequested)
@@ -78,6 +108,10 @@ namespace Client.Services
 
                     var redRelaxation = currentCount >= baseLimit && redCount > 0;
                     var overloadUsed = allowOverload && effectiveCount >= baseLimit;
+                    var capacityLimit = overloadUsed ? overloadLimit : baseLimit;
+                    var availableCapacity = Math.Max(0, capacityLimit - effectiveCount);
+                    if (availableCapacity <= 0)
+                        continue;
 
                     slots.Add(new AppointmentSlotInfo
                     {
@@ -87,7 +121,9 @@ namespace Client.Services
                             .GroupBy(c => c)
                             .ToDictionary(g => g.Key, g => g.Count()),
                         UsesOverloadCapacity = overloadUsed,
-                        RedRelaxationApplied = redRelaxation
+                        RedRelaxationApplied = redRelaxation,
+                        AvailableCapacity = availableCapacity,
+                        DayPart = dayPart
                     });
                 }
             }

--- a/Client/Services/ISchoolHolidayService.cs
+++ b/Client/Services/ISchoolHolidayService.cs
@@ -1,0 +1,10 @@
+using System;
+using Client.Models;
+
+namespace Client.Services
+{
+    public interface ISchoolHolidayService
+    {
+        bool IsSchoolHoliday(DateTime date, SchoolHolidayZone zone);
+    }
+}

--- a/Client/Services/SchoolHolidayService.cs
+++ b/Client/Services/SchoolHolidayService.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Client.Helpers;
+using Client.Models;
+using Newtonsoft.Json;
+
+namespace Client.Services
+{
+    public class SchoolHolidayService : ISchoolHolidayService
+    {
+        private static readonly Uri ApiUri = new("https://data.education.gouv.fr/api/records/1.0/search/?dataset=fr-en-calendrier-scolaire&rows=500&sort=-end_date");
+        private static readonly HttpClient HttpClient = new();
+
+        private readonly object _syncRoot = new();
+        private readonly Dictionary<SchoolHolidayZone, List<HolidayPeriod>> _periodsByZone = new();
+        private readonly object _loadLock = new();
+        private Task? _loadTask;
+
+        public bool IsSchoolHoliday(DateTime date, SchoolHolidayZone zone)
+        {
+            EnsureLoaded();
+
+            var day = date.Date;
+            foreach (var targetZone in EnumerateTargetZones(zone))
+            {
+                List<HolidayPeriod>? periods;
+                lock (_syncRoot)
+                {
+                    _periodsByZone.TryGetValue(targetZone, out periods);
+                }
+
+                if (periods == null || periods.Count == 0)
+                    continue;
+
+                foreach (var period in periods)
+                {
+                    if (day >= period.Start && day <= period.End)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private void EnsureLoaded()
+        {
+            var task = Volatile.Read(ref _loadTask);
+            if (task == null)
+            {
+                lock (_loadLock)
+                {
+                    task = _loadTask;
+                    if (task == null)
+                    {
+                        task = LoadFromApiAsync();
+                        Volatile.Write(ref _loadTask, task);
+                    }
+                }
+            }
+
+            try
+            {
+                task!.GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException("[SchoolHolidayService] LoadFromApi", ex, "CLI62");
+
+                lock (_loadLock)
+                {
+                    if (ReferenceEquals(task, _loadTask))
+                    {
+                        Volatile.Write(ref _loadTask, null);
+                    }
+                }
+            }
+        }
+
+        private async Task LoadFromApiAsync()
+        {
+            using var response = await HttpClient.GetAsync(ApiUri).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            var payload = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var document = JsonConvert.DeserializeObject<ApiResponse>(payload);
+            var records = document?.Records;
+
+            if (records == null || records.Count == 0)
+            {
+                lock (_syncRoot)
+                {
+                    _periodsByZone.Clear();
+                }
+                return;
+            }
+
+            var map = new Dictionary<SchoolHolidayZone, List<HolidayPeriod>>
+            {
+                { SchoolHolidayZone.ZoneA, new List<HolidayPeriod>() },
+                { SchoolHolidayZone.ZoneB, new List<HolidayPeriod>() },
+                { SchoolHolidayZone.ZoneC, new List<HolidayPeriod>() }
+            };
+
+            foreach (var record in records)
+            {
+                var fields = record.Fields;
+                if (fields == null || fields.StartDate == null || fields.EndDate == null)
+                    continue;
+
+                var zones = ExtractZones(fields).ToList();
+                if (zones.Count == 0)
+                {
+                    zones.AddRange(new[]
+                    {
+                        SchoolHolidayZone.ZoneA,
+                        SchoolHolidayZone.ZoneB,
+                        SchoolHolidayZone.ZoneC
+                    });
+                }
+
+                foreach (var zone in zones)
+                {
+                    if (!map.TryGetValue(zone, out var list))
+                        continue;
+
+                    list.Add(new HolidayPeriod(fields.StartDate.Value, fields.EndDate.Value));
+                }
+            }
+
+            foreach (var list in map.Values)
+            {
+                list.Sort((left, right) => left.Start.CompareTo(right.Start));
+            }
+
+            lock (_syncRoot)
+            {
+                _periodsByZone.Clear();
+                foreach (var kvp in map)
+                {
+                    if (kvp.Value.Count > 0)
+                    {
+                        _periodsByZone[kvp.Key] = kvp.Value;
+                    }
+                }
+            }
+        }
+
+        private static IEnumerable<SchoolHolidayZone> EnumerateTargetZones(SchoolHolidayZone zone)
+        {
+            if (zone == SchoolHolidayZone.Any)
+            {
+                yield return SchoolHolidayZone.ZoneA;
+                yield return SchoolHolidayZone.ZoneB;
+                yield return SchoolHolidayZone.ZoneC;
+                yield break;
+            }
+
+            yield return zone;
+        }
+
+        private static IEnumerable<SchoolHolidayZone> ExtractZones(ApiFields fields)
+        {
+            if (fields.Zones != null)
+            {
+                foreach (var entry in fields.Zones)
+                {
+                    if (TryParseZone(entry, out var zone))
+                    {
+                        yield return zone;
+                    }
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(fields.Location))
+            {
+                var parts = fields.Location.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                foreach (var part in parts)
+                {
+                    if (TryParseZone(part, out var zone))
+                    {
+                        yield return zone;
+                    }
+                }
+            }
+        }
+
+        private static bool TryParseZone(string? text, out SchoolHolidayZone zone)
+        {
+            zone = SchoolHolidayZone.Any;
+            if (string.IsNullOrWhiteSpace(text))
+                return false;
+
+            var cleaned = text.Trim().Replace(" ", string.Empty);
+            if (Enum.TryParse(cleaned, true, out zone) && zone != SchoolHolidayZone.Any)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private sealed class HolidayPeriod
+        {
+            public HolidayPeriod(DateTime start, DateTime end)
+            {
+                Start = start.Date;
+                End = end.Date;
+            }
+
+            public DateTime Start { get; }
+            public DateTime End { get; }
+        }
+
+        private sealed class ApiResponse
+        {
+            [JsonProperty("records")]
+            public List<ApiRecord>? Records { get; set; }
+        }
+
+        private sealed class ApiRecord
+        {
+            [JsonProperty("fields")]
+            public ApiFields? Fields { get; set; }
+        }
+
+        private sealed class ApiFields
+        {
+            [JsonProperty("start_date")]
+            public DateTime? StartDate { get; set; }
+
+            [JsonProperty("end_date")]
+            public DateTime? EndDate { get; set; }
+
+            [JsonProperty("zones")]
+            public List<string>? Zones { get; set; }
+
+            [JsonProperty("location")]
+            public string? Location { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a school holiday zone selector to the appointment search filters and UI
- fetch and cache French school holiday periods from the education open-data API
- apply the selected zone when excluding or requiring school-holiday days during search

## Testing
- dotnet --version *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f274f5348083248fbf4c68652b2fa7