### PR TITLE
Ensure agenda timer uses UI dispatcher

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -230,20 +230,47 @@ namespace Client
         public void RefreshAgendaTimer()
         {
             var machine = MachineConfig.Load();
-            if (!machine.AgendaModeEnabled || !machine.AutoSwitchEnabled)
+            var dispatcher = MainWindow?.DispatcherQueue ?? DispatcherQueue.GetForCurrentThread();
+            if (dispatcher == null)
             {
-                _agendaTimer?.Stop();
                 return;
             }
 
-            if (_agendaTimer == null)
+            if (!machine.AgendaModeEnabled || !machine.AutoSwitchEnabled)
             {
-                _agendaTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
-                _agendaTimer.Interval = TimeSpan.FromMinutes(1);
-                _agendaTimer.Tick += AgendaTimer_Tick;
+                void StopTimer() => _agendaTimer?.Stop();
+                if (dispatcher.HasThreadAccess)
+                {
+                    StopTimer();
+                }
+                else
+                {
+                    dispatcher.TryEnqueue(StopTimer);
+                }
+
+                return;
             }
 
-            _agendaTimer.Start();
+            void StartTimer()
+            {
+                if (_agendaTimer == null)
+                {
+                    _agendaTimer = dispatcher.CreateTimer();
+                    _agendaTimer.Interval = TimeSpan.FromMinutes(1);
+                    _agendaTimer.Tick += AgendaTimer_Tick;
+                }
+
+                _agendaTimer.Start();
+            }
+
+            if (dispatcher.HasThreadAccess)
+            {
+                StartTimer();
+            }
+            else
+            {
+                dispatcher.TryEnqueue(StartTimer);
+            }
         }
 
         private async void AgendaTimer_Tick(DispatcherQueueTimer sender, object args)
@@ -538,7 +565,10 @@ namespace Client
                 var chat = mw.ShowChatPage();
                 chat?.RefreshUsername();
                 mw.SetAccountState(true);
+                mw.RefreshAgendaSwitchState();
             }
+
+            RefreshAgendaTimer();
         }
 
         public async Task LogoutAsync()


### PR DESCRIPTION
### Motivation
- Fix the agenda auto-switch/timer not updating after account changes by ensuring timer start/stop and creation always execute on the UI dispatcher. 
- Prevent creating a `DispatcherQueueTimer` on a background thread when `RefreshAgendaTimer` is invoked off the UI thread.

### Description
- Update `Client/App.xaml.cs` to obtain a dispatcher via `MainWindow?.DispatcherQueue ?? DispatcherQueue.GetForCurrentThread()` and return early if unavailable. 
- Run timer stop/start operations on the dispatcher, using `dispatcher.HasThreadAccess` or `dispatcher.TryEnqueue(...)` to marshal actions to the UI thread. 
- Create the `_agendaTimer` with `dispatcher.CreateTimer()` and wire `AgendaTimer_Tick` only when the timer is created on the dispatcher. 
- Ensure `RefreshAgendaTimer()` is called after a successful user change and the window refreshes its agenda switch state so UI and timer reflect the new account. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f86cfe9f8832492475b4c8b2a4cb3)