### PR TITLE
Limit title bar drag region to allow ToggleSwitch interaction

### DIFF
--- a/Client/MainWindow.xaml
+++ b/Client/MainWindow.xaml
@@ -70,7 +70,9 @@
             </Grid.ColumnDefinitions>
             <Image x:Name="TitleBarIcon" Source="/Assets/EyeChat.png" Grid.Column="1" Width="32" Height="32" Margin="8,0,4,0"/>
             <TextBlock x:Name="TitleBarTextBlock" Text="EyeChat" FontSize="16" VerticalAlignment="Center" Grid.Column="2" />
+            <Grid x:Name="TitleBarDragRegion" Grid.Column="3" />
             <ToggleSwitch x:Name="AutoSwitchToggle"
+                          x:FieldModifier="public"
                           Grid.Column="4"
                           VerticalAlignment="Center"
                           Margin="0,0,16,0"

--- a/Client/MainWindow.xaml.cs
+++ b/Client/MainWindow.xaml.cs
@@ -45,15 +45,27 @@ namespace Client
             {
                 // Make the entire title bar draggable, excluding interactive controls like the account button.
                 // SetDragRectangles expects coordinates in physical pixels, so scale from effective pixels using the XamlRoot scale.
-                double scale = AppTitleBar.XamlRoot?.RasterizationScale ?? 1.0;
-                var dragRect = new RectInt32(
-                    0,
-                    0,
-                    (int)(AppTitleBar.ActualWidth * scale),
-                    (int)(AppTitleBar.ActualHeight * scale));
-
-                _appWindow.TitleBar.SetDragRectangles(new[] { dragRect });
+                SetDragRegion();
             }
+        }
+
+        private void SetDragRegion()
+        {
+            double scale = AppTitleBar.XamlRoot?.RasterizationScale ?? 1.0;
+            if (TitleBarDragRegion is null)
+            {
+                return;
+            }
+
+            var transform = TitleBarDragRegion.TransformToVisual(AppTitleBar);
+            var bounds = transform.TransformBounds(new Rect(0, 0, TitleBarDragRegion.ActualWidth, TitleBarDragRegion.ActualHeight));
+            var dragRect = new RectInt32(
+                (int)(bounds.X * scale),
+                (int)(bounds.Y * scale),
+                (int)(bounds.Width * scale),
+                (int)(bounds.Height * scale));
+
+            _appWindow.TitleBar.SetDragRectangles(new[] { dragRect });
         }
 
         private void nvSample_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)


### PR DESCRIPTION
### Motivation
- Interactive controls in the custom title bar (notably the `AutoSwitchToggle`) were not clickable because the entire title bar area was being treated as a drag region. 

### Description
- Add a dedicated `Grid` named `TitleBarDragRegion` to `Client/MainWindow.xaml` to provide an explicit, limited draggable area. 
- Ensure `AutoSwitchToggle` is accessible from code by keeping `x:FieldModifier="public"` on the `ToggleSwitch` declaration. 
- Replace the previous full-title-bar drag-rectangle logic with a new `SetDragRegion()` method in `Client/MainWindow.xaml.cs` that computes bounds via `TransformToVisual` and applies a scaled `RectInt32` to `_appWindow.TitleBar.SetDragRectangles`. 
- Call `SetDragRegion()` from `AppTitleBar_Loaded` so the drag rectangles are updated when the title bar is loaded or resized. 

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697effdab7648324bd71a079b89cc376)