### PR TITLE
Fix patient dialog handling and name parsing

### DIFF
--- a/Client/Helpers/PatientStringHelper.cs
+++ b/Client/Helpers/PatientStringHelper.cs
@@ -1,5 +1,5 @@
 using System;
-
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace Client.Helpers
@@ -14,9 +14,13 @@ namespace Client.Helpers
 
             try
             {
-                string patternTitleName = @"^(?i)(Mr\.?|Mlle|Mademoiselle|Mme|Monsieur|Madame|Enfant)?\s*(?<name>[\p{L}'\-\s]+?)(?:\s+n[eé]e\s+[\p{L}'\-\s]+)?\s+(?<firstName>[\p{L}'-]+)";
+                var sanitizedInput = (inputText ?? string.Empty).Trim();
+                if (string.IsNullOrEmpty(sanitizedInput))
+                    return;
 
-                var matchTitleName = Regex.Match(inputText ?? string.Empty, patternTitleName);
+                string patternTitleName = @"^(?i)(Mr\.?|Mlle|Mademoiselle|Mme|Monsieur|Madame|Enfant)?\s*(?<name>[\p{L}'\-\s]+)(?:\s+n[eé]e\s+[\p{L}'\-\s]+)?\s+(?<firstName>[\p{L}'\-\s]+)\s*$";
+
+                var matchTitleName = Regex.Match(sanitizedInput, patternTitleName);
 
                 if (matchTitleName.Success)
                 {
@@ -24,14 +28,13 @@ namespace Client.Helpers
                     string nom = matchTitleName.Groups["name"].Value;
                     string prenom = matchTitleName.Groups["firstName"].Value;
 
-                    patientLastName = nom.ToUpperInvariant();
-                    patientTitle = string.IsNullOrWhiteSpace(titre) ? string.Empty : titre;
-
-                    if (!string.IsNullOrEmpty(prenom))
-                    {
-                        patientFirstName = char.ToUpper(prenom[0]) + prenom.Substring(1).ToLowerInvariant();
-                    }
+                    patientTitle = string.IsNullOrWhiteSpace(titre) ? string.Empty : titre.Trim();
+                    patientLastName = NormalizeLastName(nom);
+                    patientFirstName = NormalizeFirstName(prenom);
+                    return;
                 }
+
+                ApplyFallbackParsing(sanitizedInput, out patientTitle, out patientLastName, out patientFirstName);
             }
             catch
             {
@@ -39,6 +42,86 @@ namespace Client.Helpers
                 patientLastName = string.Empty;
                 patientFirstName = string.Empty;
             }
+        }
+
+        private static void ApplyFallbackParsing(string input, out string patientTitle, out string patientLastName, out string patientFirstName)
+        {
+            patientTitle = string.Empty;
+            patientLastName = string.Empty;
+            patientFirstName = string.Empty;
+
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                return;
+            }
+
+            string workingInput = input;
+            string[] possibleTitles = new[] { "MR", "MR.", "MLE", "MLLE", "MADEMOISELLE", "MME", "MONSIEUR", "MADAME", "ENFANT" };
+
+            foreach (var possibleTitle in possibleTitles)
+            {
+                if (workingInput.StartsWith(possibleTitle, StringComparison.OrdinalIgnoreCase))
+                {
+                    patientTitle = NormalizeFirstName(possibleTitle);
+                    workingInput = workingInput[possibleTitle.Length..].TrimStart();
+                    break;
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(workingInput))
+            {
+                return;
+            }
+
+            var tokens = workingInput.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (tokens.Length == 1)
+            {
+                patientLastName = tokens[0].ToUpperInvariant();
+                return;
+            }
+
+            string firstNameRaw = tokens[^1];
+            string lastNameRaw = string.Join(' ', tokens, 0, tokens.Length - 1);
+
+            patientLastName = NormalizeLastName(lastNameRaw);
+            patientFirstName = NormalizeFirstName(firstNameRaw);
+        }
+
+        private static string NormalizeLastName(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return string.Empty;
+
+            var normalized = Regex.Replace(value, @"\s+", " ").Trim();
+            return normalized.ToUpperInvariant();
+        }
+
+        private static string NormalizeFirstName(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return string.Empty;
+
+            var textInfo = CultureInfo.GetCultureInfo("fr-FR").TextInfo;
+            var normalized = Regex.Replace(value, @"\s+", " ").Trim();
+
+            var words = normalized.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            for (int i = 0; i < words.Length; i++)
+            {
+                var segments = words[i].Split('-', StringSplitOptions.None);
+                for (int j = 0; j < segments.Length; j++)
+                {
+                    var segment = segments[j];
+                    if (string.IsNullOrEmpty(segment))
+                        continue;
+
+                    var lowered = segment.ToLowerInvariant();
+                    segments[j] = textInfo.ToTitleCase(lowered);
+                }
+
+                words[i] = string.Join('-', segments);
+            }
+
+            return string.Join(' ', words);
         }
     }
 }

