### PR TITLE
Corrige les textes en français restants

### DIFF
--- a/Client/Models/AppointmentSearchResult.cs
+++ b/Client/Models/AppointmentSearchResult.cs
@@ -112,7 +112,7 @@ namespace Client.Models
 
             if (Slot.UsesOverloadCapacity)
             {
-                parts.Add("overload");
+                parts.Add("surcharge");
             }
 
             if (Slot.RedRelaxationApplied)

--- a/Client/Models/UserInfo.cs
+++ b/Client/Models/UserInfo.cs
@@ -92,12 +92,12 @@ namespace Client.Models
 
         /// <summary>
         /// Returns a comma separated list of rooms the user is connected to.
-        /// "A Tous" and "Secrétariat" never display the "Offline" label.
+        /// "A Tous" and "Secrétariat" never display the "Hors ligne" label.
         /// </summary>
         public string RoomsDisplay
             => Username == "A Tous" || Username == "Secrétariat"
                 ? string.Join(", ", Rooms)
-                : Rooms.Count == 0 ? "Offline" : string.Join(", ", Rooms);
+                : Rooms.Count == 0 ? "Hors ligne" : string.Join(", ", Rooms);
 
         private void Rooms_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {

--- a/Client/Pages/AppointmentSearchPage.xaml
+++ b/Client/Pages/AppointmentSearchPage.xaml
@@ -92,7 +92,7 @@
             <StackPanel Orientation="Horizontal" Spacing="12">
                 <Button x:Name="SearchBeforeButton" Content="Chercher avant" Click="SearchBefore_Click" />
                 <Button x:Name="SearchButton" Content="Chercher" Click="Search_Click" />
-                <Button x:Name="SearchOverloadButton" Content="Chercher (overload)" Click="SearchOverload_Click" />
+                <Button x:Name="SearchOverloadButton" Content="Chercher (surcharge)" Click="SearchOverload_Click" />
                 <Button x:Name="SearchFurtherButton" Content="Chercher plus loin" Click="SearchFurther_Click" />
                 <Button x:Name="ExportButton" Content="Exporter les résultats" Click="Export_Click" IsEnabled="False" />
             </StackPanel>
@@ -124,7 +124,7 @@
                                     </ItemsControl.ItemTemplate>
                                 </ItemsControl>
                                 <StackPanel Orientation="Horizontal" Spacing="12">
-                                    <TextBlock Text="Overload en cours" Visibility="{x:Bind UsesOverload, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    <TextBlock Text="Surcharge en cours" Visibility="{x:Bind UsesOverload, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                     <TextBlock Text="Tolérance rouge" Visibility="{x:Bind UsesRedRelaxation, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                 </StackPanel>
                             </StackPanel>

--- a/Client/Pages/AppointmentSearchPage.xaml.cs
+++ b/Client/Pages/AppointmentSearchPage.xaml.cs
@@ -433,7 +433,7 @@ namespace Client.Pages
         private string BuildCsvExportContent()
         {
             var builder = new StringBuilder();
-            builder.AppendLine("Date;Nombre de personnes;Créneaux;Détail;Overload;Tolérance rouge;RDV existants");
+            builder.AppendLine("Date;Nombre de personnes;Créneaux;Détail;Surcharge;Tolérance rouge;RDV existants");
 
             var orderedResults = Results
                 .OrderBy(r => r.Day == DateTime.MinValue ? DateTime.MaxValue : r.Day)

--- a/Client/Pages/ChatPage.xaml
+++ b/Client/Pages/ChatPage.xaml
@@ -212,7 +212,7 @@
 
         <!-- Menu contextuel des utilisateurs -->
         <MenuFlyout x:Key="UserContextMenu" Opened="UserContextMenu_Opened">
-            <MenuFlyoutItem Text="Tu peut venir" Click="CallUser_Click"/>
+            <MenuFlyoutItem Text="Tu peux venir" Click="CallUser_Click"/>
             <MenuFlyoutItem Text="Monter" Click="MoveUserUp_Click"/>
             <MenuFlyoutItem Text="Descendre" Click="MoveUserDown_Click"/>
         </MenuFlyout>
@@ -236,7 +236,7 @@
                         <MenuFlyoutItem Text="Infos" Tag="{x:Bind}" Click="InfoPatient_Click" />
                         <MenuFlyoutItem Text="Modifier" Tag="{x:Bind}" Click="EditPatient_Click" />
                         <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
-                        <MenuFlyoutSubItem Text="Modification temps" Visibility="{Binding TimeModificationVisibility, ElementName=PageRoot}">
+                        <MenuFlyoutSubItem Text="Modifier le temps" Visibility="{Binding TimeModificationVisibility, ElementName=PageRoot}">
                         <MenuFlyoutItem Text="Mettre en premier" Tag="{x:Bind}" Click="MovePatientFirst_Click" />
                         <MenuFlyoutItem Text="Monter d'un cran" Tag="{x:Bind}" Click="MovePatientUp_Click" />
                         <MenuFlyoutItem Text="Descendre d'un cran" Tag="{x:Bind}" Click="MovePatientDown_Click" />
@@ -431,7 +431,7 @@
                             <Image Source="{x:Bind Avatar}" Width="40" Height="40"/>
                             <StackPanel>
                                 <TextBlock Text="{x:Bind Username}" Foreground="{x:Bind AccentAwareColorUserName, Converter={StaticResource StringToColorConverter}}" FontWeight="Bold"/>
-                                <TextBlock Text="{x:Bind RoomsDisplay, Mode=OneWay, FallbackValue='Offline'}"
+                                <TextBlock Text="{x:Bind RoomsDisplay, Mode=OneWay, FallbackValue='Hors ligne'}"
                                            Foreground="{x:Bind AccentAwareColorUserName, Converter={StaticResource StringToColorConverter}}"/>
                             </StackPanel>
                         </StackPanel>
@@ -470,6 +470,6 @@
                 <ThemeShadow/>
             </TextBox.Shadow>
         </TextBox>
-        <Button x:Name="ReconnectButton" Grid.Column="2" Grid.Row="1" Content="Reconnecter" Visibility="Collapsed" Click="Reconnect_Click" HorizontalAlignment="Right"/>
+        <Button x:Name="ReconnectButton" Grid.Column="2" Grid.Row="1" Content="Se reconnecter" Visibility="Collapsed" Click="Reconnect_Click" HorizontalAlignment="Right"/>
     </Grid>
 </Page>

--- a/Client/Pages/ChatPage.xaml.cs
+++ b/Client/Pages/ChatPage.xaml.cs
@@ -1133,7 +1133,7 @@ namespace Client.Pages
                 if (_service.Connection == null || _service.Connection.State != HubConnectionState.Connected)
                 {
                     ReconnectButton.Visibility = Visibility.Visible;
-                    ReconnectButton.Content = $"Reconnecter ({seconds})";
+                    ReconnectButton.Content = $"Se reconnecter ({seconds})";
                 }
                 else
                 {
@@ -1174,9 +1174,9 @@ namespace Client.Pages
             }
             string response = result switch
             {
-                ContentDialogResult.Primary => "je vient dans 0",
-                ContentDialogResult.Secondary => "je vient dans 5",
-                _ => "met en attente"
+                ContentDialogResult.Primary => "je viens dans 0 min",
+                ContentDialogResult.Secondary => "je viens dans 5 min",
+                _ => "mets en attente"
             };
 
             var avatar = AppSettings.Get("Avatar", "ms-appx:///Assets/utilisateur.png");
@@ -1461,7 +1461,7 @@ namespace Client.Pages
 
             var dialog = new ContentDialog
             {
-                Title = "Edition de salle",
+                Title = "Édition de salle",
                 CloseButtonText = "Fermer",
                 XamlRoot = (this.Content as FrameworkElement)?.XamlRoot
             };
@@ -1487,7 +1487,7 @@ namespace Client.Pages
                 }
             };
 
-            var passBtn = new Button { Content = "Changer mot de passe" };
+            var passBtn = new Button { Content = "Changer le mot de passe" };
             passBtn.Click += async (s, e) =>
             {
                 if (roomBox.SelectedItem is string sel)
@@ -1496,7 +1496,7 @@ namespace Client.Pages
                 }
             };
 
