### PR TITLE
Add user settings export/import in System settings

### DIFF
--- a/Client/Pages/SystemPage.xaml
+++ b/Client/Pages/SystemPage.xaml
@@ -102,10 +102,20 @@
                                             x:Name="UsersComboBox"
                                             ItemsSource="{x:Bind Users}"
                                             SelectedItem="{x:Bind DefaultUser, Mode=TwoWay}"/>
-                                        <Button
-                                            Content="Gérer les utilisateurs enregistrés"
-                                            Click="ManageUsers_Click"
-                                            HorizontalAlignment="Left"/>
+                                        <StackPanel Orientation="Horizontal" Spacing="10">
+                                                <Button
+                                                    Content="Gérer les utilisateurs enregistrés"
+                                                    Click="ManageUsers_Click"
+                                                    HorizontalAlignment="Left"/>
+                                                <Button
+                                                    Content="Exporter utilisateurs"
+                                                    Click="ExportUsers_Click"
+                                                    HorizontalAlignment="Left"/>
+                                                <Button
+                                                    Content="Importer utilisateurs"
+                                                    Click="ImportUsers_Click"
+                                                    HorizontalAlignment="Left"/>
+                                        </StackPanel>
                                         <ToggleSwitch Header="Se connecter avec le dernier utilisateur" IsOn="{x:Bind ConnectLastUser, Mode=TwoWay}"/>
                                         <Button Content="Sauvegarder" Click="Save_Click" HorizontalAlignment="Left"/>
                                 </StackPanel>

--- a/Client/Pages/SystemPage.xaml.cs
+++ b/Client/Pages/SystemPage.xaml.cs
@@ -10,6 +10,11 @@ using System.Threading.Tasks;
 using Client.Dialogs;
 using Client.Helpers;
 using Client.Models;
+using Newtonsoft.Json;
+using Windows.Storage;
+using Windows.Storage.Pickers;
+using Windows.Storage.Provider;
+using WinRT.Interop;
 
 namespace Client.Pages
 {
@@ -481,5 +486,159 @@ namespace Client.Pages
                 return new List<string>();
             }
         }
