### PR TITLE
Close login-conflict dialogs on forced logout and disconnect

### DIFF
--- a/Client/Services/SignalRService.cs
+++ b/Client/Services/SignalRService.cs
@@ -466,7 +466,16 @@ namespace Client.Services
                     ShowToast(string.IsNullOrWhiteSpace(reason)
                         ? "Vous avez été déconnecté."
                         : reason);
-                    await DisconnectAsync();
+                    CloseAllLoginConflictDialogs();
+
+                    if (Application.Current is App app)
+                    {
+                        await app.LogoutAsync();
+                    }
+                    else
+                    {
+                        await DisconnectAsync();
+                    }
                 });
             });
 
@@ -1096,6 +1105,45 @@ namespace Client.Services
             if (_loginConflictTimers.Remove(requestId, out var timer))
             {
                 timer.Stop();
+            }
+        }
+
+        private void CloseAllLoginConflictDialogs()
+        {
+            foreach (var timer in _loginConflictTimers.Values)
+            {
+                timer.Stop();
+            }
+            _loginConflictTimers.Clear();
+
+            if (_loginConflictDialogs.Count == 0)
+            {
+                return;
+            }
+
+            void CloseDialogs()
+            {
+                foreach (var dialog in _loginConflictDialogs.Values)
+                {
+                    try
+                    {
+                        dialog.Hide();
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"❌ Error closing login conflict dialog: {ex.Message}");
+                    }
+                }
+                _loginConflictDialogs.Clear();
+            }
+
+            if (Dispatcher is { HasThreadAccess: true })
+            {
+                CloseDialogs();
+            }
+            else
+            {
+                Dispatcher?.TryEnqueue(CloseDialogs);
             }
         }
 
@@ -2211,6 +2259,7 @@ namespace Client.Services
                 EnableReconnect = false;
             StopReconnectTimer();
             StopIdleMonitor();
+            CloseAllLoginConflictDialogs();
             if (Connection != null)
             {
                 try


### PR DESCRIPTION
### Motivation
- Fix a bug where login-conflict confirmation dialogs could remain open after a forced logout or disconnect, leaving stale UI and preventing the account state from updating.

### Description
- Add `CloseAllLoginConflictDialogs()` which stops login-conflict timers, hides pending dialogs and clears internal dialog/timer state on the UI thread.
- Invoke `CloseAllLoginConflictDialogs()` when receiving the `ForceLogout` event and from `DisconnectAsync()` to ensure dialogs are cleaned up during any logout/disconnect path.
- Change the `ForceLogout` handler to call `App.LogoutAsync()` when `Application.Current is App` to run the full logout flow, falling back to `DisconnectAsync()` if the app instance is not available.
- Perform dialog hides on the dispatcher and catch/log exceptions to avoid UI-thread issues when closing dialogs.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697da545a58c8324a761675bf8ba1cdf)