### PR TITLE
Adjust agenda schedule entry layout alignment

### DIFF
--- a/Client/Pages/AgendaConnectionPage.xaml
+++ b/Client/Pages/AgendaConnectionPage.xaml
@@ -33,21 +33,33 @@
                         <ListView.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Spacing="8">
-                                    <Grid ColumnDefinitions="160,160,160,220,Auto" ColumnSpacing="10">
+                                    <Grid ColumnDefinitions="170,180,180,1*,Auto" ColumnSpacing="12" VerticalAlignment="Center">
                                         <ComboBox ItemsSource="{Binding ElementName=RootPage, Path=DayOptions}"
                                                   SelectedValue="{Binding Day, Mode=TwoWay}"
                                                   SelectedValuePath="Day"
-                                                  DisplayMemberPath="Label" />
+                                                  DisplayMemberPath="Label"
+                                                  MinWidth="160"
+                                                  HorizontalAlignment="Stretch"
+                                                  VerticalAlignment="Center" />
                                         <TimePicker Grid.Column="1"
                                                     Time="{Binding StartTime, Mode=TwoWay}"
-                                                    IsEnabled="{Binding IsAllDay, Converter={StaticResource InverseBooleanConverter}}" />
+                                                    IsEnabled="{Binding IsAllDay, Converter={StaticResource InverseBooleanConverter}}"
+                                                    MinWidth="160"
+                                                    HorizontalAlignment="Stretch"
+                                                    VerticalAlignment="Center" />
                                         <TimePicker Grid.Column="2"
                                                     Time="{Binding EndTime, Mode=TwoWay}"
-                                                    IsEnabled="{Binding IsAllDay, Converter={StaticResource InverseBooleanConverter}}" />
+                                                    IsEnabled="{Binding IsAllDay, Converter={StaticResource InverseBooleanConverter}}"
+                                                    MinWidth="160"
+                                                    HorizontalAlignment="Stretch"
+                                                    VerticalAlignment="Center" />
                                         <ComboBox Grid.Column="3"
                                                   ItemsSource="{Binding ElementName=RootPage, Path=Users}"
                                                   SelectedItem="{Binding UserName, Mode=TwoWay}"
-                                                  IsEditable="True" />
+                                                  IsEditable="True"
+                                                  MinWidth="200"
+                                                  HorizontalAlignment="Stretch"
+                                                  VerticalAlignment="Center" />
                                         <StackPanel Grid.Column="4" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                                             <ToggleSwitch Header="Journée" IsOn="{Binding IsAllDay, Mode=TwoWay}" />
                                             <Button Content="Supprimer" Click="RemoveEntry_Click" Tag="{Binding}" />


### PR DESCRIPTION
### Motivation
- Corriger l’alignement des contrôles dans la liste des créneaux de l’`AgendaConnectionPage` et éviter que les `TimePicker`/`ComboBox` soient tronqués.
- Uniformiser les espacements et comportements d’étirement pour une meilleure présentation des champs jour/heure/utilisateur.

### Description
- Modifié `Client/Pages/AgendaConnectionPage.xaml` pour remplacer les `Grid` `ColumnDefinitions` de `160,160,160,220,Auto` par `170,180,180,1*,Auto` et augmenter le `ColumnSpacing` à `12` afin d’améliorer la distribution des colonnes.
- Ajouté `VerticalAlignment="Center"` sur la `Grid` et mis `HorizontalAlignment="Stretch"`/`VerticalAlignment="Center"` sur les `ComboBox` et `TimePicker` pour un alignement cohérent.
- Défini des `MinWidth` (`MinWidth="160"` sur les champs jour/heure et `MinWidth="200"` pour le sélecteur utilisateur) pour prévenir la troncature des contrôles éditables.

### Testing
- Aucune suite de tests automatisés n’a été exécutée car il s’agit d’un changement d’interface XAML uniquement (UI-only change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697de3efc36c83249656fd4eadf8c4f6)