### PR TITLE
Prevent duplicate user sessions by rejecting incoming connection

### DIFF
--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -270,9 +270,10 @@ namespace ChatServeur
                     var otherConnections = existingConnections.Where(id => id != Context.ConnectionId).ToList();
                     if (otherConnections.Count > 0)
                     {
-                        await Clients.Clients(otherConnections).SendAsync(
+                        await Clients.Client(Context.ConnectionId).SendAsync(
                             "ForceLogout",
                             "Ce compte est déjà connecté sur un autre poste. Veuillez vous connecter avec un autre utilisateur.");
+                        return;
                     }
 
                     _userToConnectionId[existingKey] = new HashSet<string>();


### PR DESCRIPTION
### Motivation
- Prevent a user account from being simultaneously used from two different workstations.
- Avoid forcibly disconnecting an already connected session when a duplicate login attempt occurs.
- Provide a clear notification to the incoming client when the username is already connected elsewhere.

### Description
- Updated `RegisterUser` in `Serveur/Hubs/ChatHub.cs` to detect existing connections and notify the incoming connection via the `ForceLogout` message. 
- Replaced `Clients.Clients(otherConnections)` with `Clients.Client(Context.ConnectionId)` and added an early `return` to abort registration for the incoming duplicate session. 
- This change prevents clearing the server-side connection mapping for the already-connected user and preserves the existing session.

### Testing
- No automated tests were executed as part of this change.
- No CI runs were triggered during the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696268436a8c8324a2ee91466827eeec)