### PR TITLE
Add search before option with overlapping analysis periods

### DIFF
--- a/Client/Pages/AppointmentSearchPage.xaml
+++ b/Client/Pages/AppointmentSearchPage.xaml
@@ -90,6 +90,7 @@
             </StackPanel>
 
             <StackPanel Orientation="Horizontal" Spacing="12">
+                <Button x:Name="SearchBeforeButton" Content="Chercher avant" Click="SearchBefore_Click" />
                 <Button x:Name="SearchButton" Content="Chercher" Click="Search_Click" />
                 <Button x:Name="SearchOverloadButton" Content="Chercher (overload)" Click="SearchOverload_Click" />
                 <Button x:Name="SearchFurtherButton" Content="Chercher plus loin" Click="SearchFurther_Click" />

--- a/Client/Pages/AppointmentSearchPage.xaml.cs
+++ b/Client/Pages/AppointmentSearchPage.xaml.cs
@@ -25,6 +25,9 @@ namespace Client.Pages
         private bool _suppressHorizonUpdate;
         private readonly ISchoolHolidayService _holidayService = new SchoolHolidayService();
         private int _searchOffsetMonths;
+        private DateTime? _lastRangeStart;
+        private DateTime? _lastRangeEnd;
+        private const int OverlapMarginDays = 1;
 
         public ObservableCollection<AppointmentSearchResult> Results { get; } = new();
 
@@ -94,6 +97,8 @@ namespace Client.Pages
             if (resetOffset)
             {
                 _searchOffsetMonths = 0;
+                _lastRangeStart = null;
+                _lastRangeEnd = null;
             }
 
             _searchToken?.Cancel();
@@ -102,8 +107,7 @@ namespace Client.Pages
 
             var anchorDate = ReferenceDatePicker.Date.Value.Date;
             var mode = GetSelectedMode();
-            var targetAnchor = anchorDate.AddMonths(_searchOffsetMonths);
-            var (rangeStart, rangeEnd) = ComputeSearchRange(targetAnchor, mode);
+            var (rangeStart, rangeEnd, targetAnchor) = PrepareSearchRange(anchorDate, mode);
             DateRangeText.Text = $"Période analysée : {rangeStart:dd/MM/yyyy} au {rangeEnd:dd/MM/yyyy}";
             var canClimb = ClimbToggle.IsOn;
             var isFo = FoToggle.IsOn;
@@ -117,8 +121,11 @@ namespace Client.Pages
             try
             {
                 var service = new AppointmentSearchService(_config, _machineConfig, _holidayService);
-                var slots = await service.FindAvailableSlotsAsync(anchorDate, mode, canClimb, isFo, allowOverload, filters, _searchOffsetMonths, token);
+                var slots = await service.FindAvailableSlotsAsync(targetAnchor, mode, canClimb, isFo, allowOverload, filters, token);
                 var groupedResults = AppointmentGroupBuilder.BuildResults(slots, filters);
+
+                _lastRangeStart = rangeStart;
+                _lastRangeEnd = rangeEnd;
 
                 foreach (var result in groupedResults)
                 {
@@ -127,9 +134,13 @@ namespace Client.Pages
 
                 if (groupedResults.Any())
                 {
-                    var offsetText = _searchOffsetMonths > 0
-                        ? $" (recherche décalée de {_searchOffsetMonths} mois)"
-                        : string.Empty;
+                    var offsetText = $" (ancre au {targetAnchor:dd/MM/yyyy})";
+                    if (_searchOffsetMonths != 0)
+                    {
+                        var direction = _searchOffsetMonths > 0 ? "vers le futur" : "vers le passé";
+                        var months = Math.Abs(_searchOffsetMonths);
+                        offsetText = $" (ancre au {targetAnchor:dd/MM/yyyy}, décalée de {months} mois {direction})";
+                    }
                     StatusText.Text = $"{groupedResults.Count} proposition(s) trouvée(s){offsetText}.";
                 }
                 else
@@ -160,6 +171,7 @@ namespace Client.Pages
             ModeCombo.IsEnabled = isEnabled;
             ClimbToggle.IsEnabled = isEnabled;
             FoToggle.IsEnabled = isEnabled;
+            SearchBeforeButton.IsEnabled = isEnabled;
             SearchButton.IsEnabled = isEnabled;
             SearchOverloadButton.IsEnabled = isEnabled;
             PersonCountCombo.IsEnabled = isEnabled;
@@ -322,10 +334,44 @@ namespace Client.Pages
             await RunSearchAsync(true, true);
         }
 
+        private async void SearchBefore_Click(object sender, RoutedEventArgs e)
+        {
+            _searchOffsetMonths--;
+            await RunSearchAsync(false, false);
+        }
+
         private async void SearchFurther_Click(object sender, RoutedEventArgs e)
         {
             _searchOffsetMonths++;
             await RunSearchAsync(false, false);
+        }
+
+        private (DateTime start, DateTime end, DateTime anchor) PrepareSearchRange(DateTime anchorDate, SearchMode mode)
+        {
+            var targetAnchor = anchorDate.AddMonths(_searchOffsetMonths);
+            var (rangeStart, rangeEnd) = ComputeSearchRange(targetAnchor, mode);
+
+            if (_lastRangeEnd.HasValue)
+            {
+                var desiredStart = _lastRangeEnd.Value.AddDays(-OverlapMarginDays);
+                while (rangeStart > desiredStart)
+                {
+                    targetAnchor = targetAnchor.AddDays(-1);
+                    (rangeStart, rangeEnd) = ComputeSearchRange(targetAnchor, mode);
+                }
+            }
+
+            if (_lastRangeStart.HasValue)
+            {
+                var desiredEnd = _lastRangeStart.Value.AddDays(OverlapMarginDays);
+                while (rangeEnd < desiredEnd)
+                {
+                    targetAnchor = targetAnchor.AddDays(1);
+                    (rangeStart, rangeEnd) = ComputeSearchRange(targetAnchor, mode);
+                }
+            }
+
+            return (rangeStart, rangeEnd, targetAnchor);
         }
 
         private (DateTime start, DateTime end) ComputeSearchRange(DateTime anchor, SearchMode mode)

--- a/Client/Services/AppointmentSearchService.cs
+++ b/Client/Services/AppointmentSearchService.cs
@@ -34,7 +34,6 @@ namespace Client.Services
             bool isFo,
             bool allowOverload,
             AppointmentSearchFilters filters,
-            int monthOffset,
             CancellationToken cancellationToken)
         {
             if (!_config.IsValid())
@@ -44,7 +43,7 @@ namespace Client.Services
 
             filters ??= new AppointmentSearchFilters();
 
-            var (startDate, endDate) = GetSearchRange(anchorDate.AddMonths(monthOffset), mode);
+            var (startDate, endDate) = GetSearchRange(anchorDate, mode);
             var existingAppointments = await LoadExistingAppointmentsAsync(startDate, endDate, cancellationToken).ConfigureAwait(false);
             var excludedDates = BuildExcludedDateSet(existingAppointments.Where(e => e.IsExcludedDayMarker));
             var groupedAppointments = GroupAppointments(existingAppointments.Where(e => !e.IsExcludedDayMarker));


### PR DESCRIPTION
## Summary
- add a "Chercher avant" button to the appointment search page
- adjust search execution so consecutive ranges overlap when navigating backward or forward
- update the appointment search service to take the adjusted anchor date directly

## Testing
- dotnet build WebApplication1.sln *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f3982a1d6c83249f77856a3bc481bd