+
+        private async void ExportUsers_Click(object sender, RoutedEventArgs e)
+        {
+            var xamlRoot = GetXamlRoot(sender as FrameworkElement);
+            if (xamlRoot is null)
+                return;
+
+            var users = await App.ChatService.LoadUsersFromDiskAsync();
+            if (users.Count == 0)
+            {
+                await ShowInfoDialogAsync("Export impossible", "Aucun utilisateur local trouvé à exporter.", xamlRoot);
+                return;
+            }
+
+            var picker = new FileSavePicker();
+            picker.FileTypeChoices.Add("Configuration utilisateurs EyeChat", new List<string> { ".eyechatusers" });
+            picker.SuggestedFileName = $"EyeChatUsers_{DateTime.Now:yyyyMMdd_HHmm}";
+            var hwnd = WindowNative.GetWindowHandle(App.MainWindow);
+            InitializeWithWindow.Initialize(picker, hwnd);
+
+            var file = await picker.PickSaveFileAsync();
+            if (file == null)
+                return;
+
+            try
+            {
+                var settings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var user in users)
+                {
+                    if (string.IsNullOrWhiteSpace(user.Username))
+                        continue;
+
+                    var settingsPath = GetUserSettingsFilePath(user.Username);
+                    if (File.Exists(settingsPath))
+                    {
+                        settings[user.Username] = await File.ReadAllTextAsync(settingsPath);
+                    }
+                }
+
+                var configuration = new UserExportConfiguration
+                {
+                    Users = users,
+                    Settings = settings
+                };
+
+                var json = JsonConvert.SerializeObject(configuration, Formatting.Indented);
+                CachedFileManager.DeferUpdates(file);
+                await FileIO.WriteTextAsync(file, json);
+                await CachedFileManager.CompleteUpdatesAsync(file);
+            }
+            catch (Exception ex)
+            {
+                await ShowInfoDialogAsync("Erreur d'export", $"Impossible d'enregistrer la configuration : {ex.Message}", xamlRoot);
+            }
+        }
+
+        private async void ImportUsers_Click(object sender, RoutedEventArgs e)
+        {
+            var xamlRoot = GetXamlRoot(sender as FrameworkElement);
+            if (xamlRoot is null)
+                return;
+
+            var picker = new FileOpenPicker();
+            picker.FileTypeFilter.Add(".eyechatusers");
+            var hwnd = WindowNative.GetWindowHandle(App.MainWindow);
+            InitializeWithWindow.Initialize(picker, hwnd);
+
+            var file = await picker.PickSingleFileAsync();
+            if (file == null)
+                return;
+
+            try
+            {
+                var json = await FileIO.ReadTextAsync(file);
+                var configuration = JsonConvert.DeserializeObject<UserExportConfiguration>(json);
+                if (configuration?.Users == null)
+                {
+                    await ShowInfoDialogAsync("Import invalide", "Le fichier sélectionné est vide ou invalide.", xamlRoot);
+                    return;
+                }
+
+                var users = configuration.Users
+                    .Where(u => !string.IsNullOrWhiteSpace(u.Username))
+                    .ToList();
+
+                if (users.Count == 0)
+                {
+                    await ShowInfoDialogAsync("Import invalide", "Aucun utilisateur valide trouvé dans le fichier.", xamlRoot);
+                    return;
+                }
+
+                var folder = GetLocalDataFolderPath();
+                Directory.CreateDirectory(folder);
+
+                BackupFile(Path.Combine(folder, "users.json"));
+                foreach (var existing in Directory.GetFiles(folder, "*_settings.json"))
+                {
+                    BackupFile(existing);
+                }
+
+                var usersPath = Path.Combine(folder, "users.json");
+                var usersJson = JsonConvert.SerializeObject(users, Formatting.Indented);
+                await File.WriteAllTextAsync(usersPath, usersJson);
+
+                if (configuration.Settings != null)
+                {
+                    foreach (var kvp in configuration.Settings)
+                    {
+                        if (string.IsNullOrWhiteSpace(kvp.Key))
+                            continue;
+
+                        var settingsPath = GetUserSettingsFilePath(kvp.Key);
+                        await File.WriteAllTextAsync(settingsPath, kvp.Value ?? string.Empty);
+                    }
+                }
+
+                await RefreshLocalUserListAsync();
+                await ShowInfoDialogAsync("Import terminé", $"Configuration utilisateurs importée ({users.Count} utilisateur(s)).", xamlRoot);
+            }
+            catch (Exception ex)
+            {
+                await ShowInfoDialogAsync("Erreur d'import", $"Impossible de charger la configuration : {ex.Message}", xamlRoot);
+            }
+        }
+
+        private static string GetLocalDataFolderPath()
+            => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EyeChat");
+
+        private static string GetUserSettingsFilePath(string username)
+        {
+            var safeName = AppSettings.SanitizeUserNameForFile(username ?? string.Empty);
+            if (string.IsNullOrWhiteSpace(safeName))
+                throw new ArgumentException("Le nom d'utilisateur est invalide.", nameof(username));
+
+            return Path.Combine(GetLocalDataFolderPath(), $"{safeName}_settings.json");
+        }
+
+        private static void BackupFile(string path)
+        {
+            try
+            {
+                if (File.Exists(path))
+                    File.Copy(path, path + ".bak", true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    internal class UserExportConfiguration
+    {
+        public List<UserInfo>? Users { get; set; }
+        public Dictionary<string, string>? Settings { get; set; }
     }
 }


### PR DESCRIPTION
### Motivation
- Provide the same export/import capability for local user configuration as already exists for exam configuration so site installs can pre-load users and their per-user settings. 
- The change implements a one-file export format that includes the users list and each user's `_settings.json` content for easy transfer between installations.

### Description
- Added three buttons to the System settings UI: `Gérer les utilisateurs enregistrés`, `Exporter utilisateurs` and `Importer utilisateurs` in `Client/Pages/SystemPage.xaml`.
- Implemented `ExportUsers_Click` and `ImportUsers_Click` handlers in `Client/Pages/SystemPage.xaml.cs` that use `FileSavePicker`/`FileOpenPicker` to write/read a `.eyechatusers` JSON package containing the `List<UserInfo>` and a `Dictionary<string,string>` of per-user settings; uses `JsonConvert` for serialization.
- The import path creates backups (`*.bak`) of `users.json` and existing `*_settings.json` files before writing new files and refreshes the local user list after import; helper functions `GetLocalDataFolderPath`, `GetUserSettingsFilePath` and `BackupFile` were added, and `UserExportConfiguration` type was introduced.
- Added necessary `using` imports for `Newtonsoft.Json`, Windows Storage pickers and WinRT interop to integrate the file pickers with the app window.

### Testing
- No automated tests were run on these changes (no CI/unit tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697db4f672b88324a410cb5d8de613a5)