### PR TITLE
Guard title-bar drag-region updates and ensure agenda timer runs on UI dispatcher

### DIFF
--- a/Client/App.xaml.cs
+++ b/Client/App.xaml.cs
@@ -230,20 +230,47 @@ namespace Client
         public void RefreshAgendaTimer()
         {
             var machine = MachineConfig.Load();
-            if (!machine.AgendaModeEnabled || !machine.AutoSwitchEnabled)
+            var dispatcher = MainWindow?.DispatcherQueue ?? DispatcherQueue.GetForCurrentThread();
+            if (dispatcher == null)
             {
-                _agendaTimer?.Stop();
                 return;
             }
 
-            if (_agendaTimer == null)
+            if (!machine.AgendaModeEnabled || !machine.AutoSwitchEnabled)
             {
-                _agendaTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
-                _agendaTimer.Interval = TimeSpan.FromMinutes(1);
-                _agendaTimer.Tick += AgendaTimer_Tick;
+                void StopTimer() => _agendaTimer?.Stop();
+                if (dispatcher.HasThreadAccess)
+                {
+                    StopTimer();
+                }
+                else
+                {
+                    dispatcher.TryEnqueue(StopTimer);
+                }
+
+                return;
             }
 
-            _agendaTimer.Start();
+            void StartTimer()
+            {
+                if (_agendaTimer == null)
+                {
+                    _agendaTimer = dispatcher.CreateTimer();
+                    _agendaTimer.Interval = TimeSpan.FromMinutes(1);
+                    _agendaTimer.Tick += AgendaTimer_Tick;
+                }
+
+                _agendaTimer.Start();
+            }
+
+            if (dispatcher.HasThreadAccess)
+            {
+                StartTimer();
+            }
+            else
+            {
+                dispatcher.TryEnqueue(StartTimer);
+            }
         }
 
         private async void AgendaTimer_Tick(DispatcherQueueTimer sender, object args)
@@ -538,7 +565,10 @@ namespace Client
                 var chat = mw.ShowChatPage();
                 chat?.RefreshUsername();
                 mw.SetAccountState(true);
+                mw.RefreshAgendaSwitchState();
             }
+
+            RefreshAgendaTimer();
         }
 
         public async Task LogoutAsync()

--- a/Client/MainWindow.xaml.cs
+++ b/Client/MainWindow.xaml.cs
@@ -51,12 +51,17 @@ namespace Client
 
         private void SetDragRegion()
         {
-            double scale = AppTitleBar.XamlRoot?.RasterizationScale ?? 1.0;
-            if (TitleBarDragRegion is null)
+            if (TitleBarDragRegion is null || !TitleBarDragRegion.IsLoaded || AppTitleBar?.XamlRoot is null)
             {
                 return;
             }
 
+            if (TitleBarDragRegion.ActualWidth <= 0 || TitleBarDragRegion.ActualHeight <= 0)
+            {
+                return;
+            }
+
+            double scale = AppTitleBar.XamlRoot.RasterizationScale;
             var transform = TitleBarDragRegion.TransformToVisual(AppTitleBar);
             var bounds = transform.TransformBounds(new Rect(0, 0, TitleBarDragRegion.ActualWidth, TitleBarDragRegion.ActualHeight));
             var dragRect = new RectInt32(
@@ -98,6 +103,7 @@ namespace Client
             AutoSwitchToggle.IsOn = config.AgendaModeEnabled && config.AutoSwitchEnabled;
             AutoSwitchToggle.Visibility = config.AgendaModeEnabled ? Visibility.Visible : Visibility.Collapsed;
             _isUpdatingAgendaToggle = false;
+            DispatcherQueue.TryEnqueue(SetDragRegion);
         }
         public Pages.ChatPage? ShowChatPage()
         {


### PR DESCRIPTION
### Motivation
- Prevent a COM exception from `TransformToVisual` when the title-bar or drag region visual tree isn't ready by avoiding calculations until elements are loaded and sized.  
- Ensure the agenda `DispatcherQueueTimer` is created and started/stopped on the UI dispatcher to avoid timers running on background threads and breaking auto-switch behavior.  
- Make the UI reflect account changes immediately by refreshing the agenda toggle state and timer after login.  

### Description
- In `Client/MainWindow.xaml.cs` add guards to `SetDragRegion()` that return early if `TitleBarDragRegion` is `null`, not loaded, has zero size, or if `AppTitleBar.XamlRoot` is `null`, and use `XamlRoot.RasterizationScale` only when present.  
- In `Client/MainWindow.xaml.cs` enqueue a `SetDragRegion` call via `DispatcherQueue.TryEnqueue(SetDragRegion)` at the end of `RefreshAgendaSwitchState()` so drag rectangles are recalculated after the toggle visibility changes.  
- In `Client/App.xaml.cs` obtain a dispatcher with `MainWindow?.DispatcherQueue ?? DispatcherQueue.GetForCurrentThread()` and marshal timer start/stop to the dispatcher using `dispatcher.HasThreadAccess`/`dispatcher.TryEnqueue(...)`, create the `_agendaTimer` with `dispatcher.CreateTimer()`, and call `RefreshAgendaTimer()` after a successful sign-in (alongside `RefreshAgendaSwitchState()`).  

### Testing
- No automated tests were run.  
- Manual runtime validation was performed during development to reproduce and prevent the `TransformToVisual` COM exception by toggling the title-bar elements and observing no crash.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f86cfe9f8832492475b4c8b2a4cb3)