### PR TITLE
Traduction des pages Razor en français

### DIFF
--- a/Serveur/Pages/Error.cshtml
+++ b/Serveur/Pages/Error.cshtml
@@ -1,26 +1,26 @@
 ﻿@page
 @model ErrorModel
 @{
-    ViewData["Title"] = "Error";
+    ViewData["Title"] = "Erreur";
 }
 
-<h1 class="text-danger">Error.</h1>
-<h2 class="text-danger">An error occurred while processing your request.</h2>
+<h1 class="text-danger">Erreur.</h1>
+<h2 class="text-danger">Une erreur s'est produite lors du traitement de votre demande.</h2>
 
 @if (Model.ShowRequestId)
 {
     <p>
-        <strong>Request ID:</strong> <code>@Model.RequestId</code>
+        <strong>ID de la requête :</strong> <code>@Model.RequestId</code>
     </p>
 }
 
-<h3>Development Mode</h3>
+<h3>Mode développement</h3>
 <p>
-    Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred.
+    Le passage à l'environnement de <strong>développement</strong> affiche des informations détaillées sur l'erreur survenue.
 </p>
 <p>
-    <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
-    It can result in displaying sensitive information from exceptions to end users.
-    For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
-    and restarting the app.
+    <strong>L'environnement de développement ne doit pas être activé pour les applications déployées.</strong>
+    Cela peut entraîner l'affichage d'informations sensibles issues des exceptions aux utilisateurs finaux.
+    Pour le débogage local, activez l'environnement <strong>Development</strong> en définissant la variable d'environnement <strong>ASPNETCORE_ENVIRONMENT</strong> sur <strong>Development</strong>
+    puis redémarrez l'application.
 </p>

--- a/Serveur/Pages/Index.cshtml
+++ b/Serveur/Pages/Index.cshtml
@@ -1,10 +1,10 @@
 ﻿@page
 @model IndexModel
 @{
-    ViewData["Title"] = "Home page";
+    ViewData["Title"] = "Accueil";
 }
 
 <div class="text-center">
-    <h1 class="display-4">Welcome</h1>
-    <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+    <h1 class="display-4">Bienvenue</h1>
+    <p>Découvrez comment <a href="https://learn.microsoft.com/aspnet/core">créer des applications web avec ASP.NET Core</a>.</p>
 </div>

--- a/Serveur/Pages/Privacy.cshtml
+++ b/Serveur/Pages/Privacy.cshtml
@@ -1,8 +1,8 @@
 ﻿@page
 @model PrivacyModel
 @{
-    ViewData["Title"] = "Privacy Policy";
+    ViewData["Title"] = "Politique de confidentialité";
 }
 <h1>@ViewData["Title"]</h1>
 
-<p>Use this page to detail your site's privacy policy.</p>
+<p>Utilisez cette page pour détailler la politique de confidentialité de votre site.</p>

--- a/Serveur/Pages/Shared/_Layout.cshtml
+++ b/Serveur/Pages/Shared/_Layout.cshtml
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -14,16 +14,16 @@
             <div class="container">
                 <a class="navbar-brand" asp-area="" asp-page="/Index">Serveur</a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
-                        aria-expanded="false" aria-label="Toggle navigation">
+                        aria-expanded="false" aria-label="Afficher ou masquer la navigation">
                     <span class="navbar-toggler-icon"></span>
                 </button>
                 <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
                     <ul class="navbar-nav flex-grow-1">
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-page="/Index">Home</a>
+                            <a class="nav-link text-dark" asp-area="" asp-page="/Index">Accueil</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-page="/Privacy">Privacy</a>
+                            <a class="nav-link text-dark" asp-area="" asp-page="/Privacy">Confidentialité</a>
                         </li>
                     </ul>
                 </div>
@@ -38,7 +38,7 @@
 
     <footer class="border-top footer text-muted">
         <div class="container">
-            &copy; 2025 - Serveur - <a asp-area="" asp-page="/Privacy">Privacy</a>
+            &copy; 2025 - Serveur - <a asp-area="" asp-page="/Privacy">Confidentialité</a>
         </div>
     </footer>
 


### PR DESCRIPTION
### Motivation
- Mettre l'interface par défaut en français conformément à la demande de localisation des textes UI.
- Améliorer l'accessibilité en traduisant l'attribut `aria-label` du bouton de navigation.
- Harmoniser les titres et messages système des pages Razor pour des utilisateurs francophones.

### Description
- Traduction et adaptation du layout dans `Serveur/Pages/Shared/_Layout.cshtml`, notamment `lang` passé à `fr`, le libellé `aria-label` et les libellés de navigation et du pied de page.
- Traduction du contenu de la page d'accueil dans `Serveur/Pages/Index.cshtml` (titre et paragraphe d'accueil).
- Traduction de la page de confidentialité dans `Serveur/Pages/Privacy.cshtml` (titre et texte explicatif).
- Traduction des libellés et du texte d'erreur dans `Serveur/Pages/Error.cshtml` (titre, messages, label ID de requête et message sur l'environnement de développement).

### Testing
- Aucun test automatisé n'a été exécuté pour ces modifications.
- Les fichiers modifiés ont été ajoutés et validés avec le message de commit `Traduire les pages Razor en français`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695378f95aa48324852da3ac857e647b)