### PR TITLE
Add UI progress and server/client approval flow for multi-workstation login conflicts

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -249,6 +249,47 @@ namespace Client
             }
         }
 
+        public async Task<string?> PromptForAccountSelectionAsync()
+        {
+            if (MainWindow?.Content is not FrameworkElement root)
+                return null;
+
+            var appFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat");
+            Directory.CreateDirectory(appFolder);
+            var settingsFiles = Directory.GetFiles(appFolder, "*_settings.json");
+            var users = settingsFiles
+                .Select(f => Path.GetFileNameWithoutExtension(f)?.Replace("_settings", string.Empty) ?? string.Empty)
+                .Select(AppSettings.SanitizeUserNameForFile)
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var dialog = new ContentDialog
+            {
+                Title = "Choisir l'utilisateur",
+                PrimaryButtonText = "OK",
+                CloseButtonText = "Annuler",
+                XamlRoot = root.XamlRoot
+            };
+
+            var stack = new StackPanel { Spacing = 10 };
+            var combo = new ComboBox { ItemsSource = users, PlaceholderText = "Utilisateur" };
+            var newBox = new TextBox { PlaceholderText = "Nouvel utilisateur" };
+            stack.Children.Add(combo);
+            stack.Children.Add(newBox);
+            dialog.Content = stack;
+
+            var result = await dialog.ShowAsync();
+            if (result != ContentDialogResult.Primary)
+                return null;
+
+            var name = !string.IsNullOrWhiteSpace(newBox.Text)
+                ? newBox.Text.Trim()
+                : combo.SelectedItem as string;
+
+            return string.IsNullOrWhiteSpace(name) ? null : name;
+        }
+
         public static void ApplySavedAppearance(FrameworkElement root)
         {
             var theme = AppSettings.Get("AppTheme", "Dark");

--- a/Client/MainWindow.xaml.cs
+++ b/Client/MainWindow.xaml.cs
@@ -2,12 +2,10 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
 using System.Linq;
-using System.IO;
 using Microsoft.UI.Windowing;
 using WinRT.Interop;
 using Windows.UI;
 using Microsoft.UI;
-using Client.Helpers;
 using Windows.Graphics;
 using Windows.Foundation;
 
@@ -134,39 +132,13 @@ namespace Client
 
         private async void ChangeAccount_Click(object sender, RoutedEventArgs e)
         {
-            var appFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat");
-            Directory.CreateDirectory(appFolder);
-            var settingsFiles = Directory.GetFiles(appFolder, "*_settings.json");
-            var users = settingsFiles
-                .Select(f => Path.GetFileNameWithoutExtension(f)?.Replace("_settings", string.Empty) ?? string.Empty)
-                .Select(AppSettings.SanitizeUserNameForFile)
-                .Where(name => !string.IsNullOrWhiteSpace(name))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList();
+            if (Application.Current is not App app)
+                return;
 
-            var dialog = new ContentDialog
+            var name = await app.PromptForAccountSelectionAsync();
+            if (!string.IsNullOrWhiteSpace(name))
             {
-                Title = "Choisir l'utilisateur",
-                PrimaryButtonText = "OK",
-                CloseButtonText = "Annuler",
-                XamlRoot = this.Content.XamlRoot
-            };
-
-            var stack = new StackPanel { Spacing = 10 };
-            var combo = new ComboBox { ItemsSource = users, PlaceholderText = "Utilisateur" };
-            var newBox = new TextBox { PlaceholderText = "Nouvel utilisateur" };
-            stack.Children.Add(combo);
-            stack.Children.Add(newBox);
-            dialog.Content = stack;
-
-            var result = await dialog.ShowAsync();
-            if (result == ContentDialogResult.Primary)
-            {
-                var name = !string.IsNullOrWhiteSpace(newBox.Text) ? newBox.Text.Trim() : combo.SelectedItem as string;
-                if (!string.IsNullOrWhiteSpace(name))
-                {
-                    await ((App)Application.Current).ChangeUserAsync(name);
-                }
+                await app.ChangeUserAsync(name);
             }
         }
 

--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using System.Threading;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using Windows.ApplicationModel.Chat;
 using Microsoft.VisualBasic;
 using Newtonsoft.Json;
@@ -79,6 +80,8 @@ namespace Client.Services
         public event Action<int>? ReconnectCountdownChanged;
         private bool _isConnecting;
         public bool EnableReconnect { get; set; } = true;
+        private readonly Dictionary<string, ContentDialog> _loginConflictDialogs = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, DispatcherQueueTimer> _loginConflictTimers = new(StringComparer.OrdinalIgnoreCase);
 
         public bool IsHistoryLoaded => _historyLoaded;
         public IReadOnlyList<UserInfo> KnownUsers => _lastServerUserList;
@@ -467,6 +470,74 @@ namespace Client.Services
                 });
             });
 
