### PR TITLE
Update account menu for logout state

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -427,6 +427,7 @@ namespace Client
             {
                 var chat = mw.ShowChatPage();
                 chat?.RefreshUsername();
+                mw.SetAccountState(true);
             }
         }
 
@@ -442,6 +443,11 @@ namespace Client
             }
 
             ChatService.ClearLocalData();
+
+            if (MainWindow is MainWindow mw)
+            {
+                mw.SetAccountState(false);
+            }
         }
 
         private Window? m_window;

--- a/Client/MainWindow.xaml
+++ b/Client/MainWindow.xaml
@@ -75,8 +75,8 @@
                 </Button.Content>
                 <Button.Flyout>
                     <MenuFlyout>
-                        <MenuFlyoutItem Text="Changer de compte" Click="ChangeAccount_Click" />
-                        <MenuFlyoutItem Text="Déconnexion" Click="Logout_Click" />
+                        <MenuFlyoutItem x:Name="ChangeAccountMenuItem" Text="Changer de compte" Click="ChangeAccount_Click" />
+                        <MenuFlyoutItem x:Name="LogoutMenuItem" Text="Déconnexion" Click="Logout_Click" />
                     </MenuFlyout>
                 </Button.Flyout>
             </Button>

--- a/Client/MainWindow.xaml.cs
+++ b/Client/MainWindow.xaml.cs
@@ -121,6 +121,17 @@ namespace Client
             }
         }
 
+        public void SetAccountState(bool isConnected)
+        {
+            ChangeAccountMenuItem.Text = isConnected ? "Changer de compte" : "Choisir un compte";
+            LogoutMenuItem.Visibility = isConnected ? Visibility.Visible : Visibility.Collapsed;
+
+            if (!isConnected)
+            {
+                PersonPic.Initials = string.Empty;
+            }
+        }
+
         private async void ChangeAccount_Click(object sender, RoutedEventArgs e)
         {
             var appFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat");


### PR DESCRIPTION
### Motivation
- Allow the account flyout to change when the user logs out so the UI no longer shows a logged-in avatar or the "Déconnexion" item.
- Replace the "Changer de compte" label with a neutral "Choisir un compte" when disconnected, and make it possible to programmatically toggle those states.
- Make `PersonPic` neutral when logged out by clearing its initials.

### Description
- Add `x:Name` attributes to the account flyout items in `Client/MainWindow.xaml` (`ChangeAccountMenuItem` and `LogoutMenuItem`) to target them from code.
- Add `SetAccountState(bool isConnected)` to `Client/MainWindow.xaml.cs` which sets `ChangeAccountMenuItem.Text`, toggles `LogoutMenuItem.Visibility`, and clears `PersonPic.Initials` when `isConnected` is false.
- Invoke `SetAccountState(true)` after `ChangeUserAsync` completes and invoke `SetAccountState(false)` in `LogoutAsync` inside `Client/App.xaml.cs` so the menu state updates on login/logout.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cc10b833c83248e327acf8835ef76)