### PR TITLE
Add idle-away status and enforce single-session logins

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -12,6 +12,7 @@ using System.IO;
 using Client.Pages;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.UI.Xaml.Input;
 
 namespace Client
 {
@@ -78,6 +79,7 @@ namespace Client
                 return;
 
             root.Loaded -= MainWindow_Loaded;
+            RegisterActivityHandlers(root);
 
             var machine = MachineConfig.Load();
 
@@ -201,6 +203,19 @@ namespace Client
                 await SyncUserSettingsAsync(root);
                 await DownloadMissingUserSettingsAsync();
             }
+        }
+
+        private void RegisterActivityHandlers(FrameworkElement root)
+        {
+            root.AddHandler(UIElement.PointerMovedEvent, new PointerEventHandler(OnUserActivity), true);
+            root.AddHandler(UIElement.PointerPressedEvent, new PointerEventHandler(OnUserActivity), true);
+            root.AddHandler(UIElement.PointerWheelChangedEvent, new PointerEventHandler(OnUserActivity), true);
+            root.AddHandler(UIElement.KeyDownEvent, new KeyEventHandler(OnUserActivity), true);
+        }
+
+        private void OnUserActivity(object sender, RoutedEventArgs e)
+        {
+            ChatService.ReportUserActivity();
         }
 
         private static async Task<string?> PromptForUsernameAsync(XamlRoot xamlRoot)

--- a/Client/Models/UserInfo.cs
+++ b/Client/Models/UserInfo.cs
@@ -15,6 +15,7 @@ namespace Client.Models
         private string _colorUserName = string.Empty;
         private string _accentAwareColorUserName = string.Empty;
         private bool _usesAccentContrast;
+        private string _status = string.Empty;
 
         public UserInfo()
         {
@@ -82,6 +83,21 @@ namespace Client.Models
             }
         }
 
+        public string Status
+        {
+            get => _status;
+            set
+            {
+                var newValue = value ?? string.Empty;
+                if (_status != newValue)
+                {
+                    _status = newValue;
+                    OnPropertyChanged(nameof(Status));
+                    OnPropertyChanged(nameof(RoomsDisplay));
+                }
+            }
+        }
+
         public string Note { get; set; } = string.Empty;
 
         /// <summary>
@@ -97,6 +113,7 @@ namespace Client.Models
         public string RoomsDisplay
             => Username == "A Tous" || Username == "Secrétariat"
                 ? string.Join(", ", Rooms)
+                : !string.IsNullOrWhiteSpace(Status) ? Status
                 : Rooms.Count == 0 ? "Hors ligne" : string.Join(", ", Rooms);
 
         private void Rooms_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -153,6 +170,7 @@ namespace Client.Models
                 ColorUserName = ColorUserName,
                 Note = Note,
                 IsOnline = IsOnline,
+                Status = Status,
                 CanRenameLocalUser = CanRenameLocalUser
             };
 

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -72,6 +72,10 @@ namespace Client.Services
         private Timer? _reconnectTimer;
         private Timer? _reconnectCountdownTimer;
         private int _reconnectCountdown;
+        private Timer? _idleTimer;
+        private readonly TimeSpan _idleThreshold = TimeSpan.FromMinutes(3);
+        private DateTime _lastActivityUtc = DateTime.UtcNow;
+        private bool _isAway;
         public event Action<int>? ReconnectCountdownChanged;
         private bool _isConnecting;
         public bool EnableReconnect { get; set; } = true;
@@ -417,6 +421,8 @@ namespace Client.Services
                     }
                 }
 
+                StopIdleMonitor();
+
                 foreach (var u in ConnectedUsers)
                 {
                     u.IsOnline = false;
@@ -450,6 +456,16 @@ namespace Client.Services
                 });
             });
 
+            connection.On<string>("ForceLogout", reason =>
+            {
+                Dispatcher?.TryEnqueue(async () =>
+                {
+                    ShowToast(string.IsNullOrWhiteSpace(reason)
+                        ? "Vous avez été déconnecté."
+                        : reason);
+                    await DisconnectAsync();
+                });
+            });
 
             connection.On<List<UserInfo>>("UserListUpdated", users =>
             {
@@ -640,6 +656,8 @@ namespace Client.Services
                 await connection.StartAsync();
                 await connection.InvokeAsync("RegisterUser", username, ToServerAvatar(avatar), room, color);
                 StopReconnectTimer();
+                ResetIdleStatus();
+                StartIdleMonitor();
             }
             catch (Exception ex)
             {
@@ -1881,6 +1899,7 @@ namespace Client.Services
                             DisplayName = name,
                             ColorUserName = visibleToAll ? "Blue" : "Green",
                             IsOnline = true,
+                            Status = string.Empty,
                             Note = string.Empty
                         });
                     }
@@ -1895,6 +1914,7 @@ namespace Client.Services
             if (disableReconnect)
                 EnableReconnect = false;
             StopReconnectTimer();
+            StopIdleMonitor();
             if (Connection != null)
             {
                 try
@@ -1907,6 +1927,66 @@ namespace Client.Services
                 }
             }
             _initialized = false;
