### PR TITLE
Add title-bar auto-switch toggle for agenda mode and fix DayOption XAML issue

### DIFF
--- a/Client/MainWindow.xaml
+++ b/Client/MainWindow.xaml
@@ -65,11 +65,19 @@
                 <ColumnDefinition x:Name="IconColumn" Width="Auto"/>
                 <ColumnDefinition x:Name="TitleColumn" Width="Auto"/>
                 <ColumnDefinition x:Name="LeftDragColumn" Width="*"/>
+                <ColumnDefinition x:Name="AgendaSwitchColumn" Width="Auto"/>
                 <ColumnDefinition x:Name="AccountColumn" Width="Auto"/>
             </Grid.ColumnDefinitions>
             <Image x:Name="TitleBarIcon" Source="/Assets/EyeChat.png" Grid.Column="1" Width="32" Height="32" Margin="8,0,4,0"/>
             <TextBlock x:Name="TitleBarTextBlock" Text="EyeChat" FontSize="16" VerticalAlignment="Center" Grid.Column="2" />
-            <Button x:Name="AccountButton" Grid.Column="4" Margin="0,0,150,0" Background="Transparent" BorderThickness="0">
+            <ToggleSwitch x:Name="AutoSwitchToggle"
+                          Grid.Column="4"
+                          Header="Basculement auto"
+                          VerticalAlignment="Center"
+                          Margin="0,0,16,0"
+                          Visibility="Collapsed"
+                          Toggled="AutoSwitchToggle_Toggled" />
+            <Button x:Name="AccountButton" Grid.Column="5" Margin="0,0,150,0" Background="Transparent" BorderThickness="0">
                 <Button.Content>
                     <PersonPicture x:Name="PersonPic" Height="32" />
                 </Button.Content>

--- a/Client/MainWindow.xaml.cs
+++ b/Client/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using Windows.UI;
 using Microsoft.UI;
 using Windows.Graphics;
 using Windows.Foundation;
+using Client.Helpers;
 
 namespace Client
 {
@@ -15,6 +16,7 @@ namespace Client
     {
         public bool IsTopMost { get; private set; }
         private readonly AppWindow _appWindow;
+        private bool _isUpdatingAgendaToggle;
 
         public bool IsChatPageActive => contentFrame.CurrentSourcePageType == typeof(Pages.ChatPage);
 
@@ -33,6 +35,7 @@ namespace Client
             nvSample.SelectedItem = nvSample.MenuItems.OfType<NavigationViewItem>()
                 .FirstOrDefault(item => (string)item.Tag == "ChatPage");
             contentFrame.Navigate(typeof(Pages.ChatPage));
+            RefreshAgendaSwitchState();
 
         }
 
@@ -74,6 +77,15 @@ namespace Client
                     contentFrame.Navigate(typeof(Pages.SettingsPage));
                 }
             }
+        }
+
+        public void RefreshAgendaSwitchState()
+        {
+            var config = MachineConfig.Load();
+            _isUpdatingAgendaToggle = true;
+            AutoSwitchToggle.IsOn = config.AgendaModeEnabled && config.AutoSwitchEnabled;
+            AutoSwitchToggle.Visibility = config.AgendaModeEnabled ? Visibility.Visible : Visibility.Collapsed;
+            _isUpdatingAgendaToggle = false;
         }
         public Pages.ChatPage? ShowChatPage()
         {
@@ -145,6 +157,23 @@ namespace Client
         private async void Logout_Click(object sender, RoutedEventArgs e)
         {
             await ((App)Application.Current).LogoutAsync();
+        }
+
+        private void AutoSwitchToggle_Toggled(object sender, RoutedEventArgs e)
+        {
+            if (_isUpdatingAgendaToggle)
+            {
+                return;
+            }
+
+            var config = MachineConfig.Load();
+            config.AutoSwitchEnabled = config.AgendaModeEnabled && AutoSwitchToggle.IsOn;
+            MachineConfig.Save(config);
+
+            if (Application.Current is App app)
+            {
+                app.RefreshAgendaTimer();
+            }
         }
     }
 }