+            connection.On<string, string, string, int>("LoginConflictPending", (requestId, username, existingMachine, delaySeconds) =>
+            {
+                Dispatcher?.TryEnqueue(async () =>
+                {
+                    await ShowLoginConflictPendingDialogAsync(requestId, username, existingMachine, delaySeconds);
+                });
+            });
+
+            connection.On<string, string, string, int>("LoginConflictRequested", (requestId, username, requestingMachine, delaySeconds) =>
+            {
+                Dispatcher?.TryEnqueue(async () =>
+                {
+                    await ShowLoginConflictRequestDialogAsync(requestId, username, requestingMachine, delaySeconds);
+                });
+            });
+
+            connection.On<string, string>("LoginConflictApproved", (requestId, username) =>
+            {
+                Dispatcher?.TryEnqueue(async () =>
+                {
+                    CloseLoginConflictDialog(requestId);
+                    ShowToast($"Connexion autorisée pour {username}.");
+                    await CompleteLoginAfterApprovalAsync(requestId);
+                });
+            });
+
+            connection.On<string, string>("LoginConflictDenied", (requestId, username) =>
+            {
+                Dispatcher?.TryEnqueue(async () =>
+                {
+                    CloseLoginConflictDialog(requestId);
+                    ShowToast($"Connexion refusée pour {username}.");
+                    await HandleLoginConflictDeniedAsync();
+                });
+            });
+
+            connection.On<string, string, string>("LoginConflictResolved", (requestId, username, result) =>
+            {
+                Dispatcher?.TryEnqueue(() =>
+                {
+                    CloseLoginConflictDialog(requestId);
+                    if (string.Equals(result, "denied", StringComparison.OrdinalIgnoreCase))
+                    {
+                        ShowToast($"Connexion refusée pour {username}.");
+                    }
+                    else if (string.Equals(result, "approved", StringComparison.OrdinalIgnoreCase))
+                    {
+                        ShowToast($"Connexion transférée pour {username}.");
+                    }
+                });
+            });
+
+            connection.On<string, int>("LoginConflictTooEarly", (requestId, delaySeconds) =>
+            {
+                Dispatcher?.TryEnqueue(() =>
+                {
+                    ShowToast($"Veuillez attendre {delaySeconds} secondes avant de répondre.");
+                });
+            });
+
+            connection.On<string, string>("LoginConflictTimedOut", (requestId, username) =>
+            {
+                Dispatcher?.TryEnqueue(() =>
+                {
+                    ShowToast($"Délai dépassé pour {username}, décision transférée à l'autre poste.");
+                });
+            });
+
             connection.On<List<UserInfo>>("UserListUpdated", users =>
             {
                 Dispatcher?.TryEnqueue(async () =>
@@ -654,7 +725,7 @@ namespace Client.Services
             try
             {
                 await connection.StartAsync();
-                await connection.InvokeAsync("RegisterUser", username, ToServerAvatar(avatar), room, color);
+                await connection.InvokeAsync("RegisterUser", username, ToServerAvatar(avatar), room, color, Environment.MachineName);
                 StopReconnectTimer();
                 ResetIdleStatus();
                 StartIdleMonitor();
@@ -854,6 +925,231 @@ namespace Client.Services
 
             await ConnectAsync(_username, _avatar, RoomName, _color);
         }
+
+        private async Task ShowLoginConflictPendingDialogAsync(string requestId, string username, string existingMachine, int delaySeconds)
+        {
+            if (!TryGetDialogRoot(out var root))
+                return;
+
+            var machineLabel = string.IsNullOrWhiteSpace(existingMachine) ? "un autre poste" : existingMachine;
+            var message = new TextBlock
+            {
+                Text = $"{username} est déjà connecté sur {machineLabel}. Voulez-vous quand même vous connecter ?",
+                TextWrapping = TextWrapping.Wrap
+            };
+            var countdown = new TextBlock
+            {
+                Text = $"Vous pourrez répondre dans {delaySeconds} s.",
+                TextWrapping = TextWrapping.Wrap
+            };
+            var progress = new ProgressBar
+            {
+                Minimum = 0,
+                Maximum = delaySeconds,
+                Value = 0,
+                Height = 6
+            };
+            var panel = new StackPanel { Spacing = 8 };
+            panel.Children.Add(message);
+            panel.Children.Add(countdown);
+            panel.Children.Add(progress);
+
+            var dialog = new ContentDialog
+            {
+                Title = "Connexion déjà active",
+                Content = panel,
+                PrimaryButtonText = "Oui",
+                SecondaryButtonText = "Non",
+                XamlRoot = root.XamlRoot
+            };
+            dialog.IsPrimaryButtonEnabled = false;
+            dialog.IsSecondaryButtonEnabled = false;
+
+            RegisterLoginConflictDialog(requestId, dialog);
+
+            StartLoginConflictCountdown(requestId, delaySeconds, remaining =>
+            {
+                if (remaining > 0)
+                {
+                    countdown.Text = $"Vous pourrez répondre dans {remaining} s.";
+                    progress.Value = delaySeconds - remaining;
+                    return;
+                }
+
+                countdown.Text = "Vous pouvez répondre.";
+                progress.Value = delaySeconds;
+                dialog.IsPrimaryButtonEnabled = true;
+                dialog.IsSecondaryButtonEnabled = true;
+            });
+
+            var result = await dialog.ShowAsync();
+            StopLoginConflictCountdown(requestId);
+
+            if (result == ContentDialogResult.Primary)
+            {
+                await RespondToLoginConflictAsync(requestId, true);
+            }
+            else if (result == ContentDialogResult.Secondary)
+            {
+                await RespondToLoginConflictAsync(requestId, false);
+            }
+        }
+
+        private async Task ShowLoginConflictRequestDialogAsync(string requestId, string username, string requestingMachine, int delaySeconds)
+        {
+            if (!TryGetDialogRoot(out var root))
+                return;
+
+            var machineLabel = string.IsNullOrWhiteSpace(requestingMachine) ? "un autre poste" : requestingMachine;
+            var message = new TextBlock
+            {
+                Text = $"Le poste {machineLabel} veut se connecter avec le compte {username}. Autoriser ?",
+                TextWrapping = TextWrapping.Wrap
+            };
+            var countdown = new TextBlock
+            {
+                Text = $"Vous avez {delaySeconds} s pour répondre.",
+                TextWrapping = TextWrapping.Wrap
+            };
+            var progress = new ProgressBar
+            {
+                Minimum = 0,
+                Maximum = delaySeconds,
+                Value = 0,
+                Height = 6
+            };
+            var panel = new StackPanel { Spacing = 8 };
+            panel.Children.Add(message);
+            panel.Children.Add(countdown);
+            panel.Children.Add(progress);
+
+            var dialog = new ContentDialog
+            {
+                Title = "Demande de connexion",
+                Content = panel,
+                PrimaryButtonText = "Oui",
+                SecondaryButtonText = "Non",
+                XamlRoot = root.XamlRoot
+            };
+
+            RegisterLoginConflictDialog(requestId, dialog);
+
+            StartLoginConflictCountdown(requestId, delaySeconds, remaining =>
+            {
+                if (remaining > 0)
+                {
+                    countdown.Text = $"Vous avez {remaining} s pour répondre.";
+                    progress.Value = delaySeconds - remaining;
+                    return;
+                }
+
+                countdown.Text = $"Délai expiré, décision transférée au poste {machineLabel}.";
+                progress.Value = delaySeconds;
+                dialog.IsPrimaryButtonEnabled = false;
+                dialog.IsSecondaryButtonEnabled = false;
+            });
+
+            var result = await dialog.ShowAsync();
+            StopLoginConflictCountdown(requestId);
+
+            if (result == ContentDialogResult.Primary)
+            {
+                await RespondToLoginConflictAsync(requestId, true);
+            }
+            else if (result == ContentDialogResult.Secondary)
+            {
+                await RespondToLoginConflictAsync(requestId, false);
+            }
+        }
+
+        private void RegisterLoginConflictDialog(string requestId, ContentDialog dialog)
+        {
+            _loginConflictDialogs[requestId] = dialog;
+        }
+
+        private void StartLoginConflictCountdown(string requestId, int delaySeconds, Action<int> onTick)
+        {
+            if (Dispatcher is not DispatcherQueue dispatcher)
+                return;
+
+            var remaining = Math.Max(0, delaySeconds);
+            onTick(remaining);
+
+            var timer = dispatcher.CreateTimer();
+            timer.Interval = TimeSpan.FromSeconds(1);
+            timer.Tick += (_, __) =>
+            {
+                remaining--;
+                onTick(remaining);
+                if (remaining <= 0)
+                {
+                    timer.Stop();
+                }
+            };
+
+            _loginConflictTimers[requestId] = timer;
+            timer.Start();
+        }
+
+        private void StopLoginConflictCountdown(string requestId)
+        {
+            if (_loginConflictTimers.Remove(requestId, out var timer))
+            {
+                timer.Stop();
+            }
+        }
+
+        private void CloseLoginConflictDialog(string requestId)
+        {
+            StopLoginConflictCountdown(requestId);
+            if (_loginConflictDialogs.Remove(requestId, out var dialog))
+            {
+                dialog.Hide();
+            }
+        }
+
+        private static bool TryGetDialogRoot(out FrameworkElement root)
+        {
+            if (App.MainWindow?.Content is FrameworkElement rootElement)
+            {
+                root = rootElement;
+                return true;
+            }
+
+            root = null!;
+            return false;
+        }
+
+        private async Task HandleLoginConflictDeniedAsync()
+        {
+            await DisconnectAsync();
+
+            if (Application.Current is not App app)
+                return;
+
+            var username = await app.PromptForAccountSelectionAsync();
+            if (!string.IsNullOrWhiteSpace(username))
+            {
+                await app.ChangeUserAsync(username);
+            }
+            else if (App.MainWindow is MainWindow mainWindow)
+            {
+                mainWindow.SetAccountState(false);
+            }
+        }
+
+        public async Task RespondToLoginConflictAsync(string requestId, bool approve)
+        {
+            var connection = GetRequiredConnection();
+            await connection.InvokeAsync("RespondToLoginConflict", requestId, approve);
+        }
+
+        public async Task CompleteLoginAfterApprovalAsync(string requestId)
+        {
+            var connection = GetRequiredConnection();
+            await connection.InvokeAsync("CompleteLoginAfterApproval", requestId);
+        }
+
         private void ShowToast(string message)
         {
             var payload = $"""

--- a/Serveur/Hubs/ChatHub.cs
+++ b/Serveur/Hubs/ChatHub.cs
@@ -13,11 +13,28 @@ namespace ChatServeur
 {
     public class ChatHub : Hub
     {
+        private sealed class PendingLoginRequest
+        {
+            public string RequestId { get; init; } = string.Empty;
+            public string Username { get; init; } = string.Empty;
+            public string Avatar { get; init; } = string.Empty;
+            public string Room { get; init; } = string.Empty;
+            public string Color { get; init; } = string.Empty;
+            public string MachineName { get; init; } = string.Empty;
+            public string RequestingConnectionId { get; init; } = string.Empty;
+            public List<string> ExistingConnectionIds { get; } = new();
+            public string ExistingMachineName { get; init; } = string.Empty;
+            public DateTime CreatedAtUtc { get; init; } = DateTime.UtcNow;
+            public bool ApprovedByExisting { get; set; }
+        }
+
         private static readonly Dictionary<string, UserInfo> ConnectedUsers = new();
         private static readonly Dictionary<string, HashSet<string>> _userToConnectionId = new();
         private static readonly Dictionary<string, UserInfo> AllUsers = new();
         private static readonly Dictionary<string, HashSet<string>> GroupMembers = new();
+        private static readonly Dictionary<string, PendingLoginRequest> PendingLoginRequests = new();
         private static bool _usersLoaded;
+        private const int LoginConflictDelaySeconds = 10;
 
         private static readonly List<UserInfo> BaseUsers = new()
         {
@@ -225,12 +242,123 @@ namespace ChatServeur
                 }
             }
 
+            await HandlePendingLoginDisconnectAsync(Context.ConnectionId);
             await base.OnDisconnectedAsync(ex);
         }
 
-        public async Task RegisterUser(string username, string avatar, string room, string color)
+        private async Task HandlePendingLoginDisconnectAsync(string connectionId)
+        {
+            var requesterMatches = PendingLoginRequests.Values
+                .Where(r => string.Equals(r.RequestingConnectionId, connectionId, StringComparison.Ordinal))
+                .ToList();
+
+            foreach (var request in requesterMatches)
+            {
+                PendingLoginRequests.Remove(request.RequestId);
+                if (request.ExistingConnectionIds.Count > 0)
+                {
+                    await Clients.Clients(request.ExistingConnectionIds)
+                        .SendAsync("LoginConflictResolved", request.RequestId, request.Username, "canceled");
+                }
+            }
+
+            var existingMatches = PendingLoginRequests.Values
+                .Where(r => r.ExistingConnectionIds.Contains(connectionId))
+                .ToList();
+
+            foreach (var request in existingMatches)
+            {
+                request.ExistingConnectionIds.Remove(connectionId);
+                if (request.ExistingConnectionIds.Count == 0 && !request.ApprovedByExisting)
+                {
+                    request.ApprovedByExisting = true;
+                    await Clients.Client(request.RequestingConnectionId)
+                        .SendAsync("LoginConflictApproved", request.RequestId, request.Username);
+                }
+            }
+        }
+
+        private async Task RegisterUserCoreAsync(string username, string avatar, string room, string color, string machineName)
+        {
+            avatar = ToRelativeAvatar(avatar);
+            if (string.IsNullOrWhiteSpace(avatar))
+                avatar = "/Assets/utilisateur.png";
+            EnsureUsersLoaded();
+            _logger.LogInformation("RegisterUser invoked for {Username}.", username);
+
+            var rooms = new List<string>();
+            if (AllUsers.TryGetValue(username, out var existing) && existing.Rooms.Any())
+                rooms = existing.Rooms.Where(r => r != "Hors ligne").ToList();
+            if (!rooms.Contains(room))
+                rooms.Add(room);
+
+            var user = new UserInfo
+            {
+                ConnectionId = Context.ConnectionId,
+                Username = username,
+                Avatar = avatar,
+                Rooms = rooms,
+                DisplayName = username,
+                ColorUserName = color,
+                MachineName = machineName,
+                IsOnline = true,
+                Status = string.Empty,
+                Note = string.Empty
+            };
+
+            ConnectedUsers[Context.ConnectionId] = user;
+            if (!_userToConnectionId.TryGetValue(username, out var set))
+            {
+                set = new HashSet<string>();
+                _userToConnectionId[username] = set;
+            }
+            set.Add(Context.ConnectionId);
+            AllUsers[username] = user;
+
+            var dbUser = await _db.KnownUsers.FirstOrDefaultAsync(u => u.Username == username);
+            if (dbUser == null)
+            {
+                dbUser = new KnownUser { Username = username };
+                _db.KnownUsers.Add(dbUser);
+            }
+            dbUser.ConnectionId = Context.ConnectionId;
+            dbUser.Avatar = avatar;
+            dbUser.Room = string.Join(",", user.Rooms);
+            dbUser.DisplayName = username;
+            dbUser.ColorUserName = color;
+            dbUser.IsOnline = true;
+            dbUser.Note = string.Empty;
+            await _db.SaveChangesAsync();
+
+            await Groups.AddToGroupAsync(Context.ConnectionId, "A Tous");
+            if (!GroupMembers.ContainsKey("A Tous"))
+                GroupMembers["A Tous"] = new HashSet<string>();
+            GroupMembers["A Tous"].Add(username);
+
+            var groups = await _db.GroupMemberships
+                .Where(g => g.Username == username)
+                .Select(g => g.GroupName)
+                .ToListAsync();
+
+            foreach (var group in groups)
+            {
+                await Groups.AddToGroupAsync(Context.ConnectionId, group);
+                if (!GroupMembers.ContainsKey(group))
+                    GroupMembers[group] = new HashSet<string>();
+                GroupMembers[group].Add(username);
+            }
+
+            await Clients.All.SendAsync("UserConnected", user);
+
+            var userList = BaseUsers.Concat(AllUsers.Values).ToList();
+
+            await Clients.All.SendAsync("UserListUpdated", userList);
+        }
+
+        public async Task RegisterUser(string username, string avatar, string room, string color, string machineName)
         {
             username = username?.Trim() ?? string.Empty;
+            machineName = string.IsNullOrWhiteSpace(machineName) ? "ce poste" : machineName.Trim();
 
             if (string.IsNullOrWhiteSpace(username))
             {
@@ -240,98 +368,141 @@ namespace ChatServeur
 
             try
             {
-                avatar = ToRelativeAvatar(avatar);
-                if (string.IsNullOrWhiteSpace(avatar))
-                    avatar = "/Assets/utilisateur.png";
                 EnsureUsersLoaded();
-                _logger.LogInformation("RegisterUser invoked for {Username}.", username);
-
-                var rooms = new List<string>();
-                if (AllUsers.TryGetValue(username, out var existing) && existing.Rooms.Any())
-                    rooms = existing.Rooms.Where(r => r != "Hors ligne").ToList();
-                if (!rooms.Contains(room))
-                    rooms.Add(room);
-
-                var user = new UserInfo
-                {
-                    ConnectionId = Context.ConnectionId,
-                    Username = username,
-                    Avatar = avatar,
-                    Rooms = rooms,
-                    DisplayName = username,
-                    ColorUserName = color,
-                    IsOnline = true,
-                    Status = string.Empty,
-                    Note = string.Empty
-                };
 
                 if (TryGetConnectionEntry(username, out var existingKey, out var existingConnections))
                 {
                     var otherConnections = existingConnections.Where(id => id != Context.ConnectionId).ToList();
                     if (otherConnections.Count > 0)
                     {
-                        await Clients.Client(Context.ConnectionId).SendAsync(
-                            "ForceLogout",
-                            "Ce compte est déjà connecté sur un autre poste. Veuillez vous connecter avec un autre utilisateur.");
+                        var existingMachineName = otherConnections
+                            .Select(id => ConnectedUsers.TryGetValue(id, out var info) ? info.MachineName : string.Empty)
+                            .FirstOrDefault(name => !string.IsNullOrWhiteSpace(name)) ?? "un autre poste";
+
+                        var requestId = Guid.NewGuid().ToString("N");
+                        var request = new PendingLoginRequest
+                        {
+                            RequestId = requestId,
+                            Username = username,
+                            Avatar = avatar,
+                            Room = room,
+                            Color = color,
+                            MachineName = machineName,
+                            RequestingConnectionId = Context.ConnectionId,
+                            ExistingMachineName = existingMachineName
+                        };
+                        request.ExistingConnectionIds.AddRange(otherConnections);
+                        PendingLoginRequests[requestId] = request;
+
+                        await Clients.Client(Context.ConnectionId)
+                            .SendAsync("LoginConflictPending", requestId, username, existingMachineName, LoginConflictDelaySeconds);
+                        await Clients.Clients(otherConnections)
+                            .SendAsync("LoginConflictRequested", requestId, username, machineName, LoginConflictDelaySeconds);
                         return;
                     }
 
                     _userToConnectionId[existingKey] = new HashSet<string>();
                 }
 
-                ConnectedUsers[Context.ConnectionId] = user;
-                if (!_userToConnectionId.TryGetValue(username, out var set))
-                {
-                    set = new HashSet<string>();
-                    _userToConnectionId[username] = set;
-                }
-                set.Add(Context.ConnectionId);
-                AllUsers[username] = user;
-
-                var dbUser = await _db.KnownUsers.FirstOrDefaultAsync(u => u.Username == username);
-                if (dbUser == null)
-                {
-                    dbUser = new KnownUser { Username = username };
-                    _db.KnownUsers.Add(dbUser);
-                }
-                dbUser.ConnectionId = Context.ConnectionId;
-                dbUser.Avatar = avatar;
-                dbUser.Room = string.Join(",", user.Rooms);
-                dbUser.DisplayName = username;
-                dbUser.ColorUserName = color;
-                dbUser.IsOnline = true;
-                dbUser.Note = string.Empty;
-                await _db.SaveChangesAsync();
-
-                await Groups.AddToGroupAsync(Context.ConnectionId, "A Tous");
-                if (!GroupMembers.ContainsKey("A Tous"))
-                    GroupMembers["A Tous"] = new HashSet<string>();
-                GroupMembers["A Tous"].Add(username);
-
-                var groups = await _db.GroupMemberships
-                    .Where(g => g.Username == username)
-                    .Select(g => g.GroupName)
-                    .ToListAsync();
-
-                foreach (var group in groups)
-                {
-                    await Groups.AddToGroupAsync(Context.ConnectionId, group);
-                    if (!GroupMembers.ContainsKey(group))
-                        GroupMembers[group] = new HashSet<string>();
-                    GroupMembers[group].Add(username);
-                }
-
-                await Clients.All.SendAsync("UserConnected", user);
-
-                var userList = BaseUsers.Concat(AllUsers.Values).ToList();
-
-                await Clients.All.SendAsync("UserListUpdated", userList);
+                await RegisterUserCoreAsync(username, avatar, room, color, machineName);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "SER11: Failed to register user {Username}.", username);
                 throw;
             }
+        }
+
+        public async Task RespondToLoginConflict(string requestId, bool approve)
+        {
+            if (!PendingLoginRequests.TryGetValue(requestId, out var request))
+                return;
+
+            var elapsed = DateTime.UtcNow - request.CreatedAtUtc;
+            var isRequester = string.Equals(Context.ConnectionId, request.RequestingConnectionId, StringComparison.Ordinal);
+            var isExisting = request.ExistingConnectionIds.Contains(Context.ConnectionId);
+
+            if (!isRequester && !isExisting)
+                return;
+
+            if (isExisting)
+            {
+                if (elapsed > TimeSpan.FromSeconds(LoginConflictDelaySeconds))
+                {
+                    await Clients.Client(Context.ConnectionId)
+                        .SendAsync("LoginConflictTimedOut", request.RequestId, request.Username);
+                    return;
+                }
+
+                if (approve)
+                {
+                    request.ApprovedByExisting = true;
+                    await Clients.Client(request.RequestingConnectionId)
+                        .SendAsync("LoginConflictApproved", request.RequestId, request.Username);
+                    await Clients.Clients(request.ExistingConnectionIds)
+                        .SendAsync("LoginConflictResolved", request.RequestId, request.Username, "approved");
+                    return;
+                }
+
+                PendingLoginRequests.Remove(request.RequestId);
+                await Clients.Client(request.RequestingConnectionId)
+                    .SendAsync("LoginConflictDenied", request.RequestId, request.Username);
+                await Clients.Clients(request.ExistingConnectionIds)
+                    .SendAsync("LoginConflictResolved", request.RequestId, request.Username, "denied");
+                return;
+            }
+
+            if (elapsed < TimeSpan.FromSeconds(LoginConflictDelaySeconds))
+            {
+                await Clients.Client(request.RequestingConnectionId)
+                    .SendAsync("LoginConflictTooEarly", request.RequestId, LoginConflictDelaySeconds);
+                return;
+            }
+
+            if (approve)
+            {
+                PendingLoginRequests.Remove(request.RequestId);
+                await ForceDisconnectExistingAsync(request);
+                await RegisterUserCoreAsync(request.Username, request.Avatar, request.Room, request.Color, request.MachineName);
+                await Clients.Clients(request.ExistingConnectionIds)
+                    .SendAsync("LoginConflictResolved", request.RequestId, request.Username, "approved");
+                await Clients.Client(request.RequestingConnectionId)
+                    .SendAsync("LoginConflictApproved", request.RequestId, request.Username);
+                return;
+            }
+
+            PendingLoginRequests.Remove(request.RequestId);
+            await Clients.Client(request.RequestingConnectionId)
+                .SendAsync("LoginConflictDenied", request.RequestId, request.Username);
+            await Clients.Clients(request.ExistingConnectionIds)
+                .SendAsync("LoginConflictResolved", request.RequestId, request.Username, "denied");
+        }
+
+        public async Task CompleteLoginAfterApproval(string requestId)
+        {
+            if (!PendingLoginRequests.TryGetValue(requestId, out var request))
+                return;
+
+            if (!request.ApprovedByExisting)
+                return;
+
+            if (!string.Equals(request.RequestingConnectionId, Context.ConnectionId, StringComparison.Ordinal))
+                return;
+
+            PendingLoginRequests.Remove(request.RequestId);
+            await ForceDisconnectExistingAsync(request);
+            await RegisterUserCoreAsync(request.Username, request.Avatar, request.Room, request.Color, request.MachineName);
+            await Clients.Clients(request.ExistingConnectionIds)
+                .SendAsync("LoginConflictResolved", request.RequestId, request.Username, "approved");
+        }
+
+        private async Task ForceDisconnectExistingAsync(PendingLoginRequest request)
+        {
+            if (request.ExistingConnectionIds.Count == 0)
+                return;
+
+            var reason = $"Connexion ouverte sur {request.MachineName}.";
+            await Clients.Clients(request.ExistingConnectionIds).SendAsync("ForceLogout", reason);
         }
 
         public async Task UpdateUserStatus(string username, string status)

--- a/Serveur/Models/UserInfo.cs
+++ b/Serveur/Models/UserInfo.cs
@@ -10,6 +10,7 @@ namespace ChatServeur
         public List<string> Rooms { get; set; } = new();
         public string DisplayName { get; set; } = string.Empty;
         public string ColorUserName { get; set; } = string.Empty;
+        public string MachineName { get; set; } = string.Empty;
         public bool IsOnline { get; set; }
         public string Status { get; set; } = string.Empty;
         public string Note { get; set; } = string.Empty;


### PR DESCRIPTION
### Motivation
- Prevent silent logins when the same account is used on multiple workstations by introducing an approval workflow with a short countdown, so the currently connected session can accept or deny the incoming connection.
- Improve the UX of the conflict dialogs by adding a visual progress bar synchronized with the countdown to make the delay clearer.

### Description
- Server: add `PendingLoginRequest` structure, `PendingLoginRequests` collection and `LoginConflictDelaySeconds` constant, split registration into `RegisterUserCoreAsync`, and implement `RespondToLoginConflict`, `CompleteLoginAfterApproval`, `HandlePendingLoginDisconnectAsync` and `ForceDisconnectExistingAsync` to manage request lifecycle, approvals and forced disconnects; preserve and propagate `MachineName` in `UserInfo` and registration flows (`Serveur/Hubs/ChatHub.cs`, `Serveur/Models/UserInfo.cs`).
- Client: register new SignalR handlers for `LoginConflictPending`, `LoginConflictRequested`, `LoginConflictApproved`, `LoginConflictDenied`, `LoginConflictResolved`, `LoginConflictTooEarly` and `LoginConflictTimedOut`, add dialog implementations with countdown timers and progress bars, and expose `RespondToLoginConflictAsync` / `CompleteLoginAfterApprovalAsync` to call server actions; also include `Environment.MachineName` in `RegisterUser` call (`Client/Services/SignalRService.cs`).
- UI plumbing: add reusable `PromptForAccountSelectionAsync` in `Client/App.xaml.cs` and simplify `ChangeAccount_Click` in `Client/MainWindow.xaml.cs` to reuse that selection dialog when switching accounts.
- Messaging: server now emits dedicated events to coordinate pending requests, timeouts and resolution so both requester and existing sessions are notified appropriately.

### Testing
- No automated tests were executed for these changes (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cd93dd1588324b4adb24cf724c85b)