-            var removeBtn = new Button { Content = "Supprimer utilisateur" };
+            var removeBtn = new Button { Content = "Supprimer l'utilisateur" };
             removeBtn.Click += async (s, e) =>
             {
                 if (roomBox.SelectedItem is string sel && membersList.SelectedItem is string user)

--- a/Client/Pages/HistoryPage.xaml
+++ b/Client/Pages/HistoryPage.xaml
@@ -14,7 +14,7 @@
                         <MenuFlyoutItem Text="Infos" Tag="{x:Bind}" Click="InfoPatient_Click" />
                         <MenuFlyoutItem Text="Modifier" Tag="{x:Bind}" Click="EditPatient_Click" />
                         <MenuFlyoutItem Text="Supprimer" Tag="{x:Bind}" Click="DeletePatient_Click" />
-                        <MenuFlyoutSubItem Text="Modification temps" Visibility="{Binding TimeModificationVisibility, ElementName=PageRoot}">
+                        <MenuFlyoutSubItem Text="Modifier le temps" Visibility="{Binding TimeModificationVisibility, ElementName=PageRoot}">
                             <MenuFlyoutItem Text="Mettre en premier" Tag="{x:Bind}" Click="MovePatientFirst_Click" />
                             <MenuFlyoutItem Text="Monter d'un cran" Tag="{x:Bind}" Click="MovePatientUp_Click" />
                             <MenuFlyoutItem Text="Descendre d'un cran" Tag="{x:Bind}" Click="MovePatientDown_Click" />

--- a/Client/Pages/SystemPage.xaml
+++ b/Client/Pages/SystemPage.xaml
@@ -50,7 +50,7 @@
                                                         <NumberBox Value="{x:Bind AppointmentConfig.MaxAppointmentsPerSlot, Mode=TwoWay}" Minimum="1" SmallChange="1"/>
                                                 </StackPanel>
                                                 <StackPanel Width="200">
-                                                        <TextBlock Text="Overload supplémentaire" />
+                                                        <TextBlock Text="Surcharge supplémentaire" />
                                                         <NumberBox Value="{x:Bind AppointmentConfig.OverloadExtraAppointments, Mode=TwoWay}" Minimum="1" SmallChange="1"/>
                                                 </StackPanel>
                                                 <StackPanel Width="200">


### PR DESCRIPTION
## Summary
- corrige les menus contextuels et textes du chat et de l'historique avec des formulations françaises appropriées
- remplace les mentions d'« overload » par « surcharge » dans la recherche de rendez-vous et les paramètres système
- harmonise les messages automatiques et l'étiquette « Hors ligne » pour les utilisateurs

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f75e23dc8c8324a0ccfbe52aa6fd9e