--- a/Client/Pages/AgendaConnectionPage.xaml
+++ b/Client/Pages/AgendaConnectionPage.xaml
@@ -23,14 +23,10 @@
                                TextWrapping="Wrap"
                                FontStyle="Italic"
                                Opacity="0.7" />
-                    <StackPanel Visibility="{Binding AgendaModeEnabled, ElementName=RootPage, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                Spacing="8">
-                        <ToggleSwitch Header="Basculement automatique des comptes"
-                                      IsOn="{x:Bind AutoSwitchEnabled, Mode=TwoWay}" />
-                        <TextBlock Text="Ce basculement est visible uniquement quand le mode agenda est activé."
-                                   FontStyle="Italic"
-                                   Opacity="0.7" />
-                    </StackPanel>
+                    <TextBlock Text="Le basculement automatique se contrôle depuis la barre de titre quand le mode agenda est activé."
+                               FontStyle="Italic"
+                               Opacity="0.7"
+                               Visibility="{Binding AgendaModeEnabled, ElementName=RootPage, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
                     <TextBlock Text="Créneaux de connexion" FontWeight="SemiBold" Margin="0,8,0,0" />
                     <ListView ItemsSource="{x:Bind ScheduleEntries}" SelectionMode="None">

--- a/Client/Pages/AgendaConnectionPage.xaml.cs
+++ b/Client/Pages/AgendaConnectionPage.xaml.cs
@@ -186,7 +186,9 @@ namespace Client.Pages
 
         private void Save_Click(object sender, RoutedEventArgs e)
         {
+            var latestConfig = MachineConfig.Load();
             _config.AgendaModeEnabled = AgendaModeEnabled;
+            AutoSwitchEnabled = latestConfig.AutoSwitchEnabled;
             _config.AutoSwitchEnabled = AgendaModeEnabled && AutoSwitchEnabled;
             _config.AgendaSchedule = ScheduleEntries
                 .Select(entry => new AgendaSwitchEntry
@@ -204,6 +206,10 @@ namespace Client.Pages
             if (Application.Current is App app)
             {
                 app.RefreshAgendaTimer();
+                if (App.MainWindow is MainWindow mainWindow)
+                {
+                    mainWindow.RefreshAgendaSwitchState();
+                }
             }
         }
 
@@ -231,6 +237,16 @@ namespace Client.Pages
             }
         }
 
-        public readonly record struct DayOption(DayOfWeek Day, string Label);
+        public class DayOption
+        {
+            public DayOption(DayOfWeek day, string label)
+            {
+                Day = day;
+                Label = label;
+            }
+
+            public DayOfWeek Day { get; set; }
+            public string Label { get; set; }
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Move the automatic account switch control into the title bar so it can be toggled per-workstation and shown only when agenda mode is enabled. 
- Ensure saved agenda changes update the title-bar control and the runtime agenda timer so the UI and behavior stay in sync. 
- Fix XAML codegen errors caused by an init-only record for `DayOption` by replacing it with a mutable class. 

### Description
- Add a `ToggleSwitch` named `AutoSwitchToggle` to the application title bar in `Client/MainWindow.xaml` and a `AutoSwitchToggle_Toggled` handler in `Client/MainWindow.xaml.cs` to persist `AutoSwitchEnabled` to `MachineConfig`. 
- Add `RefreshAgendaSwitchState()` in `MainWindow` to load `MachineConfig` and show/hide and set the toggle state, and call it when the window initializes and after saving agenda settings. 
- Update `Client/Pages/AgendaConnectionPage.xaml` to remove the inline auto-switch toggle and direct users to the title bar when the agenda mode is enabled. 
- Change `DayOption` from a `record struct` to a mutable `class` in `Client/Pages/AgendaConnectionPage.xaml.cs` to avoid init-only assignment errors with XAML code generation, and update `Save_Click` to reload latest config and refresh the main window state after saving. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ddd0faf648324a28503c042f5d3ff)