### PR TITLE
Run agenda timer on UI dispatcher and recalculate title-bar drag region after toggle

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -230,20 +230,47 @@ namespace Client
         public void RefreshAgendaTimer()
         {
             var machine = MachineConfig.Load();
-            if (!machine.AgendaModeEnabled || !machine.AutoSwitchEnabled)
+            var dispatcher = MainWindow?.DispatcherQueue ?? DispatcherQueue.GetForCurrentThread();
+            if (dispatcher == null)
             {
-                _agendaTimer?.Stop();
                 return;
             }
 
-            if (_agendaTimer == null)
+            if (!machine.AgendaModeEnabled || !machine.AutoSwitchEnabled)
             {
-                _agendaTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
-                _agendaTimer.Interval = TimeSpan.FromMinutes(1);
-                _agendaTimer.Tick += AgendaTimer_Tick;
+                void StopTimer() => _agendaTimer?.Stop();
+                if (dispatcher.HasThreadAccess)
+                {
+                    StopTimer();
+                }
+                else
+                {
+                    dispatcher.TryEnqueue(StopTimer);
+                }
+
+                return;
             }
 
-            _agendaTimer.Start();
+            void StartTimer()
+            {
+                if (_agendaTimer == null)
+                {
+                    _agendaTimer = dispatcher.CreateTimer();
+                    _agendaTimer.Interval = TimeSpan.FromMinutes(1);
+                    _agendaTimer.Tick += AgendaTimer_Tick;
+                }
+
+                _agendaTimer.Start();
+            }
+
+            if (dispatcher.HasThreadAccess)
+            {
+                StartTimer();
+            }
+            else
+            {
+                dispatcher.TryEnqueue(StartTimer);
+            }
         }
 
         private async void AgendaTimer_Tick(DispatcherQueueTimer sender, object args)
@@ -538,7 +565,10 @@ namespace Client
                 var chat = mw.ShowChatPage();
                 chat?.RefreshUsername();
                 mw.SetAccountState(true);
+                mw.RefreshAgendaSwitchState();
             }
+
+            RefreshAgendaTimer();
         }
 
         public async Task LogoutAsync()

--- a/Client/MainWindow.xaml.cs
+++ b/Client/MainWindow.xaml.cs
@@ -98,6 +98,7 @@ namespace Client
             AutoSwitchToggle.IsOn = config.AgendaModeEnabled && config.AutoSwitchEnabled;
             AutoSwitchToggle.Visibility = config.AgendaModeEnabled ? Visibility.Visible : Visibility.Collapsed;
             _isUpdatingAgendaToggle = false;
+            DispatcherQueue.TryEnqueue(SetDragRegion);
         }
         public Pages.ChatPage? ShowChatPage()
         {


### PR DESCRIPTION
### Motivation
- Prevent creating or starting the agenda `DispatcherQueueTimer` on a background thread which can cause the timer and auto-switch to stop working after account changes. 
- Ensure stopping/starting the timer always executes on the UI dispatcher so timer lifecycle is safe when `RefreshAgendaTimer()` is invoked off the UI thread. 
- Fix the title-bar drag region overlapping the agenda `ToggleSwitch` (making it unclickable) after the switch visibility/state changes.

### Description
- In `Client/App.xaml.cs` obtain a dispatcher via `MainWindow?.DispatcherQueue ?? DispatcherQueue.GetForCurrentThread()` and return early if it is `null`. 
- Marshal timer stop/start operations to the UI dispatcher using `dispatcher.HasThreadAccess` and `dispatcher.TryEnqueue(...)`, and create the `_agendaTimer` with `dispatcher.CreateTimer()` so the timer and its `Tick` handler are associated with the UI thread. 
- After a successful account change, call `mw.RefreshAgendaSwitchState()` and `RefreshAgendaTimer()` so the UI and timer reflect the new account. 
- In `Client/MainWindow.xaml.cs` enqueue a `SetDragRegion` call via `DispatcherQueue.TryEnqueue(SetDragRegion)` at the end of `RefreshAgendaSwitchState()` so the title-bar drag rectangle is recalculated after the toggle visibility changes.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f86cfe9f8832492475b4c8b2a4cb3)