### PR TITLE
Always call DisconnectAsync on user change and logout

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -397,8 +397,7 @@ namespace Client
 
             try
             {
-                if (ChatService.Connection != null)
-                    await ChatService.DisconnectAsync();
+                await ChatService.DisconnectAsync();
             }
             catch (Exception ex)
             {
@@ -435,8 +434,7 @@ namespace Client
         {
             try
             {
-                if (ChatService.Connection != null)
-                    await ChatService.DisconnectAsync();
+                await ChatService.DisconnectAsync();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
### Motivation
- Switching users or logging out could leave client state partially initialized because disconnect logic was skipped when `ChatService.Connection` was null. 
- The intent is to ensure the connection/service cleanup runs reliably so timers and internal flags are reset before reinitializing or clearing local data.

### Description
- Unconditionally call `await ChatService.DisconnectAsync()` in `ChangeUserAsync` and `LogoutAsync` instead of guarding with `if (ChatService.Connection != null)` in `Client/App.xaml.cs`.
- This forces the service-level shutdown logic in `SignalRService.DisconnectAsync()` to run even when there is no active `Connection` object.
- Rest of the flow remains unchanged: settings are reloaded, appearance applied and `ChatService.InitializeAsync()` is invoked after user change.

### Testing
- No automated tests were executed for this change. 
- Please run integration or manual scenarios covering user switch and logout to verify timers, user lists and local state are reset as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696266682d0083249d65ab3d00392c51)