+        }
+
+        public void ReportUserActivity()
+        {
+            _lastActivityUtc = DateTime.UtcNow;
+            if (_isAway)
+            {
+                _ = UpdateUserStatusAsync(false);
+            }
+        }
+
+        private void StartIdleMonitor()
+        {
+            _idleTimer?.Dispose();
+            _idleTimer = new Timer(async _ => await CheckIdleAsync(), null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
+        }
+
+        private void StopIdleMonitor()
+        {
+            _idleTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+            _idleTimer?.Dispose();
+            _idleTimer = null;
+            _isAway = false;
+        }
+
+        private void ResetIdleStatus()
+        {
+            _lastActivityUtc = DateTime.UtcNow;
+            _isAway = false;
+        }
+
+        private async Task CheckIdleAsync()
+        {
+            if (string.IsNullOrWhiteSpace(_username))
+                return;
+
+            if (DateTime.UtcNow - _lastActivityUtc < _idleThreshold)
+                return;
+
+            await UpdateUserStatusAsync(true);
+        }
+
+        private async Task UpdateUserStatusAsync(bool isAway)
+        {
+            if (_isAway == isAway)
+                return;
+
+            if (!TryGetActiveConnection(out var connection))
+                return;
+
+            var status = isAway ? "Absent" : string.Empty;
+            try
+            {
+                await connection.InvokeAsync("UpdateUserStatus", _username, status);
+                _isAway = isAway;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"❌ Erreur MAJ statut utilisateur : {ex.Message}");
+            }
         }
 
         public async Task RefreshGroupsAsync()

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -30,6 +30,7 @@ namespace ChatServeur
                 DisplayName = "A Tous",
                 ColorUserName = "Red",
                 IsOnline = true,
+                Status = string.Empty,
                 Note = string.Empty
             },
             new UserInfo
@@ -41,6 +42,7 @@ namespace ChatServeur
                 DisplayName = "Secrétariat",
                 ColorUserName = "Blue",
                 IsOnline = true,
+                Status = string.Empty,
                 Note = string.Empty
             }
         };
@@ -109,6 +111,7 @@ namespace ChatServeur
                     DisplayName = u.DisplayName,
                     ColorUserName = u.ColorUserName,
                     IsOnline = u.IsOnline,
+                    Status = string.Empty,
                     Note = u.Note
                 };
             }
@@ -196,6 +199,7 @@ namespace ChatServeur
 
                         user.IsOnline = false;
                         user.Rooms.Clear();
+                        user.Status = string.Empty;
                         AllUsers[user.Username] = user;
 
                         var dbUser = await _db.KnownUsers.FirstOrDefaultAsync(u => u.Username == user.Username);
@@ -257,8 +261,22 @@ namespace ChatServeur
                     DisplayName = username,
                     ColorUserName = color,
                     IsOnline = true,
+                    Status = string.Empty,
                     Note = string.Empty
                 };
+
+                if (TryGetConnectionEntry(username, out var existingKey, out var existingConnections))
+                {
+                    var otherConnections = existingConnections.Where(id => id != Context.ConnectionId).ToList();
+                    if (otherConnections.Count > 0)
+                    {
+                        await Clients.Clients(otherConnections).SendAsync(
+                            "ForceLogout",
+                            "Ce compte est déjà connecté sur un autre poste. Veuillez vous connecter avec un autre utilisateur.");
+                    }
+
+                    _userToConnectionId[existingKey] = new HashSet<string>();
+                }
 
                 ConnectedUsers[Context.ConnectionId] = user;
                 if (!_userToConnectionId.TryGetValue(username, out var set))
@@ -313,6 +331,29 @@ namespace ChatServeur
                 _logger.LogError(ex, "SER11: Failed to register user {Username}.", username);
                 throw;
             }
+        }
+
+        public async Task UpdateUserStatus(string username, string status)
+        {
+            EnsureUsersLoaded();
+
+            if (!ConnectedUsers.TryGetValue(Context.ConnectionId, out var user))
+            {
+                _logger.LogWarning("SER15: Status update ignored - connection not registered.");
+                return;
+            }
+
+            if (!string.Equals(user.Username, username, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning("SER16: Status update ignored for mismatched user {Username}.", username);
+                return;
+            }
+
+            user.Status = status?.Trim() ?? string.Empty;
+            AllUsers[user.Username] = user;
+
+            var userList = BaseUsers.Concat(AllUsers.Values).ToList();
+            await Clients.All.SendAsync("UserListUpdated", userList);
         }
 
 

--- a/Serveur/Models/UserInfo.cs
+++ b/Serveur/Models/UserInfo.cs
@@ -11,6 +11,7 @@ namespace ChatServeur
         public string DisplayName { get; set; } = string.Empty;
         public string ColorUserName { get; set; } = string.Empty;
         public bool IsOnline { get; set; }
+        public string Status { get; set; } = string.Empty;
         public string Note { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
### Motivation
- Mark users as "Absent" after 3 minutes of no mouse/keyboard activity so presence is more accurate.
- Prevent the same username from being simultaneously connected from multiple machines by disconnecting prior sessions.
- Surface the per-user status in the client user list so operators see the away state immediately.

### Description
- Introduced a `Status` field on server and client `UserInfo` (files: `Serveur/Models/UserInfo.cs`, `Client/Models/UserInfo.cs`) and updated `RoomsDisplay` to show `Status` when set.
- Server: updated `RegisterUser` in `Serveur/Hubs/ChatHub.cs` to notify and force previous connections to log out via a new `ForceLogout` client event and added a `UpdateUserStatus` hub method to accept status updates.
- Client: added idle monitoring in `Client/Services/SignalRService.cs` with a 3-minute `_idleThreshold`, timers and `ReportUserActivity`/`UpdateUserStatusAsync` to invoke `UpdateUserStatus` on the hub, and a `ForceLogout` handler that shows a toast and disconnects.
- UI glue: `Client/App.xaml.cs` now registers pointer and key event handlers and calls `ChatService.ReportUserActivity()` to reset idle timers on user activity.

### Testing
- No automated tests were run for this change.
- Please run the project's unit/integration tests and exercise client/server interactions (connect, connect same user from second client, leave client idle for 3 minutes) to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695518eee7288324b1e9d727de0f1db1)