--- a/Client/Services/HotKeyService.cs
+++ b/Client/Services/HotKeyService.cs
@@ -53,6 +53,7 @@ namespace Client.Services
 
         private IntPtr _hookID = IntPtr.Zero;
         private LowLevelKeyboardProc? _proc;
+        private static ContentDialog? _activePatientDialog;
 
         private delegate IntPtr LowLevelKeyboardProc(int nCode, IntPtr wParam, IntPtr lParam);
 
@@ -189,6 +190,18 @@ namespace Client.Services
             if (xamlRoot is null)
                 return;
 
+            if (_activePatientDialog is ContentDialog openedDialog)
+            {
+                try
+                {
+                    openedDialog.Hide();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[HotKeyService] Failed to hide existing patient dialog: {ex.Message}");
+                }
+            }
+
             var dialog = new ContentDialog
             {
                 Title = "Ajout d'un patient",
@@ -196,6 +209,8 @@ namespace Client.Services
                 CloseButtonText = "Annuler",
                 XamlRoot = xamlRoot,
             };
+
+            _activePatientDialog = dialog;
 
             var grid = new Grid { ColumnSpacing = 10, RowSpacing = 4 };
             grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
@@ -322,41 +337,51 @@ namespace Client.Services
 
             dialog.Content = grid;
 
-            var result = await dialog.ShowAsync();
-
-            if (result == ContentDialogResult.Primary)
+            try
             {
-                var inputName = nameBox.Text.Trim();
-                PatientStringHelper.ExtractInfoFromInput(inputName,
-                    out var titleBox, out var lastNameBox, out var firstNameBox);
+                var result = await dialog.ShowAsync();
 
-                var selectedExamId = examCombo.SelectedValue as string ?? string.Empty;
-                var opt = ExamOption.FindByIdentifier(options, selectedExamId);
-                var resolvedExamName = opt?.Name ?? sanitizedExamIdentifier ?? string.Empty;
-
-                var patient = new Patient
+                if (result == ContentDialogResult.Primary)
                 {
-                    Id = Guid.NewGuid().ToString(),
-                    Colors = opt?.Color ?? string.Empty,
-                    Title = titleBox,
-                    LastName = lastNameBox,
-                    FirstName = firstNameBox,
-                    Exams = resolvedExamName,
-                    Eye = (eyeCombo.SelectedItem as ComboBoxItem)?.Content as string ?? string.Empty,
-                    Annotation = string.IsNullOrWhiteSpace(commentBox.Text) ? opt?.Annotation ?? string.Empty : commentBox.Text.Trim(),
-                    Position = floorCombo.SelectedItem as string ?? string.Empty,
-                    HoldTime = DateTime.Now,
-                    Examinator = App.UserName,
-                   
-                };
+                    var inputName = nameBox.Text.Trim();
+                    PatientStringHelper.ExtractInfoFromInput(inputName,
+                        out var titleBox, out var lastNameBox, out var firstNameBox);
 
-                try
-                {
-                    await App.ChatService.DeclarePatient(patient);
+                    var selectedExamId = examCombo.SelectedValue as string ?? string.Empty;
+                    var opt = ExamOption.FindByIdentifier(options, selectedExamId);
+                    var resolvedExamName = opt?.Name ?? sanitizedExamIdentifier ?? string.Empty;
+
+                    var patient = new Patient
+                    {
+                        Id = Guid.NewGuid().ToString(),
+                        Colors = opt?.Color ?? string.Empty,
+                        Title = titleBox,
+                        LastName = lastNameBox,
+                        FirstName = firstNameBox,
+                        Exams = resolvedExamName,
+                        Eye = (eyeCombo.SelectedItem as ComboBoxItem)?.Content as string ?? string.Empty,
+                        Annotation = string.IsNullOrWhiteSpace(commentBox.Text) ? opt?.Annotation ?? string.Empty : commentBox.Text.Trim(),
+                        Position = floorCombo.SelectedItem as string ?? string.Empty,
+                        HoldTime = DateTime.Now,
+                        Examinator = App.UserName,
+
+                    };
+
+                    try
+                    {
+                        await App.ChatService.DeclarePatient(patient);
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"[HotKeyService] Error declaring patient: {ex.Message}");
+                    }
                 }
-                catch (Exception ex)
+            }
+            finally
+            {
+                if (ReferenceEquals(_activePatientDialog, dialog))
                 {
-                    Debug.WriteLine($"[HotKeyService] Error declaring patient: {ex.Message}");
+                    _activePatientDialog = null;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- keep compound surnames in uppercase and improve first-name normalization when parsing patient details
- gracefully close the existing patient creation dialog before opening a new one to prevent crashes

## Testing
- dotnet build WebApplication1.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f66c1337e48324bc2da7cc617e3d6f