### PR TITLE
Fix agenda connection settings persistence

### DIFF
--- a/Client/Pages/AgendaConnectionPage.xaml.cs
+++ b/Client/Pages/AgendaConnectionPage.xaml.cs
@@ -187,10 +187,9 @@ namespace Client.Pages
         private void Save_Click(object sender, RoutedEventArgs e)
         {
             var latestConfig = MachineConfig.Load();
-            _config.AgendaModeEnabled = AgendaModeEnabled;
-            AutoSwitchEnabled = latestConfig.AutoSwitchEnabled;
-            _config.AutoSwitchEnabled = AgendaModeEnabled && AutoSwitchEnabled;
-            _config.AgendaSchedule = ScheduleEntries
+            latestConfig.AgendaModeEnabled = AgendaModeEnabled;
+            latestConfig.AutoSwitchEnabled = AgendaModeEnabled && AutoSwitchEnabled;
+            latestConfig.AgendaSchedule = ScheduleEntries
                 .Select(entry => new AgendaSwitchEntry
                 {
                     Day = entry.Day,
@@ -201,7 +200,10 @@ namespace Client.Pages
                 })
                 .ToList();
 
-            MachineConfig.Save(_config);
+            _config.AgendaModeEnabled = latestConfig.AgendaModeEnabled;
+            _config.AutoSwitchEnabled = latestConfig.AutoSwitchEnabled;
+            _config.AgendaSchedule = latestConfig.AgendaSchedule;
+            MachineConfig.Save(latestConfig);
 
             if (Application.Current is App app)
             {


### PR DESCRIPTION
### Motivation
- Address a bug where agenda connection parameters could be saved using stale values and overwrite the automatic-switch toggle or schedule incorrectly when persisting machine settings.

### Description
- In `Client/Pages/AgendaConnectionPage.xaml.cs` the `Save_Click` handler now loads the latest `MachineConfig` via `MachineConfig.Load()`, updates `AgendaModeEnabled`, `AutoSwitchEnabled` and `AgendaSchedule` on that instance, writes it with `MachineConfig.Save(...)`, and then mirrors the saved values back to the in-memory `_config` to keep runtime state consistent.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69803e0cd7e083248589d70cd2